### PR TITLE
Fix picokeypad.clear()

### DIFF
--- a/micropython/modules/pico_rgb_keypad/pico_rgb_keypad.c
+++ b/micropython/modules/pico_rgb_keypad/pico_rgb_keypad.c
@@ -13,7 +13,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_0(picokeypad_update_obj, picokeypad_update);
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(picokeypad_set_brightness_obj, picokeypad_set_brightness);
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(picokeypad_illuminate_xy_obj, 5, 5, picokeypad_illuminate_xy);
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(picokeypad_illuminate_obj, 4, 4, picokeypad_illuminate);
-STATIC MP_DEFINE_CONST_FUN_OBJ_0(picokeypad_clear_obj, picokeypad_init);
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(picokeypad_clear_obj, picokeypad_clear);
 STATIC MP_DEFINE_CONST_FUN_OBJ_0(picokeypad_get_button_states_obj, picokeypad_get_button_states);
 
 /***** Globals Table *****/


### PR DESCRIPTION
Using release 0.1.1 of pimoroni-pico-micropython, the picokeypad.clear() function does not seem to work. Looking through the code, it appears that clear is actually calling init instead. Unfortunately, I'm just starting with micropython and don't have much C experience outside of Arduino, so testing this (or confirming I'm reading the C code for this module correctly) is a bit out of my depth.