### PR TITLE
Fix or suppress warnings

### DIFF
--- a/libraries/pico_graphics/pico_graphics.cpp
+++ b/libraries/pico_graphics/pico_graphics.cpp
@@ -67,7 +67,7 @@ namespace pimoroni {
     Pen *dest = ptr(clipped);
     while(clipped.h--) {
       // draw span of pixels for this row
-      for(uint32_t i = 0; i < clipped.w; i++) {
+      for(int32_t i = 0; i < clipped.w; i++) {
         *dest++ = pen;
       }
 
@@ -141,7 +141,7 @@ namespace pimoroni {
 
       // if this word would exceed the wrap limit then
       // move to the next line
-      if(co != 0 && co + word_width > wrap) {
+      if(co != 0 && co + word_width > (uint32_t)wrap) {
         co = 0;
         lo += 7 * scale;
       }
@@ -203,13 +203,13 @@ namespace pimoroni {
     int32_t w1row = orient2d(p3, p1, tl) + bias1;
     int32_t w2row = orient2d(p1, p2, tl) + bias2;
 
-    for (uint32_t y = 0; y < triangle_bounds.h; y++) {
+    for (int32_t y = 0; y < triangle_bounds.h; y++) {
       int32_t w0 = w0row;
       int32_t w1 = w1row;
       int32_t w2 = w2row;
 
       Pen *dest = ptr(triangle_bounds.x, triangle_bounds.y + y);
-      for (uint32_t x = 0; x < triangle_bounds.w; x++) {
+      for (int32_t x = 0; x < triangle_bounds.w; x++) {
         if ((w0 | w1 | w2) >= 0) {
           *dest = pen;
         }

--- a/micropython/modules/pico_display/usermod.cmake
+++ b/micropython/modules/pico_display/usermod.cmake
@@ -19,3 +19,9 @@ target_compile_definitions(usermod_pico_display INTERFACE
 )
 
 target_link_libraries(usermod INTERFACE usermod_pico_display)
+
+set_source_files_properties(
+    ${CMAKE_CURRENT_LIST_DIR}/pico_display.c
+    PROPERTIES COMPILE_FLAGS
+    "-Wno-discarded-qualifiers -Wno-implicit-int"
+)

--- a/micropython/modules/pico_explorer/usermod.cmake
+++ b/micropython/modules/pico_explorer/usermod.cmake
@@ -19,3 +19,9 @@ target_compile_definitions(usermod_pico_explorer INTERFACE
 )
 
 target_link_libraries(usermod INTERFACE usermod_pico_explorer)
+
+set_source_files_properties(
+    ${CMAKE_CURRENT_LIST_DIR}/pico_explorer.c
+    PROPERTIES COMPILE_FLAGS
+    "-Wno-discarded-qualifiers -Wno-implicit-int"
+)

--- a/micropython/modules/pico_rgb_keypad/usermod.cmake
+++ b/micropython/modules/pico_rgb_keypad/usermod.cmake
@@ -15,3 +15,9 @@ target_compile_definitions(usermod_pico_rgb_keypad INTERFACE
 )
 
 target_link_libraries(usermod INTERFACE usermod_pico_rgb_keypad)
+
+set_source_files_properties(
+    ${CMAKE_CURRENT_LIST_DIR}/pico_rgb_keypad.c
+    PROPERTIES COMPILE_FLAGS
+    "-Wno-discarded-qualifiers -Wno-implicit-int"
+)

--- a/micropython/modules/pico_scroll/usermod.cmake
+++ b/micropython/modules/pico_scroll/usermod.cmake
@@ -15,3 +15,9 @@ target_compile_definitions(usermod_pico_scroll INTERFACE
 )
 
 target_link_libraries(usermod INTERFACE usermod_pico_scroll)
+
+set_source_files_properties(
+    ${CMAKE_CURRENT_LIST_DIR}/pico_scroll.c
+    PROPERTIES COMPILE_FLAGS
+    "-Wno-discarded-qualifiers -Wno-implicit-int"
+)

--- a/micropython/modules/pico_unicorn/usermod.cmake
+++ b/micropython/modules/pico_unicorn/usermod.cmake
@@ -17,3 +17,9 @@ target_compile_definitions(usermod_pico_unicorn INTERFACE
 )
 
 target_link_libraries(usermod INTERFACE usermod_pico_unicorn)
+
+set_source_files_properties(
+    ${CMAKE_CURRENT_LIST_DIR}/pico_unicorn.c
+    PROPERTIES COMPILE_FLAGS
+    "-Wno-discarded-qualifiers -Wno-implicit-int"
+)


### PR DESCRIPTION
The upstream MicroPython rp2 port has re-enabled -Werror so we need to either fix warnings or,
in the case of those generated by C++/C MicroPython binding weirdness, suppress them.