### PR TITLE
breakouts-dev: Make RGBMatrix5x5 actually work

### DIFF
--- a/drivers/is31fl3731/is31fl3731.cpp
+++ b/drivers/is31fl3731/is31fl3731.cpp
@@ -38,7 +38,7 @@ namespace pimoroni {
     AUDIOPLAY = 0x18
   };
 
-  enum reg {
+  enum reg : uint8_t {
     MODE      = 0x00,
     FRAME     = 0x01,
     AUTPLAY1  = 0x02,
@@ -93,11 +93,11 @@ namespace pimoroni {
   void IS31FL3731::enable(std::initializer_list<uint8_t> pattern, uint8_t frame) {
     i2c_reg_write_uint8(reg::BANK, frame);
     uint8_t enable_buf[19];
-    uint8_t *ptr = enable_buf;
     enable_buf[0] = ENABLE_OFFSET;
-    ptr++;
+    uint8_t offset = 1;
     for(auto byte : pattern) {
-      *ptr++ = byte;
+      enable_buf[offset] = byte;
+      offset++;
     }
     i2c_write_blocking(i2c, address, enable_buf, sizeof(enable_buf), false);
   }

--- a/examples/breakout_rgbmatrix5x5/demo.cpp
+++ b/examples/breakout_rgbmatrix5x5/demo.cpp
@@ -9,85 +9,28 @@ using namespace pimoroni;
 
 BreakoutRGBMatrix5x5 rgbmatrix5x5;
 
-struct RGB {
-  uint8_t r;
-  uint8_t g;
-  uint8_t b;
-};
-
-// This wonderful lookup table maps the LEDs on RGB Matrix 5x5
-// from their 3x5x5 (remember, they're RGB) configuration to
-// their specific location in the 144 pixel buffer.
-const RGB lookup_table[] = {
-  (118, 69, 85),
-  (117, 68, 101),
-  (116, 84, 100),
-  (115, 83, 99),
-  (114, 82, 98),
-  (113, 81, 97),
-  (112, 80, 96),
-  (134, 21, 37),
-  (133, 20, 36),
-  (132, 19, 35),
-  (131, 18, 34),
-  (130, 17, 50),
-  (129, 33, 49),
-  (128, 32, 48),
-  (127, 47, 63),
-  (121, 41, 57),
-  (122, 25, 58),
-  (123, 26, 42),
-  (124, 27, 43),
-  (125, 28, 44),
-  (126, 29, 45),
-  (15, 95, 111),
-  (8, 89, 105),
-  (9, 90, 106),
-  (10, 91, 107),
-  (11, 92, 108),
-  (12, 76, 109),
-  (13, 77, 93),
-};
-
-RGB lookup_pixel(uint8_t index) {
-  return lookup_table[index];
-}
-
-void set_pixel(uint8_t x, uint8_t y, uint8_t r, uint8_t g, uint8_t b) {
-  if(x == 1 || x == 3) {
-    y = 4 - y;
-  }
-  uint8_t index = y + (x * 5);
-  RGB rgb = lookup_pixel(index);
-  rgbmatrix5x5.set(rgb.r, r);
-  rgbmatrix5x5.set(rgb.g, g);
-  rgbmatrix5x5.set(rgb.b, b);
-}
-
 int main() {
   rgbmatrix5x5.init();
-  rgbmatrix5x5.enable({
-    0b00000000, 0b10111111,
-    0b00111110, 0b00111110,
-    0b00111111, 0b10111110,
-    0b00000111, 0b10000110,
-    0b00110000, 0b00110000,
-    0b00111111, 0b10111110,
-    0b00111111, 0b10111110,
-    0b01111111, 0b11111110,
-    0b01111111, 0b00000000
-  }, 0);
+
+  const pimoroni::RGBLookup colors[4] = {
+    {255, 0, 0},
+    {0, 255, 0},
+    {0, 0, 255},
+    {128, 128, 128}
+  };
 
   uint8_t col = 0;
   while(1) {
+    pimoroni::RGBLookup color = colors[col];
     for(auto x = 0u; x < 5; x++) {
       for(auto y = 0u; y < 5; y++) {
-        set_pixel(x, y, col, col, col);
+        rgbmatrix5x5.set_pixel(x, y, color.r, color.g, color.b);
       }
     }
     rgbmatrix5x5.update(0);
-    sleep_ms(10);
+    sleep_ms(1000);
     col++;
+    col %= 4;
   }
   return 0;
 }

--- a/libraries/breakout_rgbmatrix5x5/breakout_rgbmatrix5x5.cpp
+++ b/libraries/breakout_rgbmatrix5x5/breakout_rgbmatrix5x5.cpp
@@ -2,4 +2,34 @@
 
 namespace pimoroni {
 
+    void BreakoutRGBMatrix5x5::init() {
+        IS31FL3731::init();
+        enable({
+            0b00000000, 0b10111111,
+            0b00111110, 0b00111110,
+            0b00111111, 0b10111110,
+            0b00000111, 0b10000110,
+            0b00110000, 0b00110000,
+            0b00111111, 0b10111110,
+            0b00111111, 0b10111110,
+            0b01111111, 0b11111110,
+            0b01111111, 0b00000000
+        }, 0);
+    }
+
+    RGBLookup BreakoutRGBMatrix5x5::lookup_pixel(uint8_t index) {
+        return lookup_table[index];
+    }
+
+    void BreakoutRGBMatrix5x5::set_pixel(uint8_t x, uint8_t y, uint8_t r, uint8_t g, uint8_t b) {
+        if (x == 1 || x == 3) {
+            y = 4 - y;
+        }
+        uint8_t index = y + (x * 5);
+        RGBLookup rgb = lookup_pixel(index);
+        set(rgb.r, r);
+        set(rgb.g, g);
+        set(rgb.b, b);
+    }
+
 }

--- a/libraries/breakout_rgbmatrix5x5/breakout_rgbmatrix5x5.hpp
+++ b/libraries/breakout_rgbmatrix5x5/breakout_rgbmatrix5x5.hpp
@@ -3,6 +3,51 @@
 #include "../../drivers/is31fl3731/is31fl3731.hpp"
 
 namespace pimoroni {
+    struct RGBLookup {
+        uint8_t r;
+        uint8_t g;
+        uint8_t b;
+    };
 
-  typedef IS31FL3731 BreakoutRGBMatrix5x5;
+    class BreakoutRGBMatrix5x5 : public IS31FL3731 {
+      public:
+        void init();
+        void set_pixel(uint8_t x, uint8_t y, uint8_t r, uint8_t g, uint8_t b);
+      private:
+        RGBLookup lookup_pixel(uint8_t index);
+
+        // This wonderful lookup table maps the LEDs on RGB Matrix 5x5
+        // from their 3x5x5 (remember, they're RGB) configuration to
+        // their specific location in the 144 pixel buffer.
+        const RGBLookup lookup_table[28] = {
+            {118, 69, 85},
+            {117, 68, 101},
+            {116, 84, 100},
+            {115, 83, 99},
+            {114, 82, 98},
+            {113, 81, 97},
+            {112, 80, 96},
+            {134, 21, 37},
+            {133, 20, 36},
+            {132, 19, 35},
+            {131, 18, 34},
+            {130, 17, 50},
+            {129, 33, 49},
+            {128, 32, 48},
+            {127, 47, 63},
+            {121, 41, 57},
+            {122, 25, 58},
+            {123, 26, 42},
+            {124, 27, 43},
+            {125, 28, 44},
+            {126, 29, 45},
+            {15, 95, 111},
+            {8, 89, 105},
+            {9, 90, 106},
+            {10, 91, 107},
+            {11, 92, 108},
+            {12, 76, 109},
+            {13, 77, 93},
+        };
+    };
 }


### PR DESCRIPTION
Shot in the foot by my compiler, which allowed me to define a broken LED element lookup table like so:

```c++
const RGB lookup_table[] = {
  (118, 69, 85),
  (117, 68, 101),
  (116, 84, 100),
  (115, 83, 99),
  (114, 82, 98),
  (113, 81, 97),
  (112, 80, 96),
  (134, 21, 37),
  (133, 20, 36),
  (132, 19, 35),
  (131, 18, 34),
  (130, 17, 50),
  (129, 33, 49),
  (128, 32, 48),
  (127, 47, 63),
  (121, 41, 57),
  (122, 25, 58),
  (123, 26, 42),
  (124, 27, 43),
  (125, 28, 44),
  (126, 29, 45),
  (15, 95, 111),
  (8, 89, 105),
  (9, 90, 106),
  (10, 91, 107),
  (11, 92, 108),
  (12, 76, 109),
  (13, 77, 93),
};
```

The use of `()` instead of `{}` had very quietly broken the lookup table and thus the matrix was not lighting up in any expected pattern.

I've also pulled the init and this lookup mapping out of the example and into the driver, so the user need only `set_led(x, y, r, g, b)` and `update(frame)`.