### PR TITLE
Ensure MicroPython CI breaks with invalid paths

### DIFF
--- a/.github/workflows/micropython.yml
+++ b/.github/workflows/micropython.yml
@@ -39,7 +39,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: true
-        path: pimoroni-pico
+        path: pimoroni-pico-${{ github.sha }}
 
     # Linux deps
     - name: Install deps
@@ -65,7 +65,7 @@ jobs:
     - name: Build MicroPython
       shell: bash
       working-directory: micropython/ports/rp2
-      run: make USER_C_MODULES=../../../pimoroni-pico/micropython/modules/micropython.cmake -j2
+      run: make USER_C_MODULES=../../../pimoroni-pico-${GITHUB_SHA}/micropython/modules/micropython.cmake -j2
 
     - name: Upload .uf2
       if: github.event_name == 'release'

--- a/micropython/modules/breakout_colourlcd160x80/breakout_colourlcd160x80.cpp
+++ b/micropython/modules/breakout_colourlcd160x80/breakout_colourlcd160x80.cpp
@@ -1,4 +1,4 @@
-#include "../../../pimoroni-pico/libraries/breakout_colourlcd160x80/breakout_colourlcd160x80.hpp"
+#include "../../../libraries/breakout_colourlcd160x80/breakout_colourlcd160x80.hpp"
 
 #define MP_OBJ_TO_PTR2(o, t) ((t *)(uintptr_t)(o))
 

--- a/micropython/modules/breakout_colourlcd240x240/breakout_colourlcd240x240.cpp
+++ b/micropython/modules/breakout_colourlcd240x240/breakout_colourlcd240x240.cpp
@@ -1,4 +1,4 @@
-#include "../../../pimoroni-pico/libraries/breakout_colourlcd240x240/breakout_colourlcd240x240.hpp"
+#include "../../../libraries/breakout_colourlcd240x240/breakout_colourlcd240x240.hpp"
 
 #define MP_OBJ_TO_PTR2(o, t) ((t *)(uintptr_t)(o))
 

--- a/micropython/modules/breakout_trackball/breakout_trackball.cpp
+++ b/micropython/modules/breakout_trackball/breakout_trackball.cpp
@@ -1,4 +1,4 @@
-#include "../../../pimoroni-pico/libraries/breakout_trackball/breakout_trackball.hpp"
+#include "../../../libraries/breakout_trackball/breakout_trackball.hpp"
 
 #define MP_OBJ_TO_PTR2(o, t) ((t *)(uintptr_t)(o))
 


### PR DESCRIPTION
Deliberately renames the pimoroni-pico directory so that paths which reference it will break with a compilation error.

This ensures a micropython build works robustly if a user renames/moves the pimoroni-pico directory relative to micropython.