### PR TITLE
Add breakout-garden SPI slot selection for ST7789 displays

### DIFF
--- a/drivers/st7789/st7789.cpp
+++ b/drivers/st7789/st7789.cpp
@@ -43,6 +43,7 @@ namespace pimoroni {
       pwm_set_wrap(pwm_gpio_to_slice_num(bl), 65535);
       pwm_init(pwm_gpio_to_slice_num(bl), &cfg, true);
       gpio_set_function(bl, GPIO_FUNC_PWM);
+      set_backlight(255); // Turn backlight on by default to avoid nasty surprises
     }
 
     // if auto_init_sequence then send initialisation sequence

--- a/drivers/st7789/st7789.hpp
+++ b/drivers/st7789/st7789.hpp
@@ -30,16 +30,35 @@ namespace pimoroni {
     // frame buffer where pixel data is stored
     uint16_t *frame_buffer;
 
+    enum BG_SPI_SLOT {
+      BG_SPI_FRONT,
+      BG_SPI_BACK
+    };
+
   public:
+    ST7789(uint16_t width, uint16_t height, uint16_t *frame_buffer, BG_SPI_SLOT slot) :
+      width(width), height(height), frame_buffer(frame_buffer) {
+      switch(slot) {
+        case BG_SPI_FRONT:
+          cs = 17;
+          bl = 20;
+          break;
+        case BG_SPI_BACK:
+          cs = 22;
+          bl = 21;
+          break;
+      }
+    }
+
     ST7789(uint16_t width, uint16_t height, uint16_t *frame_buffer) :
       width(width), height(height), frame_buffer(frame_buffer) {}
 
     ST7789(uint16_t width, uint16_t height, uint16_t *frame_buffer,
            spi_inst_t *spi,
-           uint8_t cs, uint8_t dc, uint8_t sck, uint8_t mosi, uint8_t miso = -1) :
+           uint8_t cs, uint8_t dc, uint8_t sck, uint8_t mosi, uint8_t miso = -1, uint8_t bl = -1) :
       spi(spi),
       width(width), height(height),      
-      cs(cs), dc(dc), sck(sck), mosi(mosi), miso(miso), frame_buffer(frame_buffer) {}
+      cs(cs), dc(dc), sck(sck), mosi(mosi), miso(miso), bl(bl), frame_buffer(frame_buffer) {}
 
     void init(bool auto_init_sequence = true, bool round = false);
 

--- a/examples/breakout_roundlcd/demo.cpp
+++ b/examples/breakout_roundlcd/demo.cpp
@@ -12,7 +12,7 @@ using namespace pimoroni;
 
 
 uint16_t buffer[BreakoutRoundLCD::WIDTH * BreakoutRoundLCD::HEIGHT];
-BreakoutRoundLCD display(buffer);
+BreakoutRoundLCD display(buffer, ST7789::BG_SPI_FRONT);
 
 constexpr float RADIUS = BreakoutRoundLCD::WIDTH / 2;
 
@@ -40,6 +40,7 @@ Pen from_hsv(float h, float s, float v) {
 
 int main() {
     display.init();
+    display.set_backlight(255);
 
     uint32_t steps = 70;
     float angle_step = 0.5f;
@@ -71,5 +72,6 @@ int main() {
         }
 
         display.update();
+        sleep_ms(10);
     }
 }

--- a/libraries/breakout_roundlcd/breakout_roundlcd.cpp
+++ b/libraries/breakout_roundlcd/breakout_roundlcd.cpp
@@ -8,8 +8,12 @@ namespace pimoroni {
   }
 
   BreakoutRoundLCD::BreakoutRoundLCD(uint16_t *buf,  spi_inst_t *spi,
-      uint8_t cs, uint8_t dc, uint8_t sck, uint8_t mosi, uint8_t miso)
-    : PicoGraphics(WIDTH, HEIGHT, buf), screen(WIDTH, HEIGHT, buf, spi, cs, dc, sck, mosi, miso)  {
+      uint8_t cs, uint8_t dc, uint8_t sck, uint8_t mosi, uint8_t miso, uint8_t bl)
+    : PicoGraphics(WIDTH, HEIGHT, buf), screen(WIDTH, HEIGHT, buf, spi, cs, dc, sck, mosi, miso, bl)  {
+    __fb = buf;
+  }
+
+  BreakoutRoundLCD::BreakoutRoundLCD(uint16_t *buf,  ST7789::BG_SPI_SLOT slot) : PicoGraphics(WIDTH, HEIGHT, buf), screen(WIDTH, HEIGHT, buf, slot) {
     __fb = buf;
   }
 

--- a/libraries/breakout_roundlcd/breakout_roundlcd.hpp
+++ b/libraries/breakout_roundlcd/breakout_roundlcd.hpp
@@ -12,7 +12,6 @@ namespace pimoroni {
   public:
     static const int WIDTH = 240;
     static const int HEIGHT = 240;
-    static const uint8_t PIN_UNUSED   = UINT8_MAX;
 
 
     //--------------------------------------------------
@@ -30,7 +29,8 @@ namespace pimoroni {
   public:
     BreakoutRoundLCD(uint16_t *buf);
     BreakoutRoundLCD(uint16_t *buf,  spi_inst_t *spi,
-      uint8_t cs, uint8_t dc, uint8_t sck, uint8_t mosi, uint8_t miso = PIN_UNUSED);
+      uint8_t cs, uint8_t dc, uint8_t sck, uint8_t mosi, uint8_t miso = -1, uint8_t bl = -1);
+    BreakoutRoundLCD(uint16_t *buf,  ST7789::BG_SPI_SLOT slot);
     
 
     //--------------------------------------------------


### PR DESCRIPTION
A new constructor has been added which accepts a enum type BG_SPI_SLOT which can be either:

`ST7789::BG_SPI_FRONT` or `ST7789::BG_SPI_BACK`.

This selects the correct CS/BL pins for the respective breakout-garden SPI slot.

Note: the pin designations do not appear to match the BG schematic, but they work!?

This is not a fix for #124 but was for the complexities I observed while looking into it. Took me half an hour to get the darn LCD working even knowing I'd done it before!

Probably needs adding for regular square, too? Not sure how that's all structured.