### PR TITLE
Remove relative include paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,10 @@ function(add_resource target file)
   target_sources(${ARGV0} PRIVATE ${NAME}.o)
 endfunction(add_resource)
 
+include_directories(
+  ${CMAKE_CURRENT_LIST_DIR}
+)
+
 add_subdirectory(drivers)
 add_subdirectory(libraries)
 

--- a/libraries/breakout_as7262/breakout_as7262.hpp
+++ b/libraries/breakout_as7262/breakout_as7262.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "../../drivers/as7262/as7262.hpp"
+#include "drivers/as7262/as7262.hpp"
 
 namespace pimoroni {
 

--- a/libraries/breakout_colourlcd160x80/breakout_colourlcd160x80.hpp
+++ b/libraries/breakout_colourlcd160x80/breakout_colourlcd160x80.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "../../drivers/st7735/st7735.hpp"
-#include "../../libraries/pico_graphics/pico_graphics.hpp"
+#include "drivers/st7735/st7735.hpp"
+#include "libraries/pico_graphics/pico_graphics.hpp"
 
 namespace pimoroni {
 

--- a/libraries/breakout_colourlcd240x240/breakout_colourlcd240x240.hpp
+++ b/libraries/breakout_colourlcd240x240/breakout_colourlcd240x240.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "../../drivers/st7789/st7789.hpp"
-#include "../../libraries/pico_graphics/pico_graphics.hpp"
+#include "drivers/st7789/st7789.hpp"
+#include "libraries/pico_graphics/pico_graphics.hpp"
 
 namespace pimoroni {
 

--- a/libraries/breakout_dotmatrix/breakout_dotmatrix.hpp
+++ b/libraries/breakout_dotmatrix/breakout_dotmatrix.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "../../drivers/ltp305/ltp305.hpp"
+#include "drivers/ltp305/ltp305.hpp"
 
 namespace pimoroni {
 

--- a/libraries/breakout_ltr559/breakout_ltr559.hpp
+++ b/libraries/breakout_ltr559/breakout_ltr559.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "../../drivers/ltr559/ltr559.hpp"
+#include "drivers/ltr559/ltr559.hpp"
 
 namespace pimoroni {
 

--- a/libraries/breakout_matrix11x7/breakout_matrix11x7.hpp
+++ b/libraries/breakout_matrix11x7/breakout_matrix11x7.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "../../drivers/is31fl3731/is31fl3731.hpp"
+#include "drivers/is31fl3731/is31fl3731.hpp"
 
 namespace pimoroni {
     class BreakoutMatrix11x7 : public IS31FL3731 {

--- a/libraries/breakout_rgbmatrix5x5/breakout_rgbmatrix5x5.hpp
+++ b/libraries/breakout_rgbmatrix5x5/breakout_rgbmatrix5x5.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "../../drivers/is31fl3731/is31fl3731.hpp"
+#include "drivers/is31fl3731/is31fl3731.hpp"
 
 namespace pimoroni {
     struct RGBLookup {

--- a/libraries/breakout_roundlcd/breakout_roundlcd.hpp
+++ b/libraries/breakout_roundlcd/breakout_roundlcd.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "../../drivers/st7789/st7789.hpp"
-#include "../../libraries/pico_graphics/pico_graphics.hpp"
+#include "drivers/st7789/st7789.hpp"
+#include "libraries/pico_graphics/pico_graphics.hpp"
 
 namespace pimoroni {
 

--- a/libraries/breakout_sgp30/breakout_sgp30.hpp
+++ b/libraries/breakout_sgp30/breakout_sgp30.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "../../drivers/sgp30/sgp30.hpp"
+#include "drivers/sgp30/sgp30.hpp"
 
 namespace pimoroni {
 

--- a/libraries/breakout_trackball/breakout_trackball.hpp
+++ b/libraries/breakout_trackball/breakout_trackball.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "../../drivers/trackball/trackball.hpp"
+#include "drivers/trackball/trackball.hpp"
 
 namespace pimoroni {
 

--- a/libraries/pico_display/pico_display.hpp
+++ b/libraries/pico_display/pico_display.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "../../drivers/st7789/st7789.hpp"
-#include "../../libraries/pico_graphics/pico_graphics.hpp"
+#include "drivers/st7789/st7789.hpp"
+#include "libraries/pico_graphics/pico_graphics.hpp"
 
 namespace pimoroni {
 

--- a/libraries/pico_explorer/pico_explorer.hpp
+++ b/libraries/pico_explorer/pico_explorer.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "../../drivers/st7789/st7789.hpp"
-#include "../../libraries/pico_graphics/pico_graphics.hpp"
+#include "drivers/st7789/st7789.hpp"
+#include "libraries/pico_graphics/pico_graphics.hpp"
 
 namespace pimoroni {
 

--- a/libraries/pico_wireless/pico_wireless.cpp
+++ b/libraries/pico_wireless/pico_wireless.cpp
@@ -1,5 +1,5 @@
 #include "pico_wireless.hpp"
-#include "../../drivers/esp32spi/spi_drv.hpp"
+#include "drivers/esp32spi/spi_drv.hpp"
 
 namespace pimoroni {
 

--- a/libraries/pico_wireless/pico_wireless.hpp
+++ b/libraries/pico_wireless/pico_wireless.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "pico/stdlib.h"
-#include "../../drivers/esp32spi/esp32spi.hpp"
+#include "drivers/esp32spi/esp32spi.hpp"
 
 namespace pimoroni {
 

--- a/micropython/modules/breakout_as7262/breakout_as7262.cpp
+++ b/micropython/modules/breakout_as7262/breakout_as7262.cpp
@@ -1,4 +1,4 @@
-#include "../../../libraries/breakout_as7262/breakout_as7262.hpp"
+#include "libraries/breakout_as7262/breakout_as7262.hpp"
 
 #define MP_OBJ_TO_PTR2(o, t) ((t *)(uintptr_t)(o))
 

--- a/micropython/modules/breakout_colourlcd160x80/breakout_colourlcd160x80.cpp
+++ b/micropython/modules/breakout_colourlcd160x80/breakout_colourlcd160x80.cpp
@@ -1,4 +1,4 @@
-#include "../../../libraries/breakout_colourlcd160x80/breakout_colourlcd160x80.hpp"
+#include "libraries/breakout_colourlcd160x80/breakout_colourlcd160x80.hpp"
 
 #define MP_OBJ_TO_PTR2(o, t) ((t *)(uintptr_t)(o))
 

--- a/micropython/modules/breakout_colourlcd240x240/breakout_colourlcd240x240.cpp
+++ b/micropython/modules/breakout_colourlcd240x240/breakout_colourlcd240x240.cpp
@@ -1,4 +1,4 @@
-#include "../../../libraries/breakout_colourlcd240x240/breakout_colourlcd240x240.hpp"
+#include "libraries/breakout_colourlcd240x240/breakout_colourlcd240x240.hpp"
 
 #define MP_OBJ_TO_PTR2(o, t) ((t *)(uintptr_t)(o))
 

--- a/micropython/modules/breakout_dotmatrix/breakout_dotmatrix.cpp
+++ b/micropython/modules/breakout_dotmatrix/breakout_dotmatrix.cpp
@@ -1,4 +1,4 @@
-#include "../../../libraries/breakout_dotmatrix/breakout_dotmatrix.hpp"
+#include "libraries/breakout_dotmatrix/breakout_dotmatrix.hpp"
 
 #define MP_OBJ_TO_PTR2(o, t) ((t *)(uintptr_t)(o))
 

--- a/micropython/modules/breakout_ltr559/breakout_ltr559.cpp
+++ b/micropython/modules/breakout_ltr559/breakout_ltr559.cpp
@@ -1,4 +1,4 @@
-#include "../../../libraries/breakout_ltr559/breakout_ltr559.hpp"
+#include "libraries/breakout_ltr559/breakout_ltr559.hpp"
 
 #define MP_OBJ_TO_PTR2(o, t) ((t *)(uintptr_t)(o))
 

--- a/micropython/modules/breakout_matrix11x7/breakout_matrix11x7.cpp
+++ b/micropython/modules/breakout_matrix11x7/breakout_matrix11x7.cpp
@@ -1,4 +1,4 @@
-#include "../../../libraries/breakout_matrix11x7/breakout_matrix11x7.hpp"
+#include "libraries/breakout_matrix11x7/breakout_matrix11x7.hpp"
 
 #define MP_OBJ_TO_PTR2(o, t) ((t *)(uintptr_t)(o))
 

--- a/micropython/modules/breakout_rgbmatrix5x5/breakout_rgbmatrix5x5.cpp
+++ b/micropython/modules/breakout_rgbmatrix5x5/breakout_rgbmatrix5x5.cpp
@@ -1,4 +1,4 @@
-#include "../../../libraries/breakout_rgbmatrix5x5/breakout_rgbmatrix5x5.hpp"
+#include "libraries/breakout_rgbmatrix5x5/breakout_rgbmatrix5x5.hpp"
 
 #define MP_OBJ_TO_PTR2(o, t) ((t *)(uintptr_t)(o))
 

--- a/micropython/modules/breakout_roundlcd/breakout_roundlcd.cpp
+++ b/micropython/modules/breakout_roundlcd/breakout_roundlcd.cpp
@@ -1,4 +1,4 @@
-#include "../../../libraries/breakout_roundlcd/breakout_roundlcd.hpp"
+#include "libraries/breakout_roundlcd/breakout_roundlcd.hpp"
 
 #define MP_OBJ_TO_PTR2(o, t) ((t *)(uintptr_t)(o))
 

--- a/micropython/modules/breakout_sgp30/breakout_sgp30.cpp
+++ b/micropython/modules/breakout_sgp30/breakout_sgp30.cpp
@@ -1,4 +1,4 @@
-#include "../../../libraries/breakout_sgp30/breakout_sgp30.hpp"
+#include "libraries/breakout_sgp30/breakout_sgp30.hpp"
 
 #define MP_OBJ_TO_PTR2(o, t) ((t *)(uintptr_t)(o))
 

--- a/micropython/modules/breakout_trackball/breakout_trackball.cpp
+++ b/micropython/modules/breakout_trackball/breakout_trackball.cpp
@@ -1,4 +1,4 @@
-#include "../../../libraries/breakout_trackball/breakout_trackball.hpp"
+#include "libraries/breakout_trackball/breakout_trackball.hpp"
 
 #define MP_OBJ_TO_PTR2(o, t) ((t *)(uintptr_t)(o))
 

--- a/micropython/modules/micropython.cmake
+++ b/micropython/modules/micropython.cmake
@@ -1,3 +1,5 @@
+include_directories(${CMAKE_CURRENT_LIST_DIR}/../../)
+
 include(${CMAKE_CURRENT_LIST_DIR}/breakout_dotmatrix/micropython.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/breakout_ltr559/micropython.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/breakout_colourlcd160x80/micropython.cmake)

--- a/micropython/modules/pico_display/pico_display.cpp
+++ b/micropython/modules/pico_display/pico_display.cpp
@@ -2,7 +2,7 @@
 #include "hardware/sync.h"
 #include "pico/binary_info.h"
 
-#include "../../../libraries/pico_display/pico_display.hpp"
+#include "libraries/pico_display/pico_display.hpp"
 
 using namespace pimoroni;
 

--- a/micropython/modules/pico_explorer/pico_explorer.cpp
+++ b/micropython/modules/pico_explorer/pico_explorer.cpp
@@ -2,7 +2,7 @@
 #include "hardware/sync.h"
 #include "pico/binary_info.h"
 
-#include "../../../libraries/pico_explorer/pico_explorer.hpp"
+#include "libraries/pico_explorer/pico_explorer.hpp"
 
 using namespace pimoroni;
 

--- a/micropython/modules/pico_rgb_keypad/pico_rgb_keypad.cpp
+++ b/micropython/modules/pico_rgb_keypad/pico_rgb_keypad.cpp
@@ -2,7 +2,7 @@
 #include "hardware/sync.h"
 #include "pico/binary_info.h"
 
-#include "../../../libraries/pico_rgb_keypad/pico_rgb_keypad.hpp"
+#include "libraries/pico_rgb_keypad/pico_rgb_keypad.hpp"
 
 using namespace pimoroni;
 

--- a/micropython/modules/pico_scroll/pico_scroll.cpp
+++ b/micropython/modules/pico_scroll/pico_scroll.cpp
@@ -3,7 +3,7 @@
 #include "pico/binary_info.h"
 #include "pico/stdlib.h"
 
-#include "../../../libraries/pico_scroll/pico_scroll.hpp"
+#include "libraries/pico_scroll/pico_scroll.hpp"
 
 using namespace pimoroni;
 

--- a/micropython/modules/pico_unicorn/pico_unicorn.cpp
+++ b/micropython/modules/pico_unicorn/pico_unicorn.cpp
@@ -2,7 +2,7 @@
 #include "hardware/sync.h"
 #include "pico/binary_info.h"
 
-#include "../../../libraries/pico_unicorn/pico_unicorn.hpp"
+#include "libraries/pico_unicorn/pico_unicorn.hpp"
 
 using namespace pimoroni;
 

--- a/micropython/modules/pico_wireless/pico_wireless.cpp
+++ b/micropython/modules/pico_wireless/pico_wireless.cpp
@@ -2,7 +2,7 @@
 #include "hardware/sync.h"
 #include "pico/binary_info.h"
 
-#include "../../../libraries/pico_wireless/pico_wireless.hpp"
+#include "libraries/pico_wireless/pico_wireless.hpp"
 
 using namespace pimoroni;
 


### PR DESCRIPTION
This change removes file-relative include paths and adds the project root as a global include path.

* Project root added to CMakeLists.txt so that all targets can find includes
* Project root added micropython.cmake so that targets used by the MicroPython build can find includes

Note: pico-boilerplate projects must set this include path  (edit: unsure if this is true!)