### PR TITLE
Slight refactor of st7789 driver, and addition of the flip function

### DIFF
--- a/drivers/st7789/st7789.cpp
+++ b/drivers/st7789/st7789.cpp
@@ -51,11 +51,11 @@ namespace pimoroni {
       sleep_ms(150);
 
       if(width == 240 && height == 240) {
-        madctl = 0x04;
+        madctl[0] = 0x04;
       }
 
       if(width == 240 && height == 135) {
-        madctl = 0x70;
+        madctl[0] = 0x70;
       }
       
       command(reg::MADCTL,    1, madctl);  // row/column addressing order - rgb pixel order

--- a/drivers/st7789/st7789.cpp
+++ b/drivers/st7789/st7789.cpp
@@ -58,6 +58,10 @@ namespace pimoroni {
         madctl[0] = 0x70;
       }
       
+      if(width == 135 && height == 240) {
+		madctl[0] = 0x00;
+      }
+
       command(reg::MADCTL,    1, madctl);  // row/column addressing order - rgb pixel order
       command(reg::TEON,      1, "\x00");  // enable frame sync signal if used
       command(reg::COLMOD,    1, "\x05");  // 16 bits per pixel
@@ -77,6 +81,11 @@ namespace pimoroni {
       if(width == 240 && height == 135) {
         command(reg::RASET,     4, "\x00\x35\x00\xbb"); // 53 .. 187 (135 rows)
         command(reg::CASET,     4, "\x00\x28\x01\x17"); // 40 .. 279 (240 columns)
+      }
+
+      if(width == 135 && height == 240) {
+        command(reg::CASET,     4, "\x00\x34\x00\xba"); // 52 .. 186 (135 rows)
+        command(reg::RASET,     4, "\x00\x28\x01\x17"); // 40 .. 279 (240 columns)
       }
     }
 

--- a/drivers/st7789/st7789.cpp
+++ b/drivers/st7789/st7789.cpp
@@ -7,6 +7,7 @@
 #include "hardware/pwm.h"
 
 namespace pimoroni {
+  char madctl[2];
 
   void ST7789::init(bool auto_init_sequence) {
     // configure spi interface and pins
@@ -50,15 +51,16 @@ namespace pimoroni {
       sleep_ms(150);
 
       if(width == 240 && height == 240) {
-        command(reg::MADCTL,    1, "\x04");  // row/column addressing order - rgb pixel order
-        command(reg::TEON,      1, "\x00");  // enable frame sync signal if used
-        command(reg::COLMOD,    1, "\x05");  // 16 bits per pixel
+        madctl = 0x04;
       }
 
       if(width == 240 && height == 135) {
-        command(reg::MADCTL,    1, "\x70");
-        command(reg::COLMOD,    1, "\x05");
+        madctl = 0x70;
       }
+      
+      command(reg::MADCTL,    1, madctl);  // row/column addressing order - rgb pixel order
+      command(reg::TEON,      1, "\x00");  // enable frame sync signal if used
+      command(reg::COLMOD,    1, "\x05");  // 16 bits per pixel
 
       command(reg::INVON);   // set inversion mode
       command(reg::SLPOUT);  // leave sleep mode
@@ -146,5 +148,10 @@ namespace pimoroni {
 
   void ST7789::vsync_callback(gpio_irq_callback_t callback) {
     gpio_set_irq_enabled_with_callback(vsync, GPIO_IRQ_EDGE_RISE, true, callback);
+  }
+
+  void ST7789::flip(){
+    madctl[0] ^= 0xC0;
+    command(reg::MADCTL,    1, madctl);
   }
 }

--- a/drivers/st7789/st7789.hpp
+++ b/drivers/st7789/st7789.hpp
@@ -47,6 +47,7 @@ namespace pimoroni {
     void vsync_callback(gpio_irq_callback_t callback);
     void update(bool dont_block = false);
     void set_backlight(uint8_t brightness);
+    void flip();
 
     enum reg {
       SWRESET   = 0x01,

--- a/libraries/pico_display/pico_display.cpp
+++ b/libraries/pico_display/pico_display.cpp
@@ -79,4 +79,7 @@ namespace pimoroni {
     return !gpio_get(button);
   }
 
+  void flip() {
+    screen.flip();
+  }
 }

--- a/libraries/pico_display/pico_display.cpp
+++ b/libraries/pico_display/pico_display.cpp
@@ -17,6 +17,11 @@ namespace pimoroni {
       __fb = buf;
   }
 
+  PicoDisplay::PicoDisplay(uint16_t *buf, int width, int height)
+    : PicoGraphics(width, height, buf), screen(width, height, buf)  {
+      __fb = buf;
+  }
+
   void PicoDisplay::init() {
     // setup the rgb led for pwm control
     pwm_config cfg = pwm_get_default_config();

--- a/libraries/pico_display/pico_display.cpp
+++ b/libraries/pico_display/pico_display.cpp
@@ -79,7 +79,7 @@ namespace pimoroni {
     return !gpio_get(button);
   }
 
-  void flip() {
+  void PicoDisplay::flip() {
     screen.flip();
   }
 }

--- a/libraries/pico_display/pico_display.hpp
+++ b/libraries/pico_display/pico_display.hpp
@@ -9,7 +9,9 @@ namespace pimoroni {
   public:
     static const int WIDTH = 240;
     static const int HEIGHT = 135;
-    static const uint8_t A = 12;
+    static const int PORTRAIT_WIDTH  = 135;
+    static const int PORTRAIT_HEIGHT = 240;
+     static const uint8_t A = 12;
     static const uint8_t B = 13;
     static const uint8_t X = 14;
     static const uint8_t Y = 15;
@@ -20,6 +22,7 @@ namespace pimoroni {
 
   public:
     PicoDisplay(uint16_t *buf);
+    PicoDisplay(uint16_t *buf, int width, int height);
 
     void init();
     void update();

--- a/libraries/pico_display/pico_display.hpp
+++ b/libraries/pico_display/pico_display.hpp
@@ -26,6 +26,7 @@ namespace pimoroni {
     void set_backlight(uint8_t brightness);
     void set_led(uint8_t r, uint8_t g, uint8_t b);
     bool is_pressed(uint8_t button);
+    void flip();
   };
 
 }

--- a/micropython/modules/pico_display/pico_display.c
+++ b/micropython/modules/pico_display/pico_display.c
@@ -22,6 +22,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_0(picodisplay_update_obj, picodisplay_update);
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(picodisplay_set_backlight_obj, picodisplay_set_backlight);
 STATIC MP_DEFINE_CONST_FUN_OBJ_3(picodisplay_set_led_obj, picodisplay_set_led);
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(picodisplay_is_pressed_obj, picodisplay_is_pressed);
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(picodisplay_flip_obj, picodisplay_flip);
 
 //From PicoGraphics parent class
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(picodisplay_set_pen_obj, 1, 3, picodisplay_set_pen);
@@ -47,6 +48,7 @@ STATIC const mp_map_elem_t picodisplay_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_set_backlight), MP_ROM_PTR(&picodisplay_set_backlight_obj) },    
     { MP_ROM_QSTR(MP_QSTR_set_led), MP_ROM_PTR(&picodisplay_set_led_obj) },
     { MP_ROM_QSTR(MP_QSTR_is_pressed), MP_ROM_PTR(&picodisplay_is_pressed_obj) },
+    { MP_ROM_QSTR(MP_QSTR_flip), MP_ROM_PTR(&picodisplay_flip_obj) },
 
     { MP_ROM_QSTR(MP_QSTR_set_pen), MP_ROM_PTR(&picodisplay_set_pen_obj) },
     { MP_ROM_QSTR(MP_QSTR_create_pen), MP_ROM_PTR(&picodisplay_create_pen_obj) },

--- a/micropython/modules/pico_display/pico_display.cpp
+++ b/micropython/modules/pico_display/pico_display.cpp
@@ -43,6 +43,15 @@ mp_obj_t picodisplay_update() {
     return mp_const_none;
 }
 
+mp_obj_t picodisplay_flip() {
+    if(display != nullptr)
+        display->flip();
+    else
+        mp_raise_msg(&mp_type_RuntimeError, NOT_INITIALISED_MSG);
+
+    return mp_const_none;
+}
+
 mp_obj_t picodisplay_set_backlight(mp_obj_t brightness_obj) {
     if(display != nullptr) {
         float brightness = mp_obj_get_float(brightness_obj);

--- a/micropython/modules/pico_display/pico_display.h
+++ b/micropython/modules/pico_display/pico_display.h
@@ -10,6 +10,7 @@ extern mp_obj_t picodisplay_set_backlight(mp_obj_t brightness_obj);
 extern mp_obj_t picodisplay_update();
 extern mp_obj_t picodisplay_set_led(mp_obj_t r_obj, mp_obj_t g_obj, mp_obj_t b_obj);
 extern mp_obj_t picodisplay_is_pressed(mp_obj_t button_obj);
+extern mp_obj_t picodisplay_flip();
 
 // From PicoGraphics parent class
 extern mp_obj_t picodisplay_set_pen(mp_uint_t n_args, const mp_obj_t *args);


### PR DESCRIPTION
As per issue #80, added a flip function. Required minor refactor of code to create a madctl variable for the st7789, as trying to read and update the registers was a miserable failure.