### PR TITLE
Set pixels as image, add show_bitmap_1d()

### DIFF
--- a/micropython/modules/pico_scroll/README.md
+++ b/micropython/modules/pico_scroll/README.md
@@ -10,6 +10,7 @@ We've included helper functions to handle every aspect of drawing to the matrix 
   - [get_width](#get_width)
   - [get_height](#get_height)
   - [set_pixel](#set_pixel)
+  - [set_pixels](#set_pixels)
   - [update](#update)
   - [clear](#clear)
   - [is_pressed](#is_pressed)
@@ -71,6 +72,17 @@ This function sets a pixel at the `x` and `y` coordinates to a brightness level 
 
 ```python
 picoscroll.set_pixel(x, y, l)
+```
+
+### set_pixels
+
+This function sets all pixel at once from a `bytearray` image indexed
+as `y * picoscroll.get_width() + x`, containing brightness levels
+between 0 and 255. Changes will not be visible until `update()` is called.
+
+```python
+image = bytearray(0 for j in range(width * height))
+picoscroll.set_pixels(image)
 ```
 
 ### update

--- a/micropython/modules/pico_scroll/README.md
+++ b/micropython/modules/pico_scroll/README.md
@@ -85,6 +85,24 @@ image = bytearray(0 for j in range(width * height))
 picoscroll.set_pixels(image)
 ```
 
+### show_bitmap_1d
+
+Show a view of a bitmap stored as the 7 least significant bits of
+bytes in a `bytearray`, top-down. Individual pixels are set to
+`brightness` based on individual bit values, with the view defined by
+the offset and the width of the scroll (i.e. 17 columns). Changes will
+not be visible until `update()` is called.
+
+```python
+bitmap = bytearray(j for j in range 127)
+for offset in range(-17, 127):
+    picoscroll.show_bitmap_1d(bitmap, 16, offset)
+    picoscroll.update()
+```
+
+will scroll a binary counter across the display (i.e. show `0x00` to
+`0x7f` in binary).
+
 ### update
 
 Pushes pixel data from the Pico to the Scroll Pack.  Until this function is called any `set_pixel` or `clear` calls won't have any visible effect.

--- a/micropython/modules/pico_scroll/pico_scroll.c
+++ b/micropython/modules/pico_scroll/pico_scroll.c
@@ -20,6 +20,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_0(picoscroll_get_width_obj, picoscroll_get_width)
 STATIC MP_DEFINE_CONST_FUN_OBJ_0(picoscroll_get_height_obj, picoscroll_get_height);
 STATIC MP_DEFINE_CONST_FUN_OBJ_0(picoscroll_update_obj, picoscroll_update);
 STATIC MP_DEFINE_CONST_FUN_OBJ_3(picoscroll_set_pixel_obj, picoscroll_set_pixel);
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(picoscroll_set_pixels_obj, picoscroll_set_pixels);
 STATIC MP_DEFINE_CONST_FUN_OBJ_0(picoscroll_clear_obj, picoscroll_clear);
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(picoscroll_is_pressed_obj, picoscroll_is_pressed);
 
@@ -31,6 +32,7 @@ STATIC const mp_map_elem_t picoscroll_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_get_height), MP_ROM_PTR(&picoscroll_get_height_obj) },
     { MP_ROM_QSTR(MP_QSTR_update), MP_ROM_PTR(&picoscroll_update_obj) },
     { MP_ROM_QSTR(MP_QSTR_set_pixel), MP_ROM_PTR(&picoscroll_set_pixel_obj) },
+    { MP_ROM_QSTR(MP_QSTR_set_pixels), MP_ROM_PTR(&picoscroll_set_pixels_obj) },
     { MP_ROM_QSTR(MP_QSTR_clear), MP_ROM_PTR(&picoscroll_clear_obj) },
     { MP_ROM_QSTR(MP_QSTR_is_pressed), MP_ROM_PTR(&picoscroll_is_pressed_obj) },        
     { MP_ROM_QSTR(MP_QSTR_BUTTON_A), MP_ROM_INT(BUTTON_A) },

--- a/micropython/modules/pico_scroll/pico_scroll.c
+++ b/micropython/modules/pico_scroll/pico_scroll.c
@@ -21,6 +21,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_0(picoscroll_get_height_obj, picoscroll_get_heigh
 STATIC MP_DEFINE_CONST_FUN_OBJ_0(picoscroll_update_obj, picoscroll_update);
 STATIC MP_DEFINE_CONST_FUN_OBJ_3(picoscroll_set_pixel_obj, picoscroll_set_pixel);
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(picoscroll_set_pixels_obj, picoscroll_set_pixels);
+STATIC MP_DEFINE_CONST_FUN_OBJ_3(picoscroll_show_bitmap_1d_obj, picoscroll_show_bitmap_1d);
 STATIC MP_DEFINE_CONST_FUN_OBJ_0(picoscroll_clear_obj, picoscroll_clear);
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(picoscroll_is_pressed_obj, picoscroll_is_pressed);
 
@@ -33,6 +34,7 @@ STATIC const mp_map_elem_t picoscroll_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_update), MP_ROM_PTR(&picoscroll_update_obj) },
     { MP_ROM_QSTR(MP_QSTR_set_pixel), MP_ROM_PTR(&picoscroll_set_pixel_obj) },
     { MP_ROM_QSTR(MP_QSTR_set_pixels), MP_ROM_PTR(&picoscroll_set_pixels_obj) },
+    { MP_ROM_QSTR(MP_QSTR_show_bitmap_1d), MP_ROM_PTR(&picoscroll_show_bitmap_1d_obj) },
     { MP_ROM_QSTR(MP_QSTR_clear), MP_ROM_PTR(&picoscroll_clear_obj) },
     { MP_ROM_QSTR(MP_QSTR_is_pressed), MP_ROM_PTR(&picoscroll_is_pressed_obj) },        
     { MP_ROM_QSTR(MP_QSTR_BUTTON_A), MP_ROM_INT(BUTTON_A) },

--- a/micropython/modules/pico_scroll/pico_scroll.cpp
+++ b/micropython/modules/pico_scroll/pico_scroll.cpp
@@ -95,7 +95,8 @@ mp_obj_t picoscroll_show_bitmap_1d(mp_obj_t bitmap_obj, mp_obj_t brightness_obj,
 	int height = PicoScroll::HEIGHT;
 
 	// this obviously shouldn't happen as the scroll is 17x7 pixels
-	if (height > (int) sizeof(unsigned char)) {
+	// would fall off end of byte if this the case
+	if (height > 8) {
 	    mp_raise_msg(&mp_type_RuntimeError, INCORRECT_SIZE_MSG);
 	}
 

--- a/micropython/modules/pico_scroll/pico_scroll.cpp
+++ b/micropython/modules/pico_scroll/pico_scroll.cpp
@@ -58,6 +58,25 @@ mp_obj_t picoscroll_set_pixel(mp_obj_t x_obj, mp_obj_t y_obj, mp_obj_t v_obj) {
     return mp_const_none;
 }
 
+mp_obj_t picoscroll_set_pixels(mp_obj_t image_obj) {
+    if(scroll != nullptr) {
+        mp_buffer_info_t bufinfo;
+	mp_get_buffer_raise(image_obj, &bufinfo, MP_BUFFER_RW);
+	unsigned char * values = (unsigned char *) bufinfo.buf;
+
+        for (int y = 0; y < PicoScroll::HEIGHT; y++) {
+	    for (int x = 0; x < PicoScroll::WIDTH; x++) {
+	        int val = values[y * PicoScroll::WIDTH + x];
+                scroll->set_pixel(x, y, val);
+	    }
+        }
+    }
+    else
+        mp_raise_msg(&mp_type_RuntimeError, NOT_INITIALISED_MSG);
+
+    return mp_const_none;
+}
+
 mp_obj_t picoscroll_clear() {
     if(scroll != nullptr)
         scroll->clear();

--- a/micropython/modules/pico_scroll/pico_scroll.cpp
+++ b/micropython/modules/pico_scroll/pico_scroll.cpp
@@ -14,6 +14,8 @@ extern "C" {
 
 #define NOT_INITIALISED_MSG     "Cannot call this function, as picoscroll is not initialised. Call picoscroll.init() first."
 
+#define BUFFER_TOO_SMALL_MSG "bytearray too small: len(image) < width * height."
+
 mp_obj_t picoscroll_init() {
     if(scroll == nullptr)
         scroll = new PicoScroll();
@@ -62,6 +64,11 @@ mp_obj_t picoscroll_set_pixels(mp_obj_t image_obj) {
     if(scroll != nullptr) {
         mp_buffer_info_t bufinfo;
 	mp_get_buffer_raise(image_obj, &bufinfo, MP_BUFFER_RW);
+
+	if (bufinfo.len < (PicoScroll::WIDTH * PicoScroll::HEIGHT)) {
+	    mp_raise_msg(&mp_type_IndexError, BUFFER_TOO_SMALL_MSG);
+	}
+
 	unsigned char * values = (unsigned char *) bufinfo.buf;
 
         for (int y = 0; y < PicoScroll::HEIGHT; y++) {

--- a/micropython/modules/pico_scroll/pico_scroll.h
+++ b/micropython/modules/pico_scroll/pico_scroll.h
@@ -8,5 +8,6 @@ extern mp_obj_t picoscroll_get_height();
 extern mp_obj_t picoscroll_update();
 extern mp_obj_t picoscroll_set_pixel(mp_obj_t x_obj, mp_obj_t y_obj, mp_obj_t v_obj);
 extern mp_obj_t picoscroll_set_pixels(mp_obj_t image_obj);
+extern mp_obj_t picoscroll_show_bitmap_1d(mp_obj_t bitmap_obj, mp_obj_t brightness, mp_obj_t offset);
 extern mp_obj_t picoscroll_clear();
 extern mp_obj_t picoscroll_is_pressed(mp_obj_t button_obj);

--- a/micropython/modules/pico_scroll/pico_scroll.h
+++ b/micropython/modules/pico_scroll/pico_scroll.h
@@ -7,5 +7,6 @@ extern mp_obj_t picoscroll_get_width();
 extern mp_obj_t picoscroll_get_height();
 extern mp_obj_t picoscroll_update();
 extern mp_obj_t picoscroll_set_pixel(mp_obj_t x_obj, mp_obj_t y_obj, mp_obj_t v_obj);
+extern mp_obj_t picoscroll_set_pixels(mp_obj_t image_obj);
 extern mp_obj_t picoscroll_clear();
 extern mp_obj_t picoscroll_is_pressed(mp_obj_t button_obj);


### PR DESCRIPTION
# Preamble
I don't know how you folks feel about PR's - if this is not your game, I will not be offended if I see a close with no comments. 

# Proposed API extensions

## Show images

Show images using a `set_pixels` method:

```python
image = bytearray(0 for j in range(width * height))
picoscroll.set_pixels(image)
```

seems convenient for cases where you want to redraw the image from one "frame" to the next, means all of the pixel value copying is done in C not Python/ 

## Scroll bitmaps

Scroll bitmaps (one dimensional, e.g. text) using a `show_bitmap_1d` method:

```python
bitmap = bytearray(j for j in range 127)
for offset in range(-17, 127):
    picoscroll.show_bitmap_1d(bitmap, 16, offset)
    picoscroll.update()
```

Detailed illustration in [this gist](https://gist.github.com/graeme-winter/ff08123ceae76399791413f2564eecaa)

Motivation for second one: pico scroll did not offer a simple method to actually scroll text across the display, and I feel that this is pretty fundamental so decided to offer one. I wondered about adding the code to render the text to a bitmap to the API but decided on balance to keep things simple, as fonts are something people hold strong opinions about. 

End product:

https://youtu.be/XIvKc523NwM

Will welcome any feedback here, I tried to stick to the "house style"