### PR TITLE
Fix for MicroPython build changes, and pin to v1.15

### DIFF
--- a/.github/workflows/micropython.yml
+++ b/.github/workflows/micropython.yml
@@ -10,6 +10,7 @@ env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   MICROPYTHON_VERSION: v1.15
   BUILD_TYPE: Release
+  BOARD_TYPE: PICO
 
 jobs:
   build:
@@ -72,7 +73,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       with:
-        asset_path: micropython/ports/rp2/build/firmware.uf2
+        asset_path: micropython/ports/rp2/build-${{env.BOARD_TYPE}}/firmware.uf2
         upload_url: ${{github.event.release.upload_url}}
         asset_name: ${{github.event.repository.name}}-${{github.event.release.tag_name}}-micropython-${{env.MICROPYTHON_VERSION}}.uf2
         asset_content_type: application/octet-stream

--- a/.github/workflows/micropython.yml
+++ b/.github/workflows/micropython.yml
@@ -8,8 +8,8 @@ on:
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  MICROPYTHON_VERSION: v1.15
   BUILD_TYPE: Release
-  RELEASE_FILE: ${{github.event.repository.name}}-micropython-${{github.event.release.tag_name}}.uf2
 
 jobs:
   build:
@@ -31,7 +31,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: micropython/micropython
-        ref: master
+        ref: ${{env.MICROPYTHON_VERSION}}
         submodules: false  # MicroPython submodules are hideously broken
         path: micropython
 
@@ -74,5 +74,5 @@ jobs:
       with:
         asset_path: micropython/ports/rp2/build/firmware.uf2
         upload_url: ${{github.event.release.upload_url}}
-        asset_name: ${{env.RELEASE_FILE}}
+        asset_name: ${{github.event.repository.name}}-${{github.event.release.tag_name}}-micropython-${{env.MICROPYTHON_VERSION}}.uf2
         asset_content_type: application/octet-stream


### PR DESCRIPTION
This change will require the MicroPython version to be manually bumped with a commit before building a new release of our firmware, but will ensure it's built against a known version of MicroPython.

The release filename now includes the MicroPython version.