### PR TITLE
Updated demo.py with A/B/X/Y button example

### DIFF
--- a/micropython/examples/pico_explorer/demo.py
+++ b/micropython/examples/pico_explorer/demo.py
@@ -35,8 +35,26 @@ while True:
     explorer.set_pen(0, 0, adc2 * 2) 
     explorer.circle(90 + adc2, 66, 10)
 
-    explorer.set_pen(255, 255, 255)
-    explorer.text("Plug a jumper wire from GP0 to AUDIO to hear noise!", 20, 110, 200)    
+    # example for the on-board A/B/X/Y buttons
+    if explorer.is_pressed(explorer.BUTTON_A):
+        explorer.set_pen(255, 255, 255)
+        explorer.text("Button A pressed", 20, 110, 200)
+    elif explorer.is_pressed(explorer.BUTTON_B):
+        explorer.set_pen(255, 255, 255)
+        explorer.text("Button B pressed", 20, 110, 200)
+    elif explorer.is_pressed(explorer.BUTTON_X) and explorer.is_pressed(explorer.BUTTON_Y):
+        explorer.set_pen(255, 255, 255)
+        explorer.text("Buttons X and Y pressed", 20, 110, 200)
+    elif explorer.is_pressed(explorer.BUTTON_X):
+        explorer.set_pen(255, 255, 255)
+        explorer.text("Button X pressed", 20, 110, 200)
+    elif explorer.is_pressed(explorer.BUTTON_Y):
+        explorer.set_pen(255, 255, 255)
+        explorer.text("Button Y pressed", 20, 110, 200)
+    else:
+        # no button press was detected
+        explorer.set_pen(255, 255, 255)
+        explorer.text("Plug a jumper wire from GP0 to AUDIO to hear noise!", 20, 110, 200)    
 
     explorer.set_tone(i)
 


### PR DESCRIPTION
Added code to show a simple example of the on-board A/B/X/Y button press detection and displaying the result on the display, as this feature of the Pico Explorer hardware was not being demonstrated in the initial demo.py example.