### PR TITLE
Add .cmake files to faciliate out of tree projects

### DIFF
--- a/drivers/msa301/msa301.cmake
+++ b/drivers/msa301/msa301.cmake
@@ -1,0 +1,10 @@
+add_library(msa301 INTERFACE)
+
+target_sources(msa301 INTERFACE
+  ${CMAKE_CURRENT_LIST_DIR}/msa301.cpp
+)
+
+target_include_directories(msa301 INTERFACE ${CMAKE_CURRENT_LIST_DIR})
+
+# Pull in pico libraries that we need
+target_link_libraries(msa301 INTERFACE pico_stdlib hardware_i2c)

--- a/drivers/st7789/st7789.cmake
+++ b/drivers/st7789/st7789.cmake
@@ -1,0 +1,5 @@
+add_library(st7789
+    ${CMAKE_CURRENT_LIST_DIR}/st7789.cpp)
+
+# Pull in pico libraries that we need
+target_link_libraries(st7789 pico_stdlib hardware_spi hardware_pwm hardware_dma)

--- a/libraries/pico_display/pico_display.cmake
+++ b/libraries/pico_display/pico_display.cmake
@@ -1,0 +1,13 @@
+include(${CMAKE_CURRENT_LIST_DIR}/../../drivers/st7789/st7789.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/../pico_graphics/pico_graphics.cmake)
+
+add_library(pico_display INTERFACE)
+
+target_sources(pico_display INTERFACE
+  ${CMAKE_CURRENT_LIST_DIR}/pico_display.cpp
+)
+
+target_include_directories(pico_display INTERFACE ${CMAKE_CURRENT_LIST_DIR})
+
+# Pull in pico libraries that we need
+target_link_libraries(pico_display INTERFACE pico_stdlib hardware_spi hardware_pwm hardware_dma st7789 pico_graphics)

--- a/libraries/pico_explorer/pico_explorer.cmake
+++ b/libraries/pico_explorer/pico_explorer.cmake
@@ -1,0 +1,13 @@
+include(${CMAKE_CURRENT_LIST_DIR}/../../drivers/st7789/st7789.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/../pico_graphics/pico_graphics.cmake)
+
+add_library(pico_explorer INTERFACE)
+
+target_sources(pico_explorer INTERFACE
+  ${CMAKE_CURRENT_LIST_DIR}/pico_explorer.cpp
+)
+
+target_include_directories(pico_explorer INTERFACE ${CMAKE_CURRENT_LIST_DIR})
+
+# Pull in pico libraries that we need
+target_link_libraries(pico_explorer INTERFACE pico_stdlib hardware_pwm hardware_adc st7789 pico_graphics)

--- a/libraries/pico_explorer/pico_explorer.cpp
+++ b/libraries/pico_explorer/pico_explorer.cpp
@@ -1,6 +1,7 @@
 #include <math.h>
 #include <string.h>
 
+#include "hardware/gpio.h"
 #include "hardware/pwm.h"
 #include "hardware/adc.h"
 

--- a/libraries/pico_graphics/pico_graphics.cmake
+++ b/libraries/pico_graphics/pico_graphics.cmake
@@ -1,0 +1,4 @@
+add_library(pico_graphics 
+    ${CMAKE_CURRENT_LIST_DIR}/types.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/font_data.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/pico_graphics.cpp)

--- a/libraries/pico_rgb_keypad/pico_rgb_keypad.cmake
+++ b/libraries/pico_rgb_keypad/pico_rgb_keypad.cmake
@@ -1,0 +1,10 @@
+add_library(pico_rgb_keypad INTERFACE)
+
+target_sources(pico_rgb_keypad INTERFACE
+  ${CMAKE_CURRENT_LIST_DIR}/pico_rgb_keypad.cpp
+)
+
+target_include_directories(pico_rgb_keypad INTERFACE ${CMAKE_CURRENT_LIST_DIR})
+
+# Pull in pico libraries that we need
+target_link_libraries(pico_rgb_keypad INTERFACE pico_stdlib hardware_i2c hardware_spi)

--- a/libraries/pico_scroll/pico_scroll.cmake
+++ b/libraries/pico_scroll/pico_scroll.cmake
@@ -1,0 +1,10 @@
+add_library(pico_scroll INTERFACE)
+
+target_sources(pico_scroll INTERFACE
+  ${CMAKE_CURRENT_LIST_DIR}/pico_scroll.cpp
+)
+
+target_include_directories(pico_scroll INTERFACE ${CMAKE_CURRENT_LIST_DIR})
+
+# Pull in pico libraries that we need
+target_link_libraries(pico_scroll INTERFACE pico_stdlib hardware_i2c)

--- a/libraries/pico_unicorn/pico_unicorn.cmake
+++ b/libraries/pico_unicorn/pico_unicorn.cmake
@@ -1,0 +1,12 @@
+add_library(pico_unicorn INTERFACE)
+
+pico_generate_pio_header(pico_unicorn ${CMAKE_CURRENT_LIST_DIR}/pico_unicorn.pio)
+
+target_sources(pico_unicorn INTERFACE
+  ${CMAKE_CURRENT_LIST_DIR}/pico_unicorn.cpp
+)
+
+target_include_directories(pico_unicorn INTERFACE ${CMAKE_CURRENT_LIST_DIR})
+
+# Pull in pico libraries that we need
+target_link_libraries(pico_unicorn INTERFACE pico_stdlib hardware_pio hardware_dma)


### PR DESCRIPTION
The added .cmake files can be included into an out-of-tree project whereas - as far as I understand it- CMakeLists.txt is only really for top level config of an CMake build setup. For example here's my CMakeLists.txt for a Pico Explorer project:

```cmake
cmake_minimum_required(VERSION 3.12)

# Symlink this file into the project directory
include(pico_sdk_import.cmake)

project(text-pico-explorer C CXX ASM)
set(CMAKE_C_STANDARD 11)
set(CMAKE_CXX_STANDARD 17)

# Initialize the SDK
pico_sdk_init()

include(../pimoroni-pico/libraries/pico_explorer/pico_explorer.cmake)

add_executable(test-pico-explorer
    main.cpp
)

target_link_libraries(test-pico-explorer
    pico_explorer)
```

Note the line:

```cmake
include(../pimoroni-pico/libraries/pico_explorer/pico_explorer.cmake)
```

Which pulls pico_explorer and dependencies into our project.