### PR TITLE
Display thermo example Keep last 48 temperatures

### DIFF
--- a/micropython/examples/pico_display/thermometer.py
+++ b/micropython/examples/pico_display/thermometer.py
@@ -18,36 +18,45 @@ conversion_factor = 3.3 / (65535)
 # Set the display backlight to 50%
 display.set_backlight(0.5)
 
-i = 0
+temperatures = []
 
 while True:
+    # fills the screen with black
+    display.set_pen(0, 0, 0)
+    display.clear()
+
     # the following two lines do some maths to convert the number from the temp sensor into celsius
     reading = sensor_temp.read_u16() * conversion_factor
     temperature = round(27 - (reading - 0.706) / 0.001721)    
     
-    # this if statement clears the display once the graph reaches the right hand side of the display
-    if i >= (width + 1):
-        i = 0
-        display.set_pen(0, 0, 0)
-        display.clear()
+    # shifts the temperatures history to the left by one sample
+    if len(temperatures) > 48:  # 240/5
+        temperatures = temperatures[1::]
+    else:
+        temperatures.append(temperature)
 
-    # chooses a pen colour based on the temperature
-    display.set_pen(0, 255, 0)
-    if temperature > 20:
-        display.set_pen(255, 0, 0)
-    if temperature < 13:
-        display.set_pen(0, 0, 255)
-        
+    i = 0
+    for t in temperatures:
+        # chooses a pen colour based on the temperature
+        display.set_pen(0, 255, 0)
+        if t > 20:
+            display.set_pen(255, 0, 0)
+        elif t < 13:
+            display.set_pen(0, 0, 255)
+    
+        # draws the reading as a tall, thin rectangle
+        display.rectangle(i, height - (t * 4), 5, height)
+
+        # the next tall thin rectangle needs to be drawn 5 pixels to the right of the last one
+        i += 5
+    
     # heck lets also set the LED to match
     display.set_led(0, 255, 0)
     if temperature > 20:
         display.set_led(255, 0, 0)
-    if temperature < 13:
+    elif temperature < 13:
         display.set_led(0, 0, 255)
-     
-    # draws the reading as a tall, thin rectangle
-    display.rectangle(i, height - (temperature * 4), 5, height)
-    
+
     # draws a white background for the text
     display.set_pen(255, 255, 255)
     display.rectangle(1, 1, 50, 25)
@@ -60,7 +69,4 @@ while True:
     display.update()
     
     # waits for 5 seconds
-    utime.sleep(5) 
-    
-    # the next tall thin rectangle needs to be drawn 5 pixels to the right of the last one
-    i += 5 
+    utime.sleep(5)


### PR DESCRIPTION
Keep history for the last 48 (240px / 5px) temperatures readings instead of completely clearing the screen once full.