### PR TITLE
Revert ST7789 backlight for Pico Display

### DIFF
--- a/drivers/st7789/st7789.hpp
+++ b/drivers/st7789/st7789.hpp
@@ -21,7 +21,7 @@ namespace pimoroni {
     int8_t sck    = 18;
     int8_t mosi   = 19;
     int8_t miso   = -1; // we generally don't use this pin
-    int8_t bl     = 21;
+    int8_t bl     = 20;
     int8_t vsync  = -1; // only available on some products
 
     uint32_t spi_baud = 64 * 1024 * 1024;


### PR DESCRIPTION
Obfuscated by some whitespace changes, the ST7789 `bl` pin default changed from `20` to `21` in https://github.com/pimoroni/pimoroni-pico/commit/f812e23d8e92dda252902c155ac409ab3f154122