### PR TITLE
Fix for MicroPython hard lock when passing in non-string object to text function

### DIFF
--- a/micropython/modules/breakout_roundlcd/breakout_roundlcd.cpp
+++ b/micropython/modules/breakout_roundlcd/breakout_roundlcd.cpp
@@ -411,22 +411,36 @@ mp_obj_t BreakoutRoundLCD_text(size_t n_args, const mp_obj_t *pos_args, mp_map_t
     
     breakout_roundlcd_BreakoutRoundLCD_obj_t *self = MP_OBJ_TO_PTR2(args[ARG_self].u_obj, breakout_roundlcd_BreakoutRoundLCD_obj_t);
 
-    mp_check_self(mp_obj_is_str_or_bytes(args[ARG_text].u_obj));
-    GET_STR_DATA_LEN(args[ARG_text].u_obj, str, str_len);
+    mp_obj_t text_obj = args[ARG_text].u_obj;
+    if(mp_obj_is_str_or_bytes(text_obj)) {
+        GET_STR_DATA_LEN(text_obj, str, str_len);
 
-    std::string t((const char*)str);
+        std::string t((const char*)str);
 
-    int x = args[ARG_x].u_int;
-    int y = args[ARG_y].u_int;
-    int wrap = args[ARG_wrap].u_int;
+        int x = args[ARG_x].u_int;
+        int y = args[ARG_y].u_int;
+        int wrap = args[ARG_wrap].u_int;
 
-    Point p(x, y);
-    if(n_args == 5) {
-        int scale = args[ARG_scale].u_int;
-        self->breakout->text(t, p, wrap, scale);
+        Point p(x, y);
+        if(n_args == 5) {
+            int scale = args[ARG_scale].u_int;
+            self->breakout->text(t, p, wrap, scale);
+        }
+        else
+            self->breakout->text(t, p, wrap);
     }
-    else
-        self->breakout->text(t, p, wrap);
+    else if(mp_obj_is_float(text_obj)) {
+        mp_raise_TypeError("can't convert 'float' object to str implicitly");
+    }
+    else if(mp_obj_is_int(text_obj)) {
+        mp_raise_TypeError("can't convert 'int' object to str implicitly");
+    }
+    else if(mp_obj_is_bool(text_obj)) {
+        mp_raise_TypeError("can't convert 'bool' object to str implicitly");
+    }
+    else {
+        mp_raise_TypeError("can't convert object to str implicitly");
+    }        
 
     return mp_const_none;
 }

--- a/micropython/modules/pico_display/pico_display.cpp
+++ b/micropython/modules/pico_display/pico_display.cpp
@@ -303,22 +303,35 @@ mp_obj_t picodisplay_character(mp_uint_t n_args, const mp_obj_t *args) {
 
 mp_obj_t picodisplay_text(mp_uint_t n_args, const mp_obj_t *args) {
     if(display != nullptr) {
-        mp_check_self(mp_obj_is_str_or_bytes(args[0]));
-        GET_STR_DATA_LEN(args[0], str, str_len);
+        if(mp_obj_is_str_or_bytes(args[0])) {
+            GET_STR_DATA_LEN(args[0], str, str_len);
 
-        std::string t((const char*)str);
+            std::string t((const char*)str);
 
-        int x = mp_obj_get_int(args[1]);
-        int y = mp_obj_get_int(args[2]);
-        int wrap = mp_obj_get_int(args[3]);
+            int x = mp_obj_get_int(args[1]);
+            int y = mp_obj_get_int(args[2]);
+            int wrap = mp_obj_get_int(args[3]);
 
-        Point p(x, y);
-        if(n_args == 5) {
-            int scale = mp_obj_get_int(args[4]);
-            display->text(t, p, wrap, scale);
+            Point p(x, y);
+            if(n_args == 5) {
+                int scale = mp_obj_get_int(args[4]);
+                display->text(t, p, wrap, scale);
+            }
+            else
+                display->text(t, p, wrap);
         }
-        else
-            display->text(t, p, wrap);
+        else if(mp_obj_is_float(args[0])) {
+            mp_raise_TypeError("can't convert 'float' object to str implicitly");
+        }
+        else if(mp_obj_is_int(args[0])) {
+            mp_raise_TypeError("can't convert 'int' object to str implicitly");
+        }
+        else if(mp_obj_is_bool(args[0])) {
+            mp_raise_TypeError("can't convert 'bool' object to str implicitly");
+        }
+        else {
+            mp_raise_TypeError("can't convert object to str implicitly");
+        }
     }
     else
         mp_raise_msg(&mp_type_RuntimeError, NOT_INITIALISED_MSG);

--- a/micropython/modules/pico_explorer/pico_explorer.cpp
+++ b/micropython/modules/pico_explorer/pico_explorer.cpp
@@ -326,22 +326,35 @@ mp_obj_t picoexplorer_character(mp_uint_t n_args, const mp_obj_t *args) {
 
 mp_obj_t picoexplorer_text(mp_uint_t n_args, const mp_obj_t *args) {
     if(explorer != nullptr) {
-        mp_check_self(mp_obj_is_str_or_bytes(args[0]));
-        GET_STR_DATA_LEN(args[0], str, str_len);
+        if(mp_obj_is_str_or_bytes(args[0])) {
+            GET_STR_DATA_LEN(args[0], str, str_len);
 
-        std::string t((const char*)str);
+            std::string t((const char*)str);
 
-        int x = mp_obj_get_int(args[1]);
-        int y = mp_obj_get_int(args[2]);
-        int wrap = mp_obj_get_int(args[3]);
+            int x = mp_obj_get_int(args[1]);
+            int y = mp_obj_get_int(args[2]);
+            int wrap = mp_obj_get_int(args[3]);
 
-        Point p(x, y);
-        if(n_args == 5) {
-            int scale = mp_obj_get_int(args[4]);
-            explorer->text(t, p, wrap, scale);
+            Point p(x, y);
+            if(n_args == 5) {
+                int scale = mp_obj_get_int(args[4]);
+                explorer->text(t, p, wrap, scale);
+            }
+            else
+                explorer->text(t, p, wrap);
         }
-        else
-            explorer->text(t, p, wrap);
+        else if(mp_obj_is_float(args[0])) {
+            mp_raise_TypeError("can't convert 'float' object to str implicitly");
+        }
+        else if(mp_obj_is_int(args[0])) {
+            mp_raise_TypeError("can't convert 'int' object to str implicitly");
+        }
+        else if(mp_obj_is_bool(args[0])) {
+            mp_raise_TypeError("can't convert 'bool' object to str implicitly");
+        }
+        else {
+            mp_raise_TypeError("can't convert object to str implicitly");
+        }
     }
     else
         mp_raise_msg(&mp_type_RuntimeError, NOT_INITIALISED_MSG);


### PR DESCRIPTION
Now raises an error if a non-string type is passed into the `.text` function to resolve #58 and #99.

This seemed best, rather that attempting to perform type conversion within the function, which could lead to numerous edge cases.