### PR TITLE
Switch MicroPython to build against upstream

### DIFF
--- a/.github/workflows/micropython.yml
+++ b/.github/workflows/micropython.yml
@@ -29,8 +29,8 @@ jobs:
     - name: Checkout MicroPython
       uses: actions/checkout@v2
       with:
-        repository: pimoroni/micropython
-        ref: continuous-integration
+        repository: micropython/micropython
+        ref: master
         submodules: false  # MicroPython submodules are hideously broken
         path: micropython
 


### PR DESCRIPTION
USER_C_MODULE support has been merged upstream. Hooray!