### PR TITLE
Fix for keywords not working in MP class constructors, and added address printout for supported breakouts

### DIFF
--- a/drivers/ioexpander/ioexpander.cpp
+++ b/drivers/ioexpander/ioexpander.cpp
@@ -359,6 +359,10 @@ namespace pimoroni {
     return i2c;
   }
 
+  int IOExpander::get_address() const {
+    return address;
+  }
+
   int IOExpander::get_sda() const {
     return sda;
   }

--- a/drivers/ioexpander/ioexpander.hpp
+++ b/drivers/ioexpander/ioexpander.hpp
@@ -175,6 +175,7 @@ namespace pimoroni {
 
     // For print access in micropython
     i2c_inst_t* get_i2c() const;
+    int get_address() const;
     int get_sda() const;
     int get_scl() const;
     int get_int() const;

--- a/drivers/is31fl3731/is31fl3731.cpp
+++ b/drivers/is31fl3731/is31fl3731.cpp
@@ -78,6 +78,10 @@ namespace pimoroni {
     return i2c;
   }
 
+  int IS31FL3731::get_address() const {
+    return address;
+  }
+
   int IS31FL3731::get_sda() const {
     return sda;
   }

--- a/drivers/is31fl3731/is31fl3731.hpp
+++ b/drivers/is31fl3731/is31fl3731.hpp
@@ -53,6 +53,7 @@ namespace pimoroni {
     bool init();
 
     i2c_inst_t* get_i2c() const;
+    int get_address() const;
     int get_sda() const;
     int get_scl() const;
 

--- a/drivers/ltp305/ltp305.cpp
+++ b/drivers/ltp305/ltp305.cpp
@@ -20,6 +20,10 @@ namespace pimoroni {
     return i2c;
   }
 
+  int LTP305::get_address() const {
+    return address;
+  }
+
   int LTP305::get_sda() const {
     return sda;
   }

--- a/drivers/ltp305/ltp305.hpp
+++ b/drivers/ltp305/ltp305.hpp
@@ -102,6 +102,7 @@ namespace pimoroni {
     bool init();
 
     i2c_inst_t* get_i2c() const;
+    int get_address() const;
     int get_sda() const;
     int get_scl() const;
 

--- a/drivers/ltr559/ltr559.cpp
+++ b/drivers/ltr559/ltr559.cpp
@@ -75,6 +75,10 @@ namespace pimoroni {
     return i2c;
   }
 
+  int LTR559::get_address() const {
+    return address;
+  }
+
   int LTR559::get_sda() const {
     return sda;
   }

--- a/drivers/ltr559/ltr559.hpp
+++ b/drivers/ltr559/ltr559.hpp
@@ -165,6 +165,7 @@ namespace pimoroni {
     void reset();
 
     i2c_inst_t* get_i2c() const;
+    int get_address() const;
     int get_sda() const;
     int get_scl() const;
     int get_int() const;

--- a/drivers/msa301/msa301.cpp
+++ b/drivers/msa301/msa301.cpp
@@ -7,7 +7,7 @@
 
 namespace pimoroni {
 
-  void MSA301::init() {
+  bool MSA301::init() {
     i2c_init(i2c, 400000);
 
     gpio_set_function(sda, GPIO_FUNC_I2C); gpio_pull_up(sda);
@@ -23,6 +23,8 @@ namespace pimoroni {
 
     set_power_mode(PowerMode::NORMAL);
     set_range_and_resolution(Range::G_2, Resolution::BITS_14);
+
+    return true;
   }
 
   void MSA301::reset() {

--- a/drivers/msa301/msa301.hpp
+++ b/drivers/msa301/msa301.hpp
@@ -129,7 +129,7 @@ namespace pimoroni {
     // Methods
     //--------------------------------------------------
   public:
-    void init();
+    bool init();
     void reset();
 
     i2c_inst_t* get_i2c() const;

--- a/drivers/trackball/trackball.cpp
+++ b/drivers/trackball/trackball.cpp
@@ -68,6 +68,10 @@ namespace pimoroni {
     return i2c;
   }
 
+  int Trackball::get_address() const {
+    return address;
+  }
+
   int Trackball::get_sda() const {
     return sda;
   }

--- a/drivers/trackball/trackball.hpp
+++ b/drivers/trackball/trackball.hpp
@@ -71,6 +71,7 @@ namespace pimoroni {
     bool init();
 
     i2c_inst_t* get_i2c() const;
+    int get_address() const;
     int get_sda() const;
     int get_scl() const;
     int get_int() const;

--- a/libraries/breakout_encoder/breakout_encoder.cpp
+++ b/libraries/breakout_encoder/breakout_encoder.cpp
@@ -32,6 +32,10 @@ namespace pimoroni {
     return ioe.get_i2c();
   }
 
+  int BreakoutEncoder::get_address() const {
+    return ioe.get_address();
+  }
+
   int BreakoutEncoder::get_sda() const {
     return ioe.get_sda();
   }

--- a/libraries/breakout_encoder/breakout_encoder.hpp
+++ b/libraries/breakout_encoder/breakout_encoder.hpp
@@ -72,6 +72,7 @@ namespace pimoroni {
 
     // For print access in micropython
     i2c_inst_t* get_i2c() const;
+    int get_address() const;
     int get_sda() const;
     int get_scl() const;
     int get_int() const;

--- a/libraries/breakout_matrix11x7/breakout_matrix11x7.cpp
+++ b/libraries/breakout_matrix11x7/breakout_matrix11x7.cpp
@@ -1,19 +1,22 @@
 #include "breakout_matrix11x7.hpp"
 
 namespace pimoroni {
-    void BreakoutMatrix11x7::init() {
-        IS31FL3731::init();
-        enable({
-            0b01111111, 0b01111111,
-            0b01111111, 0b01111111,
-            0b01111111, 0b01111111,
-            0b01111111, 0b01111111,
-            0b01111111, 0b01111111,
-            0b01111111, 0b00000000,
-            0b00000000, 0b00000000,
-            0b00000000, 0b00000000,
-            0b00000000, 0b00000000,
-        }, 0);
+    bool BreakoutMatrix11x7::init() {
+        bool success = IS31FL3731::init();
+        if(success) {
+            enable({
+                0b01111111, 0b01111111,
+                0b01111111, 0b01111111,
+                0b01111111, 0b01111111,
+                0b01111111, 0b01111111,
+                0b01111111, 0b01111111,
+                0b01111111, 0b00000000,
+                0b00000000, 0b00000000,
+                0b00000000, 0b00000000,
+                0b00000000, 0b00000000,
+            }, 0);
+        }
+        return success;
     }
 
     uint8_t BreakoutMatrix11x7::lookup_pixel(uint8_t index) {

--- a/libraries/breakout_matrix11x7/breakout_matrix11x7.hpp
+++ b/libraries/breakout_matrix11x7/breakout_matrix11x7.hpp
@@ -10,7 +10,7 @@ namespace pimoroni {
         static constexpr int8_t DEFAULT_I2C_ADDRESS    = 0x75;
         static constexpr int8_t ALTERNATE_I2C_ADDRESS  = 0x77;
 
-        void init();
+        bool init();
 
         BreakoutMatrix11x7() : IS31FL3731(DEFAULT_I2C_ADDRESS)  {};
         BreakoutMatrix11x7(uint8_t address) : IS31FL3731(address) {};

--- a/libraries/breakout_mics6814/breakout_mics6814.cpp
+++ b/libraries/breakout_mics6814/breakout_mics6814.cpp
@@ -35,6 +35,10 @@ namespace pimoroni {
     return ioe.get_i2c();
   }
 
+  int BreakoutMICS6814::get_address() const {
+    return ioe.get_address();
+  }
+
   int BreakoutMICS6814::get_sda() const {
     return ioe.get_sda();
   }

--- a/libraries/breakout_mics6814/breakout_mics6814.hpp
+++ b/libraries/breakout_mics6814/breakout_mics6814.hpp
@@ -71,6 +71,7 @@ namespace pimoroni {
 
     // For print access in micropython
     i2c_inst_t* get_i2c() const;
+    int get_address() const;
     int get_sda() const;
     int get_scl() const;
     int get_int() const;

--- a/libraries/breakout_potentiometer/breakout_potentiometer.cpp
+++ b/libraries/breakout_potentiometer/breakout_potentiometer.cpp
@@ -42,6 +42,10 @@ namespace pimoroni {
     return ioe.get_i2c();
   }
 
+  int BreakoutPotentiometer::get_address() const {
+    return ioe.get_address();
+  }
+
   int BreakoutPotentiometer::get_sda() const {
     return ioe.get_sda();
   }

--- a/libraries/breakout_potentiometer/breakout_potentiometer.hpp
+++ b/libraries/breakout_potentiometer/breakout_potentiometer.hpp
@@ -69,6 +69,7 @@ namespace pimoroni {
 
     // For print access in micropython
     i2c_inst_t* get_i2c() const;
+    int get_address() const;
     int get_sda() const;
     int get_scl() const;
     int get_int() const;

--- a/libraries/breakout_rgbmatrix5x5/breakout_rgbmatrix5x5.cpp
+++ b/libraries/breakout_rgbmatrix5x5/breakout_rgbmatrix5x5.cpp
@@ -2,19 +2,22 @@
 
 namespace pimoroni {
 
-    void BreakoutRGBMatrix5x5::init() {
-        IS31FL3731::init();
-        enable({
-            0b00000000, 0b10111111,
-            0b00111110, 0b00111110,
-            0b00111111, 0b10111110,
-            0b00000111, 0b10000110,
-            0b00110000, 0b00110000,
-            0b00111111, 0b10111110,
-            0b00111111, 0b10111110,
-            0b01111111, 0b11111110,
-            0b01111111, 0b00000000
-        }, 0);
+    bool BreakoutRGBMatrix5x5::init() {
+        bool success = IS31FL3731::init();
+        if(success) {
+            enable({
+                0b00000000, 0b10111111,
+                0b00111110, 0b00111110,
+                0b00111111, 0b10111110,
+                0b00000111, 0b10000110,
+                0b00110000, 0b00110000,
+                0b00111111, 0b10111110,
+                0b00111111, 0b10111110,
+                0b01111111, 0b11111110,
+                0b01111111, 0b00000000
+            }, 0);
+        }
+        return success;
     }
 
     RGBLookup BreakoutRGBMatrix5x5::lookup_pixel(uint8_t index) {

--- a/libraries/breakout_rgbmatrix5x5/breakout_rgbmatrix5x5.hpp
+++ b/libraries/breakout_rgbmatrix5x5/breakout_rgbmatrix5x5.hpp
@@ -16,7 +16,7 @@ namespace pimoroni {
         static constexpr int8_t DEFAULT_I2C_ADDRESS    = 0x74;
         static constexpr int8_t ALTERNATE_I2C_ADDRESS  = 0x77;
 
-        void init();
+        bool init();
         void set_pixel(uint8_t x, uint8_t y, uint8_t r, uint8_t g, uint8_t b);
   
         BreakoutRGBMatrix5x5() : IS31FL3731(DEFAULT_I2C_ADDRESS)  {};

--- a/micropython/modules/breakout_as7262/breakout_as7262.cpp
+++ b/micropython/modules/breakout_as7262/breakout_as7262.cpp
@@ -44,7 +44,7 @@ void BreakoutAS7262_print(const mp_print_t *print, mp_obj_t self_in, mp_print_ki
 mp_obj_t BreakoutAS7262_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     breakout_as7262_BreakoutAS7262_obj_t *self = nullptr;
 
-    if(n_args == 0) {
+    if(n_args + n_kw == 0) {
         mp_arg_check_num(n_args, n_kw, 0, 0, true);
         self = m_new_obj(breakout_as7262_BreakoutAS7262_obj_t);
         self->base.type = &breakout_as7262_BreakoutAS7262_type;
@@ -257,7 +257,7 @@ mp_obj_t BreakoutAS7262_set_leds(size_t n_args, const mp_obj_t *pos_args, mp_map
 
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
-    
+
     breakout_as7262_BreakoutAS7262_obj_t *self = MP_OBJ_TO_PTR2(args[ARG_self].u_obj, breakout_as7262_BreakoutAS7262_obj_t);
     self->breakout->set_leds(args[ARG_illumination].u_bool, args[ARG_indicator].u_bool);
 

--- a/micropython/modules/breakout_as7262/breakout_as7262.cpp
+++ b/micropython/modules/breakout_as7262/breakout_as7262.cpp
@@ -44,49 +44,47 @@ void BreakoutAS7262_print(const mp_print_t *print, mp_obj_t self_in, mp_print_ki
 mp_obj_t BreakoutAS7262_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     breakout_as7262_BreakoutAS7262_obj_t *self = nullptr;
 
-    if(n_args + n_kw == 0) {
-        mp_arg_check_num(n_args, n_kw, 0, 0, true);
-        self = m_new_obj(breakout_as7262_BreakoutAS7262_obj_t);
-        self->base.type = &breakout_as7262_BreakoutAS7262_type;
-        self->breakout = new BreakoutAS7262();
+    enum { ARG_i2c, ARG_sda, ARG_scl, ARG_int };
+    static const mp_arg_t allowed_args[] = {
+        { MP_QSTR_i2c, MP_ARG_INT, {.u_int = -1} },
+        { MP_QSTR_sda, MP_ARG_INT, {.u_int = 20} },
+        { MP_QSTR_scl, MP_ARG_INT, {.u_int = 21} },
+        { MP_QSTR_interrupt, MP_ARG_INT, {.u_int = BreakoutAS7262::PIN_UNUSED} },
+    };
+
+    // Parse args.
+    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+
+    // Get I2C bus.
+    int i2c_id = args[ARG_i2c].u_int;
+    int sda = args[ARG_sda].u_int;
+    int scl = args[ARG_scl].u_int;
+
+    if(i2c_id == -1) {
+        i2c_id = sda & 1;
     }
-    else {
-        enum { ARG_i2c, ARG_sda, ARG_scl, ARG_int };
-        static const mp_arg_t allowed_args[] = {
-            { MP_QSTR_i2c, MP_ARG_REQUIRED | MP_ARG_INT },
-            { MP_QSTR_sda, MP_ARG_REQUIRED | MP_ARG_INT },
-            { MP_QSTR_scl, MP_ARG_REQUIRED | MP_ARG_INT },
-            { MP_QSTR_int, MP_ARG_INT, {.u_int = BreakoutAS7262::PIN_UNUSED} },
-        };
-
-        // Parse args.
-        mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
-        mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
-
-        // Get I2C bus.
-        int i2c_id = args[ARG_i2c].u_int;
-        if(i2c_id < 0 || i2c_id > 1) {
-            mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("I2C(%d) doesn't exist"), i2c_id);
-        }
-
-        int sda = args[ARG_sda].u_int;
-        if(!IS_VALID_SDA(i2c_id, sda)) {
-            mp_raise_ValueError(MP_ERROR_TEXT("bad SDA pin"));
-        }
-
-        int scl = args[ARG_scl].u_int;
-        if(!IS_VALID_SCL(i2c_id, scl)) {
-            mp_raise_ValueError(MP_ERROR_TEXT("bad SCL pin"));
-        }
-
-        self = m_new_obj(breakout_as7262_BreakoutAS7262_obj_t);
-        self->base.type = &breakout_as7262_BreakoutAS7262_type;
-        
-        i2c_inst_t *i2c = (i2c_id == 0) ? i2c0 : i2c1;
-        self->breakout = new BreakoutAS7262(i2c, sda, scl, args[ARG_int].u_int);
+    if(i2c_id < 0 || i2c_id > 1) {
+        mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("I2C(%d) doesn't exist"), i2c_id);
     }
 
-    self->breakout->init();
+    if(!IS_VALID_SDA(i2c_id, sda)) {
+        mp_raise_ValueError(MP_ERROR_TEXT("bad SDA pin"));
+    }
+
+    if(!IS_VALID_SCL(i2c_id, scl)) {
+        mp_raise_ValueError(MP_ERROR_TEXT("bad SCL pin"));
+    }
+
+    self = m_new_obj(breakout_as7262_BreakoutAS7262_obj_t);
+    self->base.type = &breakout_as7262_BreakoutAS7262_type;
+
+    i2c_inst_t *i2c = (i2c_id == 0) ? i2c0 : i2c1;
+    self->breakout = new BreakoutAS7262(i2c, sda, scl, args[ARG_int].u_int);
+
+    if(!self->breakout->init()) {
+        mp_raise_msg(&mp_type_RuntimeError, "AS7262 breakout not found when initialising");
+    }
 
     return MP_OBJ_FROM_PTR(self);
 }

--- a/micropython/modules/breakout_as7262/breakout_as7262.cpp
+++ b/micropython/modules/breakout_as7262/breakout_as7262.cpp
@@ -62,7 +62,7 @@ mp_obj_t BreakoutAS7262_make_new(const mp_obj_type_t *type, size_t n_args, size_
     int scl = args[ARG_scl].u_int;
 
     if(i2c_id == -1) {
-        i2c_id = sda & 1;
+        i2c_id = (sda >> 1) & 0b1;  // If no i2c specified, choose the one for the given SDA pin
     }
     if(i2c_id < 0 || i2c_id > 1) {
         mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("I2C(%d) doesn't exist"), i2c_id);

--- a/micropython/modules/breakout_colourlcd160x80/breakout_colourlcd160x80.cpp
+++ b/micropython/modules/breakout_colourlcd160x80/breakout_colourlcd160x80.cpp
@@ -51,7 +51,7 @@ void BreakoutColourLCD160x80_print(const mp_print_t *print, mp_obj_t self_in, mp
 mp_obj_t BreakoutColourLCD160x80_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     breakout_colourlcd160x80_BreakoutColourLCD160x80_obj_t *self = nullptr;
 
-    if(n_args <= 1) {
+    if(n_args + n_kw <= 1) {
         enum { ARG_buffer };
         static const mp_arg_t allowed_args[] = {
             { MP_QSTR_buffer, MP_ARG_REQUIRED | MP_ARG_OBJ },
@@ -69,7 +69,7 @@ mp_obj_t BreakoutColourLCD160x80_make_new(const mp_obj_type_t *type, size_t n_ar
 
         self->breakout = new BreakoutColourLCD160x80((uint16_t *)bufinfo.buf);
     }
-    else if(n_args == 2) {
+    else if(n_args + n_kw == 2) {
         enum { ARG_buffer, ARG_slot };
         static const mp_arg_t allowed_args[] = {
             { MP_QSTR_buffer, MP_ARG_REQUIRED | MP_ARG_OBJ },

--- a/micropython/modules/breakout_colourlcd240x240/breakout_colourlcd240x240.cpp
+++ b/micropython/modules/breakout_colourlcd240x240/breakout_colourlcd240x240.cpp
@@ -51,7 +51,7 @@ void BreakoutColourLCD240x240_print(const mp_print_t *print, mp_obj_t self_in, m
 mp_obj_t BreakoutColourLCD240x240_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     breakout_colourlcd240x240_BreakoutColourLCD240x240_obj_t *self = nullptr;
 
-    if(n_args <= 1) {
+    if(n_args + n_kw <= 1) {
         enum { ARG_buffer };
         static const mp_arg_t allowed_args[] = {
             { MP_QSTR_buffer, MP_ARG_REQUIRED | MP_ARG_OBJ },
@@ -69,7 +69,7 @@ mp_obj_t BreakoutColourLCD240x240_make_new(const mp_obj_type_t *type, size_t n_a
 
         self->breakout = new BreakoutColourLCD240x240((uint16_t *)bufinfo.buf);     
     }
-    else if(n_args == 2) {
+    else if(n_args + n_kw == 2) {
         enum { ARG_buffer, ARG_slot };
         static const mp_arg_t allowed_args[] = {
             { MP_QSTR_buffer, MP_ARG_REQUIRED | MP_ARG_OBJ },

--- a/micropython/modules/breakout_dotmatrix/breakout_dotmatrix.cpp
+++ b/micropython/modules/breakout_dotmatrix/breakout_dotmatrix.cpp
@@ -41,13 +41,13 @@ void BreakoutDotMatrix_print(const mp_print_t *print, mp_obj_t self_in, mp_print
 mp_obj_t BreakoutDotMatrix_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     breakout_dotmatrix_BreakoutDotMatrix_obj_t *self = nullptr;
 
-    if(n_args == 0) {
+    if(n_args + n_kw == 0) {
         mp_arg_check_num(n_args, n_kw, 0, 0, true);
         self = m_new_obj(breakout_dotmatrix_BreakoutDotMatrix_obj_t);
         self->base.type = &breakout_dotmatrix_BreakoutDotMatrix_type;
         self->breakout = new BreakoutDotMatrix();
     }
-    else if(n_args == 1) {
+    else if(n_args + n_kw == 1) {
         enum { ARG_address };
         static const mp_arg_t allowed_args[] = {
             { MP_QSTR_address, MP_ARG_REQUIRED | MP_ARG_INT },
@@ -113,7 +113,7 @@ mp_obj_t BreakoutDotMatrix_set_brightness(size_t n_args, const mp_obj_t *pos_arg
 
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
-    
+
     breakout_dotmatrix_BreakoutDotMatrix_obj_t *self = MP_OBJ_TO_PTR2(args[ARG_self].u_obj, breakout_dotmatrix_BreakoutDotMatrix_obj_t);
 
     float brightness = mp_obj_get_float(args[ARG_brightness].u_obj);
@@ -135,7 +135,7 @@ mp_obj_t BreakoutDotMatrix_set_decimal(size_t n_args, const mp_obj_t *pos_args, 
 
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
-    
+
     breakout_dotmatrix_BreakoutDotMatrix_obj_t *self = MP_OBJ_TO_PTR2(args[ARG_self].u_obj, breakout_dotmatrix_BreakoutDotMatrix_obj_t);
     self->breakout->set_decimal(args[ARG_left].u_bool, args[ARG_right].u_bool);
 
@@ -158,7 +158,7 @@ mp_obj_t BreakoutDotMatrix_set_pixel(size_t n_args, const mp_obj_t *pos_args, mp
 
     int x = args[ARG_x].u_int;
     int y = args[ARG_y].u_int;
-    
+
     if(x < 0 || x >= BreakoutDotMatrix::WIDTH || y < 0 || y >= BreakoutDotMatrix::HEIGHT)
         mp_raise_ValueError("x or y out of range.");
     else
@@ -177,7 +177,7 @@ mp_obj_t BreakoutDotMatrix_set_character(size_t n_args, const mp_obj_t *pos_args
 
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
-    
+
     breakout_dotmatrix_BreakoutDotMatrix_obj_t *self = MP_OBJ_TO_PTR2(args[ARG_self].u_obj, breakout_dotmatrix_BreakoutDotMatrix_obj_t);
 
     int x = args[ARG_x].u_int;

--- a/micropython/modules/breakout_dotmatrix/breakout_dotmatrix.cpp
+++ b/micropython/modules/breakout_dotmatrix/breakout_dotmatrix.cpp
@@ -1,4 +1,5 @@
 #include "libraries/breakout_dotmatrix/breakout_dotmatrix.hpp"
+#include <cstdio>
 
 #define MP_OBJ_TO_PTR2(o, t) ((t *)(uintptr_t)(o))
 
@@ -27,6 +28,11 @@ void BreakoutDotMatrix_print(const mp_print_t *print, mp_obj_t self_in, mp_print
 
     mp_print_str(print, "i2c = ");
     mp_obj_print_helper(print, mp_obj_new_int((breakout->get_i2c() == i2c0) ? 0 : 1), PRINT_REPR);
+
+    mp_print_str(print, ", address = 0x");
+    char buf[3];
+    sprintf(buf, "%02X", breakout->get_address());
+    mp_print_str(print, buf);
 
     mp_print_str(print, ", sda = ");
     mp_obj_print_helper(print, mp_obj_new_int(breakout->get_sda()), PRINT_REPR);

--- a/micropython/modules/breakout_dotmatrix/breakout_dotmatrix.cpp
+++ b/micropython/modules/breakout_dotmatrix/breakout_dotmatrix.cpp
@@ -65,7 +65,7 @@ mp_obj_t BreakoutDotMatrix_make_new(const mp_obj_type_t *type, size_t n_args, si
     int scl = args[ARG_scl].u_int;
 
     if(i2c_id == -1) {
-        i2c_id = sda & 1;
+        i2c_id = (sda >> 1) & 0b1;  // If no i2c specified, choose the one for the given SDA pin
     }
     if(i2c_id < 0 || i2c_id > 1) {
         mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("I2C(%d) doesn't exist"), i2c_id);

--- a/micropython/modules/breakout_dotmatrix/breakout_dotmatrix.cpp
+++ b/micropython/modules/breakout_dotmatrix/breakout_dotmatrix.cpp
@@ -47,64 +47,47 @@ void BreakoutDotMatrix_print(const mp_print_t *print, mp_obj_t self_in, mp_print
 mp_obj_t BreakoutDotMatrix_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     breakout_dotmatrix_BreakoutDotMatrix_obj_t *self = nullptr;
 
-    if(n_args + n_kw == 0) {
-        mp_arg_check_num(n_args, n_kw, 0, 0, true);
-        self = m_new_obj(breakout_dotmatrix_BreakoutDotMatrix_obj_t);
-        self->base.type = &breakout_dotmatrix_BreakoutDotMatrix_type;
-        self->breakout = new BreakoutDotMatrix();
+    enum { ARG_i2c, ARG_address, ARG_sda, ARG_scl };
+    static const mp_arg_t allowed_args[] = {
+        { MP_QSTR_i2c, MP_ARG_INT, {.u_int = -1} },
+        { MP_QSTR_address, MP_ARG_INT, {.u_int = BreakoutDotMatrix::DEFAULT_I2C_ADDRESS} },
+        { MP_QSTR_sda, MP_ARG_INT, {.u_int = 20} },
+        { MP_QSTR_scl, MP_ARG_INT, {.u_int = 21} },
+    };
+
+    // Parse args.
+    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+
+    // Get I2C bus.
+    int i2c_id = args[ARG_i2c].u_int;
+    int sda = args[ARG_sda].u_int;
+    int scl = args[ARG_scl].u_int;
+
+    if(i2c_id == -1) {
+        i2c_id = sda & 1;
     }
-    else if(n_args + n_kw == 1) {
-        enum { ARG_address };
-        static const mp_arg_t allowed_args[] = {
-            { MP_QSTR_address, MP_ARG_REQUIRED | MP_ARG_INT },
-        };
-
-        // Parse args.
-        mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
-        mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
-
-        self = m_new_obj(breakout_dotmatrix_BreakoutDotMatrix_obj_t);
-        self->base.type = &breakout_dotmatrix_BreakoutDotMatrix_type;
-        
-        self->breakout = new BreakoutDotMatrix(args[ARG_address].u_int);
-    }
-    else {
-        enum { ARG_i2c, ARG_address, ARG_sda, ARG_scl };
-        static const mp_arg_t allowed_args[] = {
-            { MP_QSTR_i2c, MP_ARG_REQUIRED | MP_ARG_INT },
-            { MP_QSTR_address, MP_ARG_REQUIRED | MP_ARG_INT },
-            { MP_QSTR_sda, MP_ARG_REQUIRED | MP_ARG_INT },
-            { MP_QSTR_scl, MP_ARG_REQUIRED | MP_ARG_INT },
-        };
-
-        // Parse args.
-        mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
-        mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
-
-        // Get I2C bus.
-        int i2c_id = args[ARG_i2c].u_int;
-        if(i2c_id < 0 || i2c_id > 1) {
-            mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("I2C(%d) doesn't exist"), i2c_id);
-        }
-
-        int sda = args[ARG_sda].u_int;
-        if (!IS_VALID_SDA(i2c_id, sda)) {
-            mp_raise_ValueError(MP_ERROR_TEXT("bad SDA pin"));
-        }
-
-        int scl = args[ARG_scl].u_int;
-        if (!IS_VALID_SCL(i2c_id, scl)) {
-            mp_raise_ValueError(MP_ERROR_TEXT("bad SCL pin"));
-        }
-
-        self = m_new_obj(breakout_dotmatrix_BreakoutDotMatrix_obj_t);
-        self->base.type = &breakout_dotmatrix_BreakoutDotMatrix_type;
-        
-        i2c_inst_t *i2c = (i2c_id == 0) ? i2c0 : i2c1;
-        self->breakout = new BreakoutDotMatrix(i2c, args[ARG_address].u_int, sda, scl);
+    if(i2c_id < 0 || i2c_id > 1) {
+        mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("I2C(%d) doesn't exist"), i2c_id);
     }
 
-    self->breakout->init();
+    if(!IS_VALID_SDA(i2c_id, sda)) {
+        mp_raise_ValueError(MP_ERROR_TEXT("bad SDA pin"));
+    }
+
+    if(!IS_VALID_SCL(i2c_id, scl)) {
+        mp_raise_ValueError(MP_ERROR_TEXT("bad SCL pin"));
+    }
+
+    self = m_new_obj(breakout_dotmatrix_BreakoutDotMatrix_obj_t);
+    self->base.type = &breakout_dotmatrix_BreakoutDotMatrix_type;
+    
+    i2c_inst_t *i2c = (i2c_id == 0) ? i2c0 : i2c1;
+    self->breakout = new BreakoutDotMatrix(i2c, args[ARG_address].u_int, sda, scl);
+
+    if(!self->breakout->init()) {
+        mp_raise_msg(&mp_type_RuntimeError, "DotMatrix breakout not found when initialising");
+    }
 
     return MP_OBJ_FROM_PTR(self);
 }

--- a/micropython/modules/breakout_encoder/breakout_encoder.cpp
+++ b/micropython/modules/breakout_encoder/breakout_encoder.cpp
@@ -44,13 +44,13 @@ void BreakoutEncoder_print(const mp_print_t *print, mp_obj_t self_in, mp_print_k
 mp_obj_t BreakoutEncoder_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     breakout_encoder_BreakoutEncoder_obj_t *self = nullptr;
 
-    if(n_args == 0) {
+    if(n_args + n_kw == 0) {
         mp_arg_check_num(n_args, n_kw, 0, 0, true);
         self = m_new_obj(breakout_encoder_BreakoutEncoder_obj_t);
         self->base.type = &breakout_encoder_BreakoutEncoder_type;
         self->breakout = new BreakoutEncoder();
     }
-    else if(n_args == 1) {
+    else if(n_args + n_kw == 1) {
         enum { ARG_address };
         static const mp_arg_t allowed_args[] = {
             { MP_QSTR_address, MP_ARG_REQUIRED | MP_ARG_INT },

--- a/micropython/modules/breakout_encoder/breakout_encoder.cpp
+++ b/micropython/modules/breakout_encoder/breakout_encoder.cpp
@@ -69,7 +69,7 @@ mp_obj_t BreakoutEncoder_make_new(const mp_obj_type_t *type, size_t n_args, size
     int scl = args[ARG_scl].u_int;
 
     if(i2c_id == -1) {
-        i2c_id = sda & 1;
+        i2c_id = (sda >> 1) & 0b1;  // If no i2c specified, choose the one for the given SDA pin
     }
     if(i2c_id < 0 || i2c_id > 1) {
         mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("I2C(%d) doesn't exist"), i2c_id);

--- a/micropython/modules/breakout_encoder/breakout_encoder.cpp
+++ b/micropython/modules/breakout_encoder/breakout_encoder.cpp
@@ -50,63 +50,44 @@ void BreakoutEncoder_print(const mp_print_t *print, mp_obj_t self_in, mp_print_k
 mp_obj_t BreakoutEncoder_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     breakout_encoder_BreakoutEncoder_obj_t *self = nullptr;
 
-    if(n_args + n_kw == 0) {
-        mp_arg_check_num(n_args, n_kw, 0, 0, true);
-        self = m_new_obj(breakout_encoder_BreakoutEncoder_obj_t);
-        self->base.type = &breakout_encoder_BreakoutEncoder_type;
-        self->breakout = new BreakoutEncoder();
+    enum { ARG_i2c, ARG_address, ARG_sda, ARG_scl, ARG_interrupt };
+    static const mp_arg_t allowed_args[] = {
+        { MP_QSTR_i2c, MP_ARG_INT, {.u_int = -1} },
+        { MP_QSTR_address, MP_ARG_INT, {.u_int = BreakoutEncoder::DEFAULT_I2C_ADDRESS} },
+        { MP_QSTR_sda, MP_ARG_INT, {.u_int = 20} },
+        { MP_QSTR_scl, MP_ARG_INT, {.u_int = 21} },
+        { MP_QSTR_interrupt, MP_ARG_INT, {.u_int = BreakoutEncoder::PIN_UNUSED} },
+    };
+
+    // Parse args.
+    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+
+    // Get I2C bus.
+    int i2c_id = args[ARG_i2c].u_int;
+    int sda = args[ARG_sda].u_int;
+    int scl = args[ARG_scl].u_int;
+
+    if(i2c_id == -1) {
+        i2c_id = sda & 1;
     }
-    else if(n_args + n_kw == 1) {
-        enum { ARG_address };
-        static const mp_arg_t allowed_args[] = {
-            { MP_QSTR_address, MP_ARG_REQUIRED | MP_ARG_INT },
-        };
-
-        // Parse args.
-        mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
-        mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
-
-        self = m_new_obj(breakout_encoder_BreakoutEncoder_obj_t);
-        self->base.type = &breakout_encoder_BreakoutEncoder_type;
-
-        self->breakout = new BreakoutEncoder(args[ARG_address].u_int);
+    if(i2c_id < 0 || i2c_id > 1) {
+        mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("I2C(%d) doesn't exist"), i2c_id);
     }
-    else {
-        enum { ARG_i2c, ARG_address, ARG_sda, ARG_scl, ARG_interrupt };
-        static const mp_arg_t allowed_args[] = {
-            { MP_QSTR_i2c, MP_ARG_REQUIRED | MP_ARG_INT },
-            { MP_QSTR_address, MP_ARG_REQUIRED | MP_ARG_INT },
-            { MP_QSTR_sda, MP_ARG_REQUIRED | MP_ARG_INT },
-            { MP_QSTR_scl, MP_ARG_REQUIRED | MP_ARG_INT },
-            { MP_QSTR_interrupt, MP_ARG_INT, {.u_int = BreakoutEncoder::PIN_UNUSED} },
-        };
 
-        // Parse args.
-        mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
-        mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
-
-        // Get I2C bus.
-        int i2c_id = args[ARG_i2c].u_int;
-        if(i2c_id < 0 || i2c_id > 1) {
-            mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("I2C(%d) doesn't exist"), i2c_id);
-        }
-
-        int sda = args[ARG_sda].u_int;
-        if (!IS_VALID_SDA(i2c_id, sda)) {
-            mp_raise_ValueError(MP_ERROR_TEXT("bad SDA pin"));
-        }
-
-        int scl = args[ARG_scl].u_int;
-        if (!IS_VALID_SCL(i2c_id, scl)) {
-            mp_raise_ValueError(MP_ERROR_TEXT("bad SCL pin"));
-        }
-
-        self = m_new_obj(breakout_encoder_BreakoutEncoder_obj_t);
-        self->base.type = &breakout_encoder_BreakoutEncoder_type;
-
-        i2c_inst_t *i2c = (i2c_id == 0) ? i2c0 : i2c1;
-        self->breakout = new BreakoutEncoder(i2c, args[ARG_address].u_int, sda, scl, args[ARG_interrupt].u_int);
+    if(!IS_VALID_SDA(i2c_id, sda)) {
+        mp_raise_ValueError(MP_ERROR_TEXT("bad SDA pin"));
     }
+
+    if(!IS_VALID_SCL(i2c_id, scl)) {
+        mp_raise_ValueError(MP_ERROR_TEXT("bad SCL pin"));
+    }
+
+    self = m_new_obj(breakout_encoder_BreakoutEncoder_obj_t);
+    self->base.type = &breakout_encoder_BreakoutEncoder_type;
+
+    i2c_inst_t *i2c = (i2c_id == 0) ? i2c0 : i2c1;
+    self->breakout = new BreakoutEncoder(i2c, args[ARG_address].u_int, sda, scl, args[ARG_interrupt].u_int);
 
     if(!self->breakout->init()) {
         mp_raise_msg(&mp_type_RuntimeError, "Encoder breakout not found when initialising");

--- a/micropython/modules/breakout_encoder/breakout_encoder.cpp
+++ b/micropython/modules/breakout_encoder/breakout_encoder.cpp
@@ -1,4 +1,5 @@
 #include "libraries/breakout_encoder/breakout_encoder.hpp"
+#include <cstdio>
 
 #define MP_OBJ_TO_PTR2(o, t) ((t *)(uintptr_t)(o))
 
@@ -27,6 +28,11 @@ void BreakoutEncoder_print(const mp_print_t *print, mp_obj_t self_in, mp_print_k
 
     mp_print_str(print, "i2c = ");
     mp_obj_print_helper(print, mp_obj_new_int((breakout->get_i2c() == i2c0) ? 0 : 1), PRINT_REPR);
+
+    mp_print_str(print, ", address = 0x");
+    char buf[3];
+    sprintf(buf, "%02X", breakout->get_address());
+    mp_print_str(print, buf);
 
     mp_print_str(print, ", sda = ");
     mp_obj_print_helper(print, mp_obj_new_int(breakout->get_sda()), PRINT_REPR);

--- a/micropython/modules/breakout_ioexpander/breakout_ioexpander.cpp
+++ b/micropython/modules/breakout_ioexpander/breakout_ioexpander.cpp
@@ -44,13 +44,13 @@ void BreakoutIOExpander_print(const mp_print_t *print, mp_obj_t self_in, mp_prin
 mp_obj_t BreakoutIOExpander_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     breakout_ioexpander_BreakoutIOExpander_obj_t *self = nullptr;
 
-    if(n_args == 0) {
+    if(n_args + n_kw == 0) {
         mp_arg_check_num(n_args, n_kw, 0, 0, true);
         self = m_new_obj(breakout_ioexpander_BreakoutIOExpander_obj_t);
         self->base.type = &breakout_ioexpander_BreakoutIOExpander_type;
         self->breakout = new BreakoutIOExpander();
     }
-    else if(n_args == 1) {
+    else if(n_args + n_kw == 1) {
         enum { ARG_address };
         static const mp_arg_t allowed_args[] = {
             { MP_QSTR_address, MP_ARG_REQUIRED | MP_ARG_INT },

--- a/micropython/modules/breakout_ioexpander/breakout_ioexpander.cpp
+++ b/micropython/modules/breakout_ioexpander/breakout_ioexpander.cpp
@@ -50,63 +50,44 @@ void BreakoutIOExpander_print(const mp_print_t *print, mp_obj_t self_in, mp_prin
 mp_obj_t BreakoutIOExpander_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     breakout_ioexpander_BreakoutIOExpander_obj_t *self = nullptr;
 
-    if(n_args + n_kw == 0) {
-        mp_arg_check_num(n_args, n_kw, 0, 0, true);
-        self = m_new_obj(breakout_ioexpander_BreakoutIOExpander_obj_t);
-        self->base.type = &breakout_ioexpander_BreakoutIOExpander_type;
-        self->breakout = new BreakoutIOExpander();
+    enum { ARG_i2c, ARG_address, ARG_sda, ARG_scl, ARG_interrupt };
+    static const mp_arg_t allowed_args[] = {
+        { MP_QSTR_i2c, MP_ARG_INT, {.u_int = -1} },
+        { MP_QSTR_address, MP_ARG_INT, {.u_int = BreakoutIOExpander::DEFAULT_I2C_ADDRESS} },
+        { MP_QSTR_sda, MP_ARG_INT, {.u_int = 20} },
+        { MP_QSTR_scl, MP_ARG_INT, {.u_int = 21} },
+        { MP_QSTR_interrupt, MP_ARG_INT, {.u_int = BreakoutIOExpander::PIN_UNUSED} },
+    };
+
+    // Parse args.
+    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+
+    // Get I2C bus.
+    int i2c_id = args[ARG_i2c].u_int;
+    int sda = args[ARG_sda].u_int;
+    int scl = args[ARG_scl].u_int;
+
+    if(i2c_id == -1) {
+        i2c_id = sda & 1;
     }
-    else if(n_args + n_kw == 1) {
-        enum { ARG_address };
-        static const mp_arg_t allowed_args[] = {
-            { MP_QSTR_address, MP_ARG_REQUIRED | MP_ARG_INT },
-        };
-
-        // Parse args.
-        mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
-        mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
-
-        self = m_new_obj(breakout_ioexpander_BreakoutIOExpander_obj_t);
-        self->base.type = &breakout_ioexpander_BreakoutIOExpander_type;
-
-        self->breakout = new BreakoutIOExpander(args[ARG_address].u_int);
+    if(i2c_id < 0 || i2c_id > 1) {
+        mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("I2C(%d) doesn't exist"), i2c_id);
     }
-    else {
-        enum { ARG_i2c, ARG_address, ARG_sda, ARG_scl, ARG_interrupt };
-        static const mp_arg_t allowed_args[] = {
-            { MP_QSTR_i2c, MP_ARG_REQUIRED | MP_ARG_INT },
-            { MP_QSTR_address, MP_ARG_REQUIRED | MP_ARG_INT },
-            { MP_QSTR_sda, MP_ARG_REQUIRED | MP_ARG_INT },
-            { MP_QSTR_scl, MP_ARG_REQUIRED | MP_ARG_INT },
-            { MP_QSTR_interrupt, MP_ARG_INT, {.u_int = BreakoutIOExpander::PIN_UNUSED} },
-        };
 
-        // Parse args.
-        mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
-        mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
-
-        // Get I2C bus.
-        int i2c_id = args[ARG_i2c].u_int;
-        if(i2c_id < 0 || i2c_id > 1) {
-            mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("I2C(%d) doesn't exist"), i2c_id);
-        }
-
-        int sda = args[ARG_sda].u_int;
-        if (!IS_VALID_SDA(i2c_id, sda)) {
-            mp_raise_ValueError(MP_ERROR_TEXT("bad SDA pin"));
-        }
-
-        int scl = args[ARG_scl].u_int;
-        if (!IS_VALID_SCL(i2c_id, scl)) {
-            mp_raise_ValueError(MP_ERROR_TEXT("bad SCL pin"));
-        }
-
-        self = m_new_obj(breakout_ioexpander_BreakoutIOExpander_obj_t);
-        self->base.type = &breakout_ioexpander_BreakoutIOExpander_type;
-
-        i2c_inst_t *i2c = (i2c_id == 0) ? i2c0 : i2c1;
-        self->breakout = new BreakoutIOExpander(i2c, args[ARG_address].u_int, sda, scl, args[ARG_interrupt].u_int);
+    if(!IS_VALID_SDA(i2c_id, sda)) {
+        mp_raise_ValueError(MP_ERROR_TEXT("bad SDA pin"));
     }
+
+    if(!IS_VALID_SCL(i2c_id, scl)) {
+        mp_raise_ValueError(MP_ERROR_TEXT("bad SCL pin"));
+    }
+
+    self = m_new_obj(breakout_ioexpander_BreakoutIOExpander_obj_t);
+    self->base.type = &breakout_ioexpander_BreakoutIOExpander_type;
+
+    i2c_inst_t *i2c = (i2c_id == 0) ? i2c0 : i2c1;
+    self->breakout = new BreakoutIOExpander(i2c, args[ARG_address].u_int, sda, scl, args[ARG_interrupt].u_int);
 
     if(!self->breakout->init()) {
         mp_raise_msg(&mp_type_RuntimeError, "IOExpander breakout not found when initialising");

--- a/micropython/modules/breakout_ioexpander/breakout_ioexpander.cpp
+++ b/micropython/modules/breakout_ioexpander/breakout_ioexpander.cpp
@@ -69,7 +69,7 @@ mp_obj_t BreakoutIOExpander_make_new(const mp_obj_type_t *type, size_t n_args, s
     int scl = args[ARG_scl].u_int;
 
     if(i2c_id == -1) {
-        i2c_id = sda & 1;
+        i2c_id = (sda >> 1) & 0b1;  // If no i2c specified, choose the one for the given SDA pin
     }
     if(i2c_id < 0 || i2c_id > 1) {
         mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("I2C(%d) doesn't exist"), i2c_id);

--- a/micropython/modules/breakout_ioexpander/breakout_ioexpander.cpp
+++ b/micropython/modules/breakout_ioexpander/breakout_ioexpander.cpp
@@ -1,4 +1,5 @@
 #include "libraries/breakout_ioexpander/breakout_ioexpander.hpp"
+#include <cstdio>
 
 #define MP_OBJ_TO_PTR2(o, t) ((t *)(uintptr_t)(o))
 
@@ -27,6 +28,11 @@ void BreakoutIOExpander_print(const mp_print_t *print, mp_obj_t self_in, mp_prin
 
     mp_print_str(print, "i2c = ");
     mp_obj_print_helper(print, mp_obj_new_int((breakout->get_i2c() == i2c0) ? 0 : 1), PRINT_REPR);
+
+    mp_print_str(print, ", address = 0x");
+    char buf[3];
+    sprintf(buf, "%02X", breakout->get_address());
+    mp_print_str(print, buf);
 
     mp_print_str(print, ", sda = ");
     mp_obj_print_helper(print, mp_obj_new_int(breakout->get_sda()), PRINT_REPR);

--- a/micropython/modules/breakout_ltr559/breakout_ltr559.cpp
+++ b/micropython/modules/breakout_ltr559/breakout_ltr559.cpp
@@ -1,4 +1,5 @@
 #include "libraries/breakout_ltr559/breakout_ltr559.hpp"
+#include <cstdio>
 
 #define MP_OBJ_TO_PTR2(o, t) ((t *)(uintptr_t)(o))
 
@@ -27,6 +28,11 @@ void BreakoutLTR559_print(const mp_print_t *print, mp_obj_t self_in, mp_print_ki
 
     mp_print_str(print, "i2c = ");
     mp_obj_print_helper(print, mp_obj_new_int((breakout->get_i2c() == i2c0) ? 0 : 1), PRINT_REPR);
+
+    mp_print_str(print, ", address = 0x");
+    char buf[3];
+    sprintf(buf, "%02X", breakout->get_address());
+    mp_print_str(print, buf);
 
     mp_print_str(print, ", sda = ");
     mp_obj_print_helper(print, mp_obj_new_int(breakout->get_sda()), PRINT_REPR);

--- a/micropython/modules/breakout_ltr559/breakout_ltr559.cpp
+++ b/micropython/modules/breakout_ltr559/breakout_ltr559.cpp
@@ -69,7 +69,7 @@ mp_obj_t BreakoutLTR559_make_new(const mp_obj_type_t *type, size_t n_args, size_
     int scl = args[ARG_scl].u_int;
 
     if(i2c_id == -1) {
-        i2c_id = sda & 1;
+        i2c_id = (sda >> 1) & 0b1;  // If no i2c specified, choose the one for the given SDA pin
     }
     if(i2c_id < 0 || i2c_id > 1) {
         mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("I2C(%d) doesn't exist"), i2c_id);

--- a/micropython/modules/breakout_ltr559/breakout_ltr559.cpp
+++ b/micropython/modules/breakout_ltr559/breakout_ltr559.cpp
@@ -50,65 +50,48 @@ void BreakoutLTR559_print(const mp_print_t *print, mp_obj_t self_in, mp_print_ki
 mp_obj_t BreakoutLTR559_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     breakout_ltr559_BreakoutLTR559_obj_t *self = nullptr;
 
-    if(n_args + n_kw == 0) {
-        mp_arg_check_num(n_args, n_kw, 0, 0, true);
-        self = m_new_obj(breakout_ltr559_BreakoutLTR559_obj_t);
-        self->base.type = &breakout_ltr559_BreakoutLTR559_type;
-        self->breakout = new BreakoutLTR559();
+    enum { ARG_i2c, ARG_address, ARG_sda, ARG_scl, ARG_interrupt };
+    static const mp_arg_t allowed_args[] = {
+        { MP_QSTR_i2c, MP_ARG_INT, {.u_int = -1} },
+        { MP_QSTR_address, MP_ARG_INT, {.u_int = BreakoutLTR559::DEFAULT_I2C_ADDRESS} },
+        { MP_QSTR_sda, MP_ARG_INT, {.u_int = 20} },
+        { MP_QSTR_scl, MP_ARG_INT, {.u_int = 21} },
+        { MP_QSTR_interrupt, MP_ARG_INT, {.u_int = BreakoutLTR559::PIN_UNUSED} },
+    };
+
+    // Parse args.
+    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+
+    // Get I2C bus.
+    int i2c_id = args[ARG_i2c].u_int;
+    int sda = args[ARG_sda].u_int;
+    int scl = args[ARG_scl].u_int;
+
+    if(i2c_id == -1) {
+        i2c_id = sda & 1;
     }
-    else if(n_args + n_kw == 1) {
-        enum { ARG_address };
-        static const mp_arg_t allowed_args[] = {
-            { MP_QSTR_address, MP_ARG_REQUIRED | MP_ARG_INT },
-        };
-
-        // Parse args.
-        mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
-        mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
-
-        self = m_new_obj(breakout_ltr559_BreakoutLTR559_obj_t);
-        self->base.type = &breakout_ltr559_BreakoutLTR559_type;
-
-        self->breakout = new BreakoutLTR559(args[ARG_address].u_int);
-    }
-    else {
-        enum { ARG_i2c, ARG_address, ARG_sda, ARG_scl, ARG_interrupt };
-        static const mp_arg_t allowed_args[] = {
-            { MP_QSTR_i2c, MP_ARG_REQUIRED | MP_ARG_INT },
-            { MP_QSTR_address, MP_ARG_REQUIRED | MP_ARG_INT },
-            { MP_QSTR_sda, MP_ARG_REQUIRED | MP_ARG_INT },
-            { MP_QSTR_scl, MP_ARG_REQUIRED | MP_ARG_INT },
-            { MP_QSTR_interrupt, MP_ARG_INT, {.u_int = BreakoutLTR559::PIN_UNUSED} },
-        };
-
-        // Parse args.
-        mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
-        mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
-
-        // Get I2C bus.
-        int i2c_id = args[ARG_i2c].u_int;
-        if(i2c_id < 0 || i2c_id > 1) {
-            mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("I2C(%d) doesn't exist"), i2c_id);
-        }
-
-        int sda = args[ARG_sda].u_int;
-        if (!IS_VALID_SDA(i2c_id, sda)) {
-            mp_raise_ValueError(MP_ERROR_TEXT("bad SDA pin"));
-        }
-
-        int scl = args[ARG_scl].u_int;
-        if (!IS_VALID_SCL(i2c_id, scl)) {
-            mp_raise_ValueError(MP_ERROR_TEXT("bad SCL pin"));
-        }
-
-        self = m_new_obj(breakout_ltr559_BreakoutLTR559_obj_t);
-        self->base.type = &breakout_ltr559_BreakoutLTR559_type;
-        
-        i2c_inst_t *i2c = (i2c_id == 0) ? i2c0 : i2c1;
-        self->breakout = new BreakoutLTR559(i2c, args[ARG_address].u_int, sda, scl, args[ARG_interrupt].u_int);
+    if(i2c_id < 0 || i2c_id > 1) {
+        mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("I2C(%d) doesn't exist"), i2c_id);
     }
 
-    self->breakout->init();
+    if(!IS_VALID_SDA(i2c_id, sda)) {
+        mp_raise_ValueError(MP_ERROR_TEXT("bad SDA pin"));
+    }
+
+    if(!IS_VALID_SCL(i2c_id, scl)) {
+        mp_raise_ValueError(MP_ERROR_TEXT("bad SCL pin"));
+    }
+
+    self = m_new_obj(breakout_ltr559_BreakoutLTR559_obj_t);
+    self->base.type = &breakout_ltr559_BreakoutLTR559_type;
+    
+    i2c_inst_t *i2c = (i2c_id == 0) ? i2c0 : i2c1;
+    self->breakout = new BreakoutLTR559(i2c, args[ARG_address].u_int, sda, scl, args[ARG_interrupt].u_int);
+
+    if(!self->breakout->init()) {
+        mp_raise_msg(&mp_type_RuntimeError, "LTR559 breakout not found when initialising");
+    }
 
     return MP_OBJ_FROM_PTR(self);
 }

--- a/micropython/modules/breakout_ltr559/breakout_ltr559.cpp
+++ b/micropython/modules/breakout_ltr559/breakout_ltr559.cpp
@@ -44,13 +44,13 @@ void BreakoutLTR559_print(const mp_print_t *print, mp_obj_t self_in, mp_print_ki
 mp_obj_t BreakoutLTR559_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     breakout_ltr559_BreakoutLTR559_obj_t *self = nullptr;
 
-    if(n_args == 0) {
+    if(n_args + n_kw == 0) {
         mp_arg_check_num(n_args, n_kw, 0, 0, true);
         self = m_new_obj(breakout_ltr559_BreakoutLTR559_obj_t);
         self->base.type = &breakout_ltr559_BreakoutLTR559_type;
         self->breakout = new BreakoutLTR559();
     }
-    else if(n_args == 1) {
+    else if(n_args + n_kw == 1) {
         enum { ARG_address };
         static const mp_arg_t allowed_args[] = {
             { MP_QSTR_address, MP_ARG_REQUIRED | MP_ARG_INT },
@@ -62,7 +62,7 @@ mp_obj_t BreakoutLTR559_make_new(const mp_obj_type_t *type, size_t n_args, size_
 
         self = m_new_obj(breakout_ltr559_BreakoutLTR559_obj_t);
         self->base.type = &breakout_ltr559_BreakoutLTR559_type;
-        
+
         self->breakout = new BreakoutLTR559(args[ARG_address].u_int);
     }
     else {
@@ -93,7 +93,7 @@ mp_obj_t BreakoutLTR559_make_new(const mp_obj_type_t *type, size_t n_args, size_
         int scl = args[ARG_scl].u_int;
         if (!IS_VALID_SCL(i2c_id, scl)) {
             mp_raise_ValueError(MP_ERROR_TEXT("bad SCL pin"));
-        }        
+        }
 
         self = m_new_obj(breakout_ltr559_BreakoutLTR559_obj_t);
         self->base.type = &breakout_ltr559_BreakoutLTR559_type;
@@ -152,7 +152,7 @@ mp_obj_t BreakoutLTR559_interrupts(size_t n_args, const mp_obj_t *pos_args, mp_m
 
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
-    
+
     breakout_ltr559_BreakoutLTR559_obj_t *self = MP_OBJ_TO_PTR2(args[ARG_self].u_obj, breakout_ltr559_BreakoutLTR559_obj_t);
     self->breakout->interrupts(args[ARG_light].u_bool, args[ARG_proximity].u_bool);
 
@@ -171,7 +171,7 @@ mp_obj_t BreakoutLTR559_proximity_led(size_t n_args, const mp_obj_t *pos_args, m
 
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
-    
+
     breakout_ltr559_BreakoutLTR559_obj_t *self = MP_OBJ_TO_PTR2(args[ARG_self].u_obj, breakout_ltr559_BreakoutLTR559_obj_t);
 
     int current = args[ARG_current].u_int;
@@ -203,7 +203,7 @@ mp_obj_t BreakoutLTR559_light_control(size_t n_args, const mp_obj_t *pos_args, m
 
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
-    
+
     breakout_ltr559_BreakoutLTR559_obj_t *self = MP_OBJ_TO_PTR2(args[ARG_self].u_obj, breakout_ltr559_BreakoutLTR559_obj_t);
 
     int gain = args[ARG_gain].u_int;
@@ -226,7 +226,7 @@ mp_obj_t BreakoutLTR559_proximity_control(size_t n_args, const mp_obj_t *pos_arg
 
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
-    
+
     breakout_ltr559_BreakoutLTR559_obj_t *self = MP_OBJ_TO_PTR2(args[ARG_self].u_obj, breakout_ltr559_BreakoutLTR559_obj_t);
     self->breakout->proximity_control(args[ARG_active].u_bool, args[ARG_saturation_indicator].u_bool);
 
@@ -243,7 +243,7 @@ mp_obj_t BreakoutLTR559_light_threshold(size_t n_args, const mp_obj_t *pos_args,
 
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
-    
+
     breakout_ltr559_BreakoutLTR559_obj_t *self = MP_OBJ_TO_PTR2(args[ARG_self].u_obj, breakout_ltr559_BreakoutLTR559_obj_t);
 
     int lower = args[ARG_lower].u_int;
@@ -269,7 +269,7 @@ mp_obj_t BreakoutLTR559_proximity_threshold(size_t n_args, const mp_obj_t *pos_a
 
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
-    
+
     breakout_ltr559_BreakoutLTR559_obj_t *self = MP_OBJ_TO_PTR2(args[ARG_self].u_obj, breakout_ltr559_BreakoutLTR559_obj_t);
 
     int lower = args[ARG_lower].u_int;
@@ -295,7 +295,7 @@ mp_obj_t BreakoutLTR559_light_measurement_rate(size_t n_args, const mp_obj_t *po
 
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
-    
+
     breakout_ltr559_BreakoutLTR559_obj_t *self = MP_OBJ_TO_PTR2(args[ARG_self].u_obj, breakout_ltr559_BreakoutLTR559_obj_t);
 
     int integration_time = args[ARG_integration_time].u_int;
@@ -320,7 +320,7 @@ mp_obj_t BreakoutLTR559_proximity_measurement_rate(size_t n_args, const mp_obj_t
 
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
-    
+
     breakout_ltr559_BreakoutLTR559_obj_t *self = MP_OBJ_TO_PTR2(args[ARG_self].u_obj, breakout_ltr559_BreakoutLTR559_obj_t);
 
     int rate = args[ARG_rate].u_int;
@@ -342,7 +342,7 @@ mp_obj_t BreakoutLTR559_proximity_offset(size_t n_args, const mp_obj_t *pos_args
 
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
-    
+
     breakout_ltr559_BreakoutLTR559_obj_t *self = MP_OBJ_TO_PTR2(args[ARG_self].u_obj, breakout_ltr559_BreakoutLTR559_obj_t);
 
     int offset = args[ARG_offset].u_int;

--- a/micropython/modules/breakout_matrix11x7/breakout_matrix11x7.cpp
+++ b/micropython/modules/breakout_matrix11x7/breakout_matrix11x7.cpp
@@ -47,64 +47,47 @@ void BreakoutMatrix11x7_print(const mp_print_t *print, mp_obj_t self_in, mp_prin
 mp_obj_t BreakoutMatrix11x7_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     breakout_matrix11x7_BreakoutMatrix11x7_obj_t *self = nullptr;
 
-    if(n_args + n_kw == 0) {
-        mp_arg_check_num(n_args, n_kw, 0, 0, true);
-        self = m_new_obj(breakout_matrix11x7_BreakoutMatrix11x7_obj_t);
-        self->base.type = &breakout_matrix11x7_BreakoutMatrix11x7_type;
-        self->breakout = new BreakoutMatrix11x7();        
+    enum { ARG_i2c, ARG_address, ARG_sda, ARG_scl };
+    static const mp_arg_t allowed_args[] = {
+        { MP_QSTR_i2c, MP_ARG_INT, {.u_int = -1} },
+        { MP_QSTR_address, MP_ARG_INT, {.u_int = BreakoutMatrix11x7::DEFAULT_I2C_ADDRESS} },
+        { MP_QSTR_sda, MP_ARG_INT, {.u_int = 20} },
+        { MP_QSTR_scl, MP_ARG_INT, {.u_int = 21} },
+    };
+
+    // Parse args.
+    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+
+    // Get I2C bus.
+    int i2c_id = args[ARG_i2c].u_int;
+    int sda = args[ARG_sda].u_int;
+    int scl = args[ARG_scl].u_int;
+
+    if(i2c_id == -1) {
+        i2c_id = sda & 1;
     }
-    else if(n_args + n_kw == 1) {
-        enum { ARG_address };
-        static const mp_arg_t allowed_args[] = {
-            { MP_QSTR_address, MP_ARG_REQUIRED | MP_ARG_INT },
-        };
-
-        // Parse args.
-        mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
-        mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
-
-        self = m_new_obj(breakout_matrix11x7_BreakoutMatrix11x7_obj_t);
-        self->base.type = &breakout_matrix11x7_BreakoutMatrix11x7_type;
-
-        self->breakout = new BreakoutMatrix11x7(args[ARG_address].u_int);     
-    }
-    else {
-        enum { ARG_i2c, ARG_address, ARG_sda, ARG_scl };
-        static const mp_arg_t allowed_args[] = {
-            { MP_QSTR_i2c, MP_ARG_REQUIRED | MP_ARG_INT },
-            { MP_QSTR_address, MP_ARG_REQUIRED | MP_ARG_INT },
-            { MP_QSTR_sda, MP_ARG_REQUIRED | MP_ARG_INT },
-            { MP_QSTR_scl, MP_ARG_REQUIRED | MP_ARG_INT },
-        };
-
-        // Parse args.
-        mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
-        mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
-
-        // Get I2C bus.
-        int i2c_id = args[ARG_i2c].u_int;
-        if(i2c_id < 0 || i2c_id > 1) {
-            mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("I2C(%d) doesn't exist"), i2c_id);
-        }
-
-        int sda = args[ARG_sda].u_int;
-        if (!IS_VALID_SDA(i2c_id, sda)) {
-            mp_raise_ValueError(MP_ERROR_TEXT("bad SDA pin"));
-        }
-
-        int scl = args[ARG_scl].u_int;
-        if (!IS_VALID_SCL(i2c_id, scl)) {
-            mp_raise_ValueError(MP_ERROR_TEXT("bad SCL pin"));
-        }
-
-        self = m_new_obj(breakout_matrix11x7_BreakoutMatrix11x7_obj_t);
-        self->base.type = &breakout_matrix11x7_BreakoutMatrix11x7_type;
-        
-        i2c_inst_t *i2c = (i2c_id == 0) ? i2c0 : i2c1;
-        self->breakout = new BreakoutMatrix11x7(i2c, args[ARG_address].u_int, sda, scl);
+    if(i2c_id < 0 || i2c_id > 1) {
+        mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("I2C(%d) doesn't exist"), i2c_id);
     }
 
-    self->breakout->init();
+    if(!IS_VALID_SDA(i2c_id, sda)) {
+        mp_raise_ValueError(MP_ERROR_TEXT("bad SDA pin"));
+    }
+
+    if(!IS_VALID_SCL(i2c_id, scl)) {
+        mp_raise_ValueError(MP_ERROR_TEXT("bad SCL pin"));
+    }
+
+    self = m_new_obj(breakout_matrix11x7_BreakoutMatrix11x7_obj_t);
+    self->base.type = &breakout_matrix11x7_BreakoutMatrix11x7_type;
+
+    i2c_inst_t *i2c = (i2c_id == 0) ? i2c0 : i2c1;
+    self->breakout = new BreakoutMatrix11x7(i2c, args[ARG_address].u_int, sda, scl);
+
+    if(!self->breakout->init()) {
+        mp_raise_msg(&mp_type_RuntimeError, "Matrix11x7 breakout not found when initialising");
+    }
 
     return MP_OBJ_FROM_PTR(self);
 }

--- a/micropython/modules/breakout_matrix11x7/breakout_matrix11x7.cpp
+++ b/micropython/modules/breakout_matrix11x7/breakout_matrix11x7.cpp
@@ -41,13 +41,13 @@ void BreakoutMatrix11x7_print(const mp_print_t *print, mp_obj_t self_in, mp_prin
 mp_obj_t BreakoutMatrix11x7_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     breakout_matrix11x7_BreakoutMatrix11x7_obj_t *self = nullptr;
 
-    if(n_args == 0) {
+    if(n_args + n_kw == 0) {
         mp_arg_check_num(n_args, n_kw, 0, 0, true);
         self = m_new_obj(breakout_matrix11x7_BreakoutMatrix11x7_obj_t);
         self->base.type = &breakout_matrix11x7_BreakoutMatrix11x7_type;
         self->breakout = new BreakoutMatrix11x7();        
     }
-    else if(n_args == 1) {
+    else if(n_args + n_kw == 1) {
         enum { ARG_address };
         static const mp_arg_t allowed_args[] = {
             { MP_QSTR_address, MP_ARG_REQUIRED | MP_ARG_INT },
@@ -59,7 +59,7 @@ mp_obj_t BreakoutMatrix11x7_make_new(const mp_obj_type_t *type, size_t n_args, s
 
         self = m_new_obj(breakout_matrix11x7_BreakoutMatrix11x7_obj_t);
         self->base.type = &breakout_matrix11x7_BreakoutMatrix11x7_type;
-        
+
         self->breakout = new BreakoutMatrix11x7(args[ARG_address].u_int);     
     }
     else {
@@ -89,7 +89,7 @@ mp_obj_t BreakoutMatrix11x7_make_new(const mp_obj_type_t *type, size_t n_args, s
         int scl = args[ARG_scl].u_int;
         if (!IS_VALID_SCL(i2c_id, scl)) {
             mp_raise_ValueError(MP_ERROR_TEXT("bad SCL pin"));
-        }        
+        }
 
         self = m_new_obj(breakout_matrix11x7_BreakoutMatrix11x7_obj_t);
         self->base.type = &breakout_matrix11x7_BreakoutMatrix11x7_type;

--- a/micropython/modules/breakout_matrix11x7/breakout_matrix11x7.cpp
+++ b/micropython/modules/breakout_matrix11x7/breakout_matrix11x7.cpp
@@ -1,4 +1,5 @@
 #include "libraries/breakout_matrix11x7/breakout_matrix11x7.hpp"
+#include <cstdio>
 
 #define MP_OBJ_TO_PTR2(o, t) ((t *)(uintptr_t)(o))
 
@@ -27,6 +28,11 @@ void BreakoutMatrix11x7_print(const mp_print_t *print, mp_obj_t self_in, mp_prin
 
     mp_print_str(print, "i2c = ");
     mp_obj_print_helper(print, mp_obj_new_int((breakout->get_i2c() == i2c0) ? 0 : 1), PRINT_REPR);
+
+    mp_print_str(print, ", address = 0x");
+    char buf[3];
+    sprintf(buf, "%02X", breakout->get_address());
+    mp_print_str(print, buf);
 
     mp_print_str(print, ", sda = ");
     mp_obj_print_helper(print, mp_obj_new_int(breakout->get_sda()), PRINT_REPR);

--- a/micropython/modules/breakout_mics6814/breakout_mics6814.cpp
+++ b/micropython/modules/breakout_mics6814/breakout_mics6814.cpp
@@ -1,4 +1,5 @@
 #include "libraries/breakout_mics6814/breakout_mics6814.hpp"
+#include <cstdio>
 
 #define MP_OBJ_TO_PTR2(o, t) ((t *)(uintptr_t)(o))
 
@@ -27,6 +28,11 @@ void BreakoutMICS6814_print(const mp_print_t *print, mp_obj_t self_in, mp_print_
 
     mp_print_str(print, "i2c = ");
     mp_obj_print_helper(print, mp_obj_new_int((breakout->get_i2c() == i2c0) ? 0 : 1), PRINT_REPR);
+
+    mp_print_str(print, ", address = 0x");
+    char buf[3];
+    sprintf(buf, "%02X", breakout->get_address());
+    mp_print_str(print, buf);
 
     mp_print_str(print, ", sda = ");
     mp_obj_print_helper(print, mp_obj_new_int(breakout->get_sda()), PRINT_REPR);

--- a/micropython/modules/breakout_mics6814/breakout_mics6814.cpp
+++ b/micropython/modules/breakout_mics6814/breakout_mics6814.cpp
@@ -69,7 +69,7 @@ mp_obj_t BreakoutMICS6814_make_new(const mp_obj_type_t *type, size_t n_args, siz
     int scl = args[ARG_scl].u_int;
 
     if(i2c_id == -1) {
-        i2c_id = sda & 1;
+        i2c_id = (sda >> 1) & 0b1;  // If no i2c specified, choose the one for the given SDA pin
     }
     if(i2c_id < 0 || i2c_id > 1) {
         mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("I2C(%d) doesn't exist"), i2c_id);

--- a/micropython/modules/breakout_mics6814/breakout_mics6814.cpp
+++ b/micropython/modules/breakout_mics6814/breakout_mics6814.cpp
@@ -50,63 +50,44 @@ void BreakoutMICS6814_print(const mp_print_t *print, mp_obj_t self_in, mp_print_
 mp_obj_t BreakoutMICS6814_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     breakout_mics6814_BreakoutMICS6814_obj_t *self = nullptr;
 
-    if(n_args + n_kw == 0) {
-        mp_arg_check_num(n_args, n_kw, 0, 0, true);
-        self = m_new_obj(breakout_mics6814_BreakoutMICS6814_obj_t);
-        self->base.type = &breakout_mics6814_BreakoutMICS6814_type;
-        self->breakout = new BreakoutMICS6814();
-    }
-    else if(n_args + n_kw == 1) {
-        enum { ARG_address };
+    enum { ARG_i2c, ARG_address, ARG_sda, ARG_scl, ARG_interrupt };
         static const mp_arg_t allowed_args[] = {
-            { MP_QSTR_address, MP_ARG_REQUIRED | MP_ARG_INT },
-        };
+        { MP_QSTR_i2c, MP_ARG_INT, {.u_int = -1} },
+        { MP_QSTR_address, MP_ARG_INT, {.u_int = BreakoutMICS6814::DEFAULT_I2C_ADDRESS} },
+        { MP_QSTR_sda, MP_ARG_INT, {.u_int = 20} },
+        { MP_QSTR_scl, MP_ARG_INT, {.u_int = 21} },
+        { MP_QSTR_interrupt, MP_ARG_INT, {.u_int = BreakoutMICS6814::PIN_UNUSED} },
+    };
 
-        // Parse args.
-        mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
-        mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+    // Parse args.
+    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-        self = m_new_obj(breakout_mics6814_BreakoutMICS6814_obj_t);
-        self->base.type = &breakout_mics6814_BreakoutMICS6814_type;
+    // Get I2C bus.
+    int i2c_id = args[ARG_i2c].u_int;
+    int sda = args[ARG_sda].u_int;
+    int scl = args[ARG_scl].u_int;
 
-        self->breakout = new BreakoutMICS6814(args[ARG_address].u_int);
+    if(i2c_id == -1) {
+        i2c_id = sda & 1;
     }
-    else {
-        enum { ARG_i2c, ARG_address, ARG_sda, ARG_scl, ARG_interrupt };
-        static const mp_arg_t allowed_args[] = {
-            { MP_QSTR_i2c, MP_ARG_REQUIRED | MP_ARG_INT },
-            { MP_QSTR_address, MP_ARG_REQUIRED | MP_ARG_INT },
-            { MP_QSTR_sda, MP_ARG_REQUIRED | MP_ARG_INT },
-            { MP_QSTR_scl, MP_ARG_REQUIRED | MP_ARG_INT },
-            { MP_QSTR_interrupt, MP_ARG_INT, {.u_int = BreakoutMICS6814::PIN_UNUSED} },
-        };
-
-        // Parse args.
-        mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
-        mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
-
-        // Get I2C bus.
-        int i2c_id = args[ARG_i2c].u_int;
-        if(i2c_id < 0 || i2c_id > 1) {
-            mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("I2C(%d) doesn't exist"), i2c_id);
-        }
-
-        int sda = args[ARG_sda].u_int;
-        if (!IS_VALID_SDA(i2c_id, sda)) {
-            mp_raise_ValueError(MP_ERROR_TEXT("bad SDA pin"));
-        }
-
-        int scl = args[ARG_scl].u_int;
-        if (!IS_VALID_SCL(i2c_id, scl)) {
-            mp_raise_ValueError(MP_ERROR_TEXT("bad SCL pin"));
-        }
-
-        self = m_new_obj(breakout_mics6814_BreakoutMICS6814_obj_t);
-        self->base.type = &breakout_mics6814_BreakoutMICS6814_type;
-
-        i2c_inst_t *i2c = (i2c_id == 0) ? i2c0 : i2c1;
-        self->breakout = new BreakoutMICS6814(i2c, args[ARG_address].u_int, sda, scl, args[ARG_interrupt].u_int);
+    if(i2c_id < 0 || i2c_id > 1) {
+        mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("I2C(%d) doesn't exist"), i2c_id);
     }
+
+    if(!IS_VALID_SDA(i2c_id, sda)) {
+        mp_raise_ValueError(MP_ERROR_TEXT("bad SDA pin"));
+    }
+
+    if(!IS_VALID_SCL(i2c_id, scl)) {
+        mp_raise_ValueError(MP_ERROR_TEXT("bad SCL pin"));
+    }
+
+    self = m_new_obj(breakout_mics6814_BreakoutMICS6814_obj_t);
+    self->base.type = &breakout_mics6814_BreakoutMICS6814_type;
+
+    i2c_inst_t *i2c = (i2c_id == 0) ? i2c0 : i2c1;
+    self->breakout = new BreakoutMICS6814(i2c, args[ARG_address].u_int, sda, scl, args[ARG_interrupt].u_int);
 
     if(!self->breakout->init()) {
         mp_raise_msg(&mp_type_RuntimeError, "MICS6814 breakout not found when initialising");

--- a/micropython/modules/breakout_mics6814/breakout_mics6814.cpp
+++ b/micropython/modules/breakout_mics6814/breakout_mics6814.cpp
@@ -44,13 +44,13 @@ void BreakoutMICS6814_print(const mp_print_t *print, mp_obj_t self_in, mp_print_
 mp_obj_t BreakoutMICS6814_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     breakout_mics6814_BreakoutMICS6814_obj_t *self = nullptr;
 
-    if(n_args == 0) {
+    if(n_args + n_kw == 0) {
         mp_arg_check_num(n_args, n_kw, 0, 0, true);
         self = m_new_obj(breakout_mics6814_BreakoutMICS6814_obj_t);
         self->base.type = &breakout_mics6814_BreakoutMICS6814_type;
         self->breakout = new BreakoutMICS6814();
     }
-    else if(n_args == 1) {
+    else if(n_args + n_kw == 1) {
         enum { ARG_address };
         static const mp_arg_t allowed_args[] = {
             { MP_QSTR_address, MP_ARG_REQUIRED | MP_ARG_INT },
@@ -254,7 +254,7 @@ mp_obj_t BreakoutMICS6814_read_all(mp_obj_t self_in) {
     tuple[REDUCING] = mp_obj_new_float(reading.reducing);
     tuple[NH3] = mp_obj_new_float(reading.nh3);
     tuple[OXIDISING] = mp_obj_new_float(reading.oxidising);
-    
+
     return mp_obj_new_tuple(4, tuple);
 }
 

--- a/micropython/modules/breakout_msa301/breakout_msa301.cpp
+++ b/micropython/modules/breakout_msa301/breakout_msa301.cpp
@@ -44,7 +44,7 @@ void BreakoutMSA301_print(const mp_print_t *print, mp_obj_t self_in, mp_print_ki
 mp_obj_t BreakoutMSA301_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     breakout_msa301_BreakoutMSA301_obj_t *self = nullptr;
 
-    if(n_args == 0) {
+    if(n_args + n_kw == 0) {
         mp_arg_check_num(n_args, n_kw, 0, 0, true);
         self = m_new_obj(breakout_msa301_BreakoutMSA301_obj_t);
         self->base.type = &breakout_msa301_BreakoutMSA301_type;
@@ -77,7 +77,7 @@ mp_obj_t BreakoutMSA301_make_new(const mp_obj_type_t *type, size_t n_args, size_
         int scl = args[ARG_scl].u_int;
         if (!IS_VALID_SCL(i2c_id, scl)) {
             mp_raise_ValueError(MP_ERROR_TEXT("bad SCL pin"));
-        }        
+        }
 
         self = m_new_obj(breakout_msa301_BreakoutMSA301_obj_t);
         self->base.type = &breakout_msa301_BreakoutMSA301_type;
@@ -145,7 +145,7 @@ mp_obj_t BreakoutMSA301_get_x_axis(size_t n_args, const mp_obj_t *pos_args, mp_m
 
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
-    
+
     breakout_msa301_BreakoutMSA301_obj_t *self = MP_OBJ_TO_PTR2(args[ARG_self].u_obj, breakout_msa301_BreakoutMSA301_obj_t);
 
     int sample_count = args[ARG_sample_count].u_int;
@@ -166,7 +166,7 @@ mp_obj_t BreakoutMSA301_get_y_axis(size_t n_args, const mp_obj_t *pos_args, mp_m
 
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
-    
+
     breakout_msa301_BreakoutMSA301_obj_t *self = MP_OBJ_TO_PTR2(args[ARG_self].u_obj, breakout_msa301_BreakoutMSA301_obj_t);
 
     int sample_count = args[ARG_sample_count].u_int;
@@ -187,7 +187,7 @@ mp_obj_t BreakoutMSA301_get_z_axis(size_t n_args, const mp_obj_t *pos_args, mp_m
 
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
-    
+
     breakout_msa301_BreakoutMSA301_obj_t *self = MP_OBJ_TO_PTR2(args[ARG_self].u_obj, breakout_msa301_BreakoutMSA301_obj_t);
 
     int sample_count = args[ARG_sample_count].u_int;

--- a/micropython/modules/breakout_msa301/breakout_msa301.cpp
+++ b/micropython/modules/breakout_msa301/breakout_msa301.cpp
@@ -44,49 +44,47 @@ void BreakoutMSA301_print(const mp_print_t *print, mp_obj_t self_in, mp_print_ki
 mp_obj_t BreakoutMSA301_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     breakout_msa301_BreakoutMSA301_obj_t *self = nullptr;
 
-    if(n_args + n_kw == 0) {
-        mp_arg_check_num(n_args, n_kw, 0, 0, true);
-        self = m_new_obj(breakout_msa301_BreakoutMSA301_obj_t);
-        self->base.type = &breakout_msa301_BreakoutMSA301_type;
-        self->breakout = new BreakoutMSA301();
+    enum { ARG_i2c, ARG_sda, ARG_scl, ARG_interrupt };
+    static const mp_arg_t allowed_args[] = {
+        { MP_QSTR_i2c, MP_ARG_INT, {.u_int = -1} },
+        { MP_QSTR_sda, MP_ARG_INT, {.u_int = 20} },
+        { MP_QSTR_scl, MP_ARG_INT, {.u_int = 21} },
+        { MP_QSTR_interrupt, MP_ARG_INT, {.u_int = BreakoutMSA301::PIN_UNUSED} },
+    };
+
+    // Parse args.
+    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+
+    // Get I2C bus.
+    int i2c_id = args[ARG_i2c].u_int;
+    int sda = args[ARG_sda].u_int;
+    int scl = args[ARG_scl].u_int;
+
+    if(i2c_id == -1) {
+        i2c_id = sda & 1;
     }
-    else {
-        enum { ARG_i2c, ARG_sda, ARG_scl, ARG_interrupt };
-        static const mp_arg_t allowed_args[] = {
-            { MP_QSTR_i2c, MP_ARG_REQUIRED | MP_ARG_INT },
-            { MP_QSTR_sda, MP_ARG_REQUIRED | MP_ARG_INT },
-            { MP_QSTR_scl, MP_ARG_REQUIRED | MP_ARG_INT },
-            { MP_QSTR_interrupt, MP_ARG_INT, {.u_int = BreakoutMSA301::PIN_UNUSED} },
-        };
-
-        // Parse args.
-        mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
-        mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
-
-        // Get I2C bus.
-        int i2c_id = args[ARG_i2c].u_int;
-        if(i2c_id < 0 || i2c_id > 1) {
-            mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("I2C(%d) doesn't exist"), i2c_id);
-        }
-
-        int sda = args[ARG_sda].u_int;
-        if (!IS_VALID_SDA(i2c_id, sda)) {
-            mp_raise_ValueError(MP_ERROR_TEXT("bad SDA pin"));
-        }
-
-        int scl = args[ARG_scl].u_int;
-        if (!IS_VALID_SCL(i2c_id, scl)) {
-            mp_raise_ValueError(MP_ERROR_TEXT("bad SCL pin"));
-        }
-
-        self = m_new_obj(breakout_msa301_BreakoutMSA301_obj_t);
-        self->base.type = &breakout_msa301_BreakoutMSA301_type;
-        
-        i2c_inst_t *i2c = (i2c_id == 0) ? i2c0 : i2c1;
-        self->breakout = new BreakoutMSA301(i2c, sda, scl, args[ARG_interrupt].u_int);
+    if(i2c_id < 0 || i2c_id > 1) {
+        mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("I2C(%d) doesn't exist"), i2c_id);
     }
 
-    self->breakout->init();
+    if(!IS_VALID_SDA(i2c_id, sda)) {
+        mp_raise_ValueError(MP_ERROR_TEXT("bad SDA pin"));
+    }
+
+    if(!IS_VALID_SCL(i2c_id, scl)) {
+        mp_raise_ValueError(MP_ERROR_TEXT("bad SCL pin"));
+    }
+
+    self = m_new_obj(breakout_msa301_BreakoutMSA301_obj_t);
+    self->base.type = &breakout_msa301_BreakoutMSA301_type;
+    
+    i2c_inst_t *i2c = (i2c_id == 0) ? i2c0 : i2c1;
+    self->breakout = new BreakoutMSA301(i2c, sda, scl, args[ARG_interrupt].u_int);
+
+    if(!self->breakout->init()) {
+        mp_raise_msg(&mp_type_RuntimeError, "MSA301 breakout not found when initialising");
+    }
 
     return MP_OBJ_FROM_PTR(self);
 }

--- a/micropython/modules/breakout_msa301/breakout_msa301.cpp
+++ b/micropython/modules/breakout_msa301/breakout_msa301.cpp
@@ -62,7 +62,7 @@ mp_obj_t BreakoutMSA301_make_new(const mp_obj_type_t *type, size_t n_args, size_
     int scl = args[ARG_scl].u_int;
 
     if(i2c_id == -1) {
-        i2c_id = sda & 1;
+        i2c_id = (sda >> 1) & 0b1;  // If no i2c specified, choose the one for the given SDA pin
     }
     if(i2c_id < 0 || i2c_id > 1) {
         mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("I2C(%d) doesn't exist"), i2c_id);

--- a/micropython/modules/breakout_potentiometer/breakout_potentiometer.cpp
+++ b/micropython/modules/breakout_potentiometer/breakout_potentiometer.cpp
@@ -69,7 +69,7 @@ mp_obj_t BreakoutPotentiometer_make_new(const mp_obj_type_t *type, size_t n_args
     int scl = args[ARG_scl].u_int;
 
     if(i2c_id == -1) {
-        i2c_id = sda & 1;
+        i2c_id = (sda >> 1) & 0b1;  // If no i2c specified, choose the one for the given SDA pin
     }
     if(i2c_id < 0 || i2c_id > 1) {
         mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("I2C(%d) doesn't exist"), i2c_id);

--- a/micropython/modules/breakout_potentiometer/breakout_potentiometer.cpp
+++ b/micropython/modules/breakout_potentiometer/breakout_potentiometer.cpp
@@ -44,13 +44,13 @@ void BreakoutPotentiometer_print(const mp_print_t *print, mp_obj_t self_in, mp_p
 mp_obj_t BreakoutPotentiometer_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     breakout_potentiometer_BreakoutPotentiometer_obj_t *self = nullptr;
 
-    if(n_args == 0) {
+    if(n_args + n_kw == 0) {
         mp_arg_check_num(n_args, n_kw, 0, 0, true);
         self = m_new_obj(breakout_potentiometer_BreakoutPotentiometer_obj_t);
         self->base.type = &breakout_potentiometer_BreakoutPotentiometer_type;
         self->breakout = new BreakoutPotentiometer();
     }
-    else if(n_args == 1) {
+    else if(n_args + n_kw == 1) {
         enum { ARG_address };
         static const mp_arg_t allowed_args[] = {
             { MP_QSTR_address, MP_ARG_REQUIRED | MP_ARG_INT },

--- a/micropython/modules/breakout_potentiometer/breakout_potentiometer.cpp
+++ b/micropython/modules/breakout_potentiometer/breakout_potentiometer.cpp
@@ -1,4 +1,5 @@
 #include "libraries/breakout_potentiometer/breakout_potentiometer.hpp"
+#include <cstdio>
 
 #define MP_OBJ_TO_PTR2(o, t) ((t *)(uintptr_t)(o))
 
@@ -27,6 +28,11 @@ void BreakoutPotentiometer_print(const mp_print_t *print, mp_obj_t self_in, mp_p
 
     mp_print_str(print, "i2c = ");
     mp_obj_print_helper(print, mp_obj_new_int((breakout->get_i2c() == i2c0) ? 0 : 1), PRINT_REPR);
+
+    mp_print_str(print, ", address = 0x");
+    char buf[3];
+    sprintf(buf, "%02X", breakout->get_address());
+    mp_print_str(print, buf);
 
     mp_print_str(print, ", sda = ");
     mp_obj_print_helper(print, mp_obj_new_int(breakout->get_sda()), PRINT_REPR);

--- a/micropython/modules/breakout_potentiometer/breakout_potentiometer.cpp
+++ b/micropython/modules/breakout_potentiometer/breakout_potentiometer.cpp
@@ -50,63 +50,44 @@ void BreakoutPotentiometer_print(const mp_print_t *print, mp_obj_t self_in, mp_p
 mp_obj_t BreakoutPotentiometer_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     breakout_potentiometer_BreakoutPotentiometer_obj_t *self = nullptr;
 
-    if(n_args + n_kw == 0) {
-        mp_arg_check_num(n_args, n_kw, 0, 0, true);
-        self = m_new_obj(breakout_potentiometer_BreakoutPotentiometer_obj_t);
-        self->base.type = &breakout_potentiometer_BreakoutPotentiometer_type;
-        self->breakout = new BreakoutPotentiometer();
+    enum { ARG_i2c, ARG_address, ARG_sda, ARG_scl, ARG_interrupt };
+    static const mp_arg_t allowed_args[] = {
+        { MP_QSTR_i2c, MP_ARG_INT, {.u_int = -1} },
+        { MP_QSTR_address, MP_ARG_INT, {.u_int = BreakoutPotentiometer::DEFAULT_I2C_ADDRESS} },
+        { MP_QSTR_sda, MP_ARG_INT, {.u_int = 20} },
+        { MP_QSTR_scl, MP_ARG_INT, {.u_int = 21} },
+        { MP_QSTR_interrupt, MP_ARG_INT, {.u_int = BreakoutPotentiometer::PIN_UNUSED} },
+    };
+
+    // Parse args.
+    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+
+    // Get I2C bus.
+    int i2c_id = args[ARG_i2c].u_int;
+    int sda = args[ARG_sda].u_int;
+    int scl = args[ARG_scl].u_int;
+
+    if(i2c_id == -1) {
+        i2c_id = sda & 1;
     }
-    else if(n_args + n_kw == 1) {
-        enum { ARG_address };
-        static const mp_arg_t allowed_args[] = {
-            { MP_QSTR_address, MP_ARG_REQUIRED | MP_ARG_INT },
-        };
-
-        // Parse args.
-        mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
-        mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
-
-        self = m_new_obj(breakout_potentiometer_BreakoutPotentiometer_obj_t);
-        self->base.type = &breakout_potentiometer_BreakoutPotentiometer_type;
-
-        self->breakout = new BreakoutPotentiometer(args[ARG_address].u_int);
+    if(i2c_id < 0 || i2c_id > 1) {
+        mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("I2C(%d) doesn't exist"), i2c_id);
     }
-    else {
-        enum { ARG_i2c, ARG_address, ARG_sda, ARG_scl, ARG_interrupt };
-        static const mp_arg_t allowed_args[] = {
-            { MP_QSTR_i2c, MP_ARG_REQUIRED | MP_ARG_INT },
-            { MP_QSTR_address, MP_ARG_REQUIRED | MP_ARG_INT },
-            { MP_QSTR_sda, MP_ARG_REQUIRED | MP_ARG_INT },
-            { MP_QSTR_scl, MP_ARG_REQUIRED | MP_ARG_INT },
-            { MP_QSTR_interrupt, MP_ARG_INT, {.u_int = BreakoutPotentiometer::PIN_UNUSED} },
-        };
 
-        // Parse args.
-        mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
-        mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
-
-        // Get I2C bus.
-        int i2c_id = args[ARG_i2c].u_int;
-        if(i2c_id < 0 || i2c_id > 1) {
-            mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("I2C(%d) doesn't exist"), i2c_id);
-        }
-
-        int sda = args[ARG_sda].u_int;
-        if (!IS_VALID_SDA(i2c_id, sda)) {
-            mp_raise_ValueError(MP_ERROR_TEXT("bad SDA pin"));
-        }
-
-        int scl = args[ARG_scl].u_int;
-        if (!IS_VALID_SCL(i2c_id, scl)) {
-            mp_raise_ValueError(MP_ERROR_TEXT("bad SCL pin"));
-        }
-
-        self = m_new_obj(breakout_potentiometer_BreakoutPotentiometer_obj_t);
-        self->base.type = &breakout_potentiometer_BreakoutPotentiometer_type;
-
-        i2c_inst_t *i2c = (i2c_id == 0) ? i2c0 : i2c1;
-        self->breakout = new BreakoutPotentiometer(i2c, args[ARG_address].u_int, sda, scl, args[ARG_interrupt].u_int);
+    if(!IS_VALID_SDA(i2c_id, sda)) {
+        mp_raise_ValueError(MP_ERROR_TEXT("bad SDA pin"));
     }
+
+    if(!IS_VALID_SCL(i2c_id, scl)) {
+        mp_raise_ValueError(MP_ERROR_TEXT("bad SCL pin"));
+    }
+
+    self = m_new_obj(breakout_potentiometer_BreakoutPotentiometer_obj_t);
+    self->base.type = &breakout_potentiometer_BreakoutPotentiometer_type;
+
+    i2c_inst_t *i2c = (i2c_id == 0) ? i2c0 : i2c1;
+    self->breakout = new BreakoutPotentiometer(i2c, args[ARG_address].u_int, sda, scl, args[ARG_interrupt].u_int);
 
     if(!self->breakout->init()) {
         mp_raise_msg(&mp_type_RuntimeError, "Potentiometer breakout not found when initialising");

--- a/micropython/modules/breakout_rgbmatrix5x5/breakout_rgbmatrix5x5.cpp
+++ b/micropython/modules/breakout_rgbmatrix5x5/breakout_rgbmatrix5x5.cpp
@@ -65,7 +65,7 @@ mp_obj_t BreakoutRGBMatrix5x5_make_new(const mp_obj_type_t *type, size_t n_args,
     int scl = args[ARG_scl].u_int;
 
     if(i2c_id == -1) {
-        i2c_id = sda & 1;
+        i2c_id = (sda >> 1) & 0b1;  // If no i2c specified, choose the one for the given SDA pin
     }
     if(i2c_id < 0 || i2c_id > 1) {
         mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("I2C(%d) doesn't exist"), i2c_id);

--- a/micropython/modules/breakout_rgbmatrix5x5/breakout_rgbmatrix5x5.cpp
+++ b/micropython/modules/breakout_rgbmatrix5x5/breakout_rgbmatrix5x5.cpp
@@ -41,13 +41,13 @@ void BreakoutRGBMatrix5x5_print(const mp_print_t *print, mp_obj_t self_in, mp_pr
 mp_obj_t BreakoutRGBMatrix5x5_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     breakout_rgbmatrix5x5_BreakoutRGBMatrix5x5_obj_t *self = nullptr;
 
-    if(n_args == 0) {
+    if(n_args + n_kw == 0) {
         mp_arg_check_num(n_args, n_kw, 0, 0, true);
         self = m_new_obj(breakout_rgbmatrix5x5_BreakoutRGBMatrix5x5_obj_t);
         self->base.type = &breakout_rgbmatrix5x5_BreakoutRGBMatrix5x5_type;
-        self->breakout = new BreakoutRGBMatrix5x5();        
+        self->breakout = new BreakoutRGBMatrix5x5();
     }
-    else if(n_args == 1) {
+    else if(n_args + n_kw == 1) {
         enum { ARG_address };
         static const mp_arg_t allowed_args[] = {
             { MP_QSTR_address, MP_ARG_REQUIRED | MP_ARG_INT },
@@ -59,8 +59,8 @@ mp_obj_t BreakoutRGBMatrix5x5_make_new(const mp_obj_type_t *type, size_t n_args,
 
         self = m_new_obj(breakout_rgbmatrix5x5_BreakoutRGBMatrix5x5_obj_t);
         self->base.type = &breakout_rgbmatrix5x5_BreakoutRGBMatrix5x5_type;
-        
-        self->breakout = new BreakoutRGBMatrix5x5(args[ARG_address].u_int);     
+
+        self->breakout = new BreakoutRGBMatrix5x5(args[ARG_address].u_int);
     }
     else {
         enum { ARG_i2c, ARG_address, ARG_sda, ARG_scl };
@@ -89,7 +89,7 @@ mp_obj_t BreakoutRGBMatrix5x5_make_new(const mp_obj_type_t *type, size_t n_args,
         int scl = args[ARG_scl].u_int;
         if (!IS_VALID_SCL(i2c_id, scl)) {
             mp_raise_ValueError(MP_ERROR_TEXT("bad SCL pin"));
-        }        
+        }
 
         self = m_new_obj(breakout_rgbmatrix5x5_BreakoutRGBMatrix5x5_obj_t);
         self->base.type = &breakout_rgbmatrix5x5_BreakoutRGBMatrix5x5_type;
@@ -117,7 +117,7 @@ mp_obj_t BreakoutRGBMatrix5x5_set_pixel(size_t n_args, const mp_obj_t *pos_args,
 
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
-    
+
     breakout_rgbmatrix5x5_BreakoutRGBMatrix5x5_obj_t *self = MP_OBJ_TO_PTR2(args[ARG_self].u_obj, breakout_rgbmatrix5x5_BreakoutRGBMatrix5x5_obj_t);
 
     int x = args[ARG_x].u_int;

--- a/micropython/modules/breakout_rgbmatrix5x5/breakout_rgbmatrix5x5.cpp
+++ b/micropython/modules/breakout_rgbmatrix5x5/breakout_rgbmatrix5x5.cpp
@@ -1,4 +1,5 @@
 #include "libraries/breakout_rgbmatrix5x5/breakout_rgbmatrix5x5.hpp"
+#include <cstdio>
 
 #define MP_OBJ_TO_PTR2(o, t) ((t *)(uintptr_t)(o))
 
@@ -27,6 +28,11 @@ void BreakoutRGBMatrix5x5_print(const mp_print_t *print, mp_obj_t self_in, mp_pr
 
     mp_print_str(print, "i2c = ");
     mp_obj_print_helper(print, mp_obj_new_int((breakout->get_i2c() == i2c0) ? 0 : 1), PRINT_REPR);
+
+    mp_print_str(print, ", address = 0x");
+    char buf[3];
+    sprintf(buf, "%02X", breakout->get_address());
+    mp_print_str(print, buf);
 
     mp_print_str(print, ", sda = ");
     mp_obj_print_helper(print, mp_obj_new_int(breakout->get_sda()), PRINT_REPR);

--- a/micropython/modules/breakout_rgbmatrix5x5/breakout_rgbmatrix5x5.cpp
+++ b/micropython/modules/breakout_rgbmatrix5x5/breakout_rgbmatrix5x5.cpp
@@ -47,64 +47,47 @@ void BreakoutRGBMatrix5x5_print(const mp_print_t *print, mp_obj_t self_in, mp_pr
 mp_obj_t BreakoutRGBMatrix5x5_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     breakout_rgbmatrix5x5_BreakoutRGBMatrix5x5_obj_t *self = nullptr;
 
-    if(n_args + n_kw == 0) {
-        mp_arg_check_num(n_args, n_kw, 0, 0, true);
-        self = m_new_obj(breakout_rgbmatrix5x5_BreakoutRGBMatrix5x5_obj_t);
-        self->base.type = &breakout_rgbmatrix5x5_BreakoutRGBMatrix5x5_type;
-        self->breakout = new BreakoutRGBMatrix5x5();
+    enum { ARG_i2c, ARG_address, ARG_sda, ARG_scl };
+    static const mp_arg_t allowed_args[] = {
+        { MP_QSTR_i2c, MP_ARG_INT, {.u_int = -1} },
+        { MP_QSTR_address, MP_ARG_INT, {.u_int = BreakoutRGBMatrix5x5::DEFAULT_I2C_ADDRESS} },
+        { MP_QSTR_sda, MP_ARG_INT, {.u_int = 20} },
+        { MP_QSTR_scl, MP_ARG_INT, {.u_int = 21} },
+    };
+
+    // Parse args.
+    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+
+    // Get I2C bus.
+    int i2c_id = args[ARG_i2c].u_int;
+    int sda = args[ARG_sda].u_int;
+    int scl = args[ARG_scl].u_int;
+
+    if(i2c_id == -1) {
+        i2c_id = sda & 1;
     }
-    else if(n_args + n_kw == 1) {
-        enum { ARG_address };
-        static const mp_arg_t allowed_args[] = {
-            { MP_QSTR_address, MP_ARG_REQUIRED | MP_ARG_INT },
-        };
-
-        // Parse args.
-        mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
-        mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
-
-        self = m_new_obj(breakout_rgbmatrix5x5_BreakoutRGBMatrix5x5_obj_t);
-        self->base.type = &breakout_rgbmatrix5x5_BreakoutRGBMatrix5x5_type;
-
-        self->breakout = new BreakoutRGBMatrix5x5(args[ARG_address].u_int);
-    }
-    else {
-        enum { ARG_i2c, ARG_address, ARG_sda, ARG_scl };
-        static const mp_arg_t allowed_args[] = {
-            { MP_QSTR_i2c, MP_ARG_REQUIRED | MP_ARG_INT },
-            { MP_QSTR_address, MP_ARG_REQUIRED | MP_ARG_INT },
-            { MP_QSTR_sda, MP_ARG_REQUIRED | MP_ARG_INT },
-            { MP_QSTR_scl, MP_ARG_REQUIRED | MP_ARG_INT },
-        };
-
-        // Parse args.
-        mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
-        mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
-
-        // Get I2C bus.
-        int i2c_id = args[ARG_i2c].u_int;
-        if(i2c_id < 0 || i2c_id > 1) {
-            mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("I2C(%d) doesn't exist"), i2c_id);
-        }
-
-        int sda = args[ARG_sda].u_int;
-        if (!IS_VALID_SDA(i2c_id, sda)) {
-            mp_raise_ValueError(MP_ERROR_TEXT("bad SDA pin"));
-        }
-
-        int scl = args[ARG_scl].u_int;
-        if (!IS_VALID_SCL(i2c_id, scl)) {
-            mp_raise_ValueError(MP_ERROR_TEXT("bad SCL pin"));
-        }
-
-        self = m_new_obj(breakout_rgbmatrix5x5_BreakoutRGBMatrix5x5_obj_t);
-        self->base.type = &breakout_rgbmatrix5x5_BreakoutRGBMatrix5x5_type;
-        
-        i2c_inst_t *i2c = (i2c_id == 0) ? i2c0 : i2c1;
-        self->breakout = new BreakoutRGBMatrix5x5(i2c, args[ARG_address].u_int, sda, scl);
+    if(i2c_id < 0 || i2c_id > 1) {
+        mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("I2C(%d) doesn't exist"), i2c_id);
     }
 
-    self->breakout->init();
+    if(!IS_VALID_SDA(i2c_id, sda)) {
+        mp_raise_ValueError(MP_ERROR_TEXT("bad SDA pin"));
+    }
+
+    if(!IS_VALID_SCL(i2c_id, scl)) {
+        mp_raise_ValueError(MP_ERROR_TEXT("bad SCL pin"));
+    }
+
+    self = m_new_obj(breakout_rgbmatrix5x5_BreakoutRGBMatrix5x5_obj_t);
+    self->base.type = &breakout_rgbmatrix5x5_BreakoutRGBMatrix5x5_type;
+    
+    i2c_inst_t *i2c = (i2c_id == 0) ? i2c0 : i2c1;
+    self->breakout = new BreakoutRGBMatrix5x5(i2c, args[ARG_address].u_int, sda, scl);
+
+    if(!self->breakout->init()) {
+        mp_raise_msg(&mp_type_RuntimeError, "RGBMatrix5x5 breakout not found when initialising");
+    }
 
     return MP_OBJ_FROM_PTR(self);
 }

--- a/micropython/modules/breakout_roundlcd/breakout_roundlcd.cpp
+++ b/micropython/modules/breakout_roundlcd/breakout_roundlcd.cpp
@@ -51,7 +51,7 @@ void BreakoutRoundLCD_print(const mp_print_t *print, mp_obj_t self_in, mp_print_
 mp_obj_t BreakoutRoundLCD_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     breakout_roundlcd_BreakoutRoundLCD_obj_t *self = nullptr;
 
-    if(n_args <= 1) {
+    if(n_args + n_kw <= 1) {
         enum { ARG_buffer };
         static const mp_arg_t allowed_args[] = {
             { MP_QSTR_buffer, MP_ARG_REQUIRED | MP_ARG_OBJ },
@@ -69,7 +69,7 @@ mp_obj_t BreakoutRoundLCD_make_new(const mp_obj_type_t *type, size_t n_args, siz
 
         self->breakout = new BreakoutRoundLCD((uint16_t *)bufinfo.buf);     
     }
-    else if(n_args == 2) {
+    else if(n_args + n_kw == 2) {
         enum { ARG_buffer, ARG_slot };
         static const mp_arg_t allowed_args[] = {
             { MP_QSTR_buffer, MP_ARG_REQUIRED | MP_ARG_OBJ },
@@ -329,7 +329,7 @@ mp_obj_t BreakoutRoundLCD_pixel_span(size_t n_args, const mp_obj_t *pos_args, mp
 
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
-    
+
     breakout_roundlcd_BreakoutRoundLCD_obj_t *self = MP_OBJ_TO_PTR2(args[ARG_self].u_obj, breakout_roundlcd_BreakoutRoundLCD_obj_t);
 
     int x = args[ARG_x].u_int;

--- a/micropython/modules/breakout_rtc/breakout_rtc.cpp
+++ b/micropython/modules/breakout_rtc/breakout_rtc.cpp
@@ -47,49 +47,47 @@ void BreakoutRTC_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_
 mp_obj_t BreakoutRTC_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     breakout_rtc_BreakoutRTC_obj_t *self = nullptr;
 
-    if(n_args + n_kw == 0) {
-        mp_arg_check_num(n_args, n_kw, 0, 0, true);
-        self = m_new_obj(breakout_rtc_BreakoutRTC_obj_t);
-        self->base.type = &breakout_rtc_BreakoutRTC_type;
-        self->breakout = new BreakoutRTC();
+    enum { ARG_i2c, ARG_sda, ARG_scl, ARG_interrupt };
+    static const mp_arg_t allowed_args[] = {
+        { MP_QSTR_i2c, MP_ARG_INT, {.u_int = -1} },
+        { MP_QSTR_sda, MP_ARG_INT, {.u_int = 20} },
+        { MP_QSTR_scl, MP_ARG_INT, {.u_int = 21} },
+        { MP_QSTR_interrupt, MP_ARG_INT, {.u_int = BreakoutRTC::PIN_UNUSED} },
+    };
+
+    // Parse args.
+    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+
+    // Get I2C bus.
+    int i2c_id = args[ARG_i2c].u_int;
+    int sda = args[ARG_sda].u_int;
+    int scl = args[ARG_scl].u_int;
+
+    if(i2c_id == -1) {
+        i2c_id = sda & 1;
     }
-    else {
-        enum { ARG_i2c, ARG_sda, ARG_scl, ARG_interrupt };
-        static const mp_arg_t allowed_args[] = {
-            { MP_QSTR_i2c, MP_ARG_REQUIRED | MP_ARG_INT },
-            { MP_QSTR_sda, MP_ARG_REQUIRED | MP_ARG_INT },
-            { MP_QSTR_scl, MP_ARG_REQUIRED | MP_ARG_INT },
-            { MP_QSTR_interrupt, MP_ARG_INT, {.u_int = BreakoutRTC::PIN_UNUSED} },
-        };
-
-        // Parse args.
-        mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
-        mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
-
-        // Get I2C bus.
-        int i2c_id = args[ARG_i2c].u_int;
-        if(i2c_id < 0 || i2c_id > 1) {
-            mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("I2C(%d) doesn't exist"), i2c_id);
-        }
-
-        int sda = args[ARG_sda].u_int;
-        if (!IS_VALID_SDA(i2c_id, sda)) {
-            mp_raise_ValueError(MP_ERROR_TEXT("bad SDA pin"));
-        }
-
-        int scl = args[ARG_scl].u_int;
-        if (!IS_VALID_SCL(i2c_id, scl)) {
-            mp_raise_ValueError(MP_ERROR_TEXT("bad SCL pin"));
-        }
-
-        self = m_new_obj(breakout_rtc_BreakoutRTC_obj_t);
-        self->base.type = &breakout_rtc_BreakoutRTC_type;
-
-        i2c_inst_t *i2c = (i2c_id == 0) ? i2c0 : i2c1;
-        self->breakout = new BreakoutRTC(i2c, sda, scl, args[ARG_interrupt].u_int);
+    if(i2c_id < 0 || i2c_id > 1) {
+        mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("I2C(%d) doesn't exist"), i2c_id);
     }
 
-    self->breakout->init();
+    if(!IS_VALID_SDA(i2c_id, sda)) {
+        mp_raise_ValueError(MP_ERROR_TEXT("bad SDA pin"));
+    }
+
+    if(!IS_VALID_SCL(i2c_id, scl)) {
+        mp_raise_ValueError(MP_ERROR_TEXT("bad SCL pin"));
+    }
+
+    self = m_new_obj(breakout_rtc_BreakoutRTC_obj_t);
+    self->base.type = &breakout_rtc_BreakoutRTC_type;
+
+    i2c_inst_t *i2c = (i2c_id == 0) ? i2c0 : i2c1;
+    self->breakout = new BreakoutRTC(i2c, sda, scl, args[ARG_interrupt].u_int);
+
+    if(!self->breakout->init()) {
+        mp_raise_msg(&mp_type_RuntimeError, "RTC breakout not found when initialising");
+    }
 
     return MP_OBJ_FROM_PTR(self);
 }

--- a/micropython/modules/breakout_rtc/breakout_rtc.cpp
+++ b/micropython/modules/breakout_rtc/breakout_rtc.cpp
@@ -47,7 +47,7 @@ void BreakoutRTC_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_
 mp_obj_t BreakoutRTC_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     breakout_rtc_BreakoutRTC_obj_t *self = nullptr;
 
-    if(n_args == 0) {
+    if(n_args + n_kw == 0) {
         mp_arg_check_num(n_args, n_kw, 0, 0, true);
         self = m_new_obj(breakout_rtc_BreakoutRTC_obj_t);
         self->base.type = &breakout_rtc_BreakoutRTC_type;
@@ -80,11 +80,11 @@ mp_obj_t BreakoutRTC_make_new(const mp_obj_type_t *type, size_t n_args, size_t n
         int scl = args[ARG_scl].u_int;
         if (!IS_VALID_SCL(i2c_id, scl)) {
             mp_raise_ValueError(MP_ERROR_TEXT("bad SCL pin"));
-        }        
+        }
 
         self = m_new_obj(breakout_rtc_BreakoutRTC_obj_t);
         self->base.type = &breakout_rtc_BreakoutRTC_type;
-        
+
         i2c_inst_t *i2c = (i2c_id == 0) ? i2c0 : i2c1;
         self->breakout = new BreakoutRTC(i2c, sda, scl, args[ARG_interrupt].u_int);
     }
@@ -537,10 +537,10 @@ mp_obj_t BreakoutRTC_set_timer(size_t n_args, const mp_obj_t *pos_args, mp_map_t
     }
     else {
         switch(timer_frequency) {
-            case 4096:    // 4096Hz (default)    // up to 122us error on first time
+            case 4096:  // 4096Hz (default)    // up to 122us error on first time
             case 64:    // 64Hz          // up to 7.813ms error on first time
-            case 1:      // 1Hz          // up to 7.813ms error on first time
-            case 60000:    // 1/60Hz        // up to 7.813ms error on first time
+            case 1:     // 1Hz          // up to 7.813ms error on first time
+            case 60000: // 1/60Hz        // up to 7.813ms error on first time
                 self->breakout->set_timer(timer_repeat, timer_frequency, timer_value, set_interrupt, start_timer, enable_clock_output);
                 break;
 

--- a/micropython/modules/breakout_rtc/breakout_rtc.cpp
+++ b/micropython/modules/breakout_rtc/breakout_rtc.cpp
@@ -65,7 +65,7 @@ mp_obj_t BreakoutRTC_make_new(const mp_obj_type_t *type, size_t n_args, size_t n
     int scl = args[ARG_scl].u_int;
 
     if(i2c_id == -1) {
-        i2c_id = sda & 1;
+        i2c_id = (sda >> 1) & 0b1;  // If no i2c specified, choose the one for the given SDA pin
     }
     if(i2c_id < 0 || i2c_id > 1) {
         mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("I2C(%d) doesn't exist"), i2c_id);

--- a/micropython/modules/breakout_sgp30/breakout_sgp30.cpp
+++ b/micropython/modules/breakout_sgp30/breakout_sgp30.cpp
@@ -41,7 +41,7 @@ void BreakoutSGP30_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kin
 mp_obj_t BreakoutSGP30_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     breakout_sgp30_BreakoutSGP30_obj_t *self = nullptr;
 
-    if(n_args == 0) {
+    if(n_args + n_kw == 0) {
         mp_arg_check_num(n_args, n_kw, 0, 0, true);
         self = m_new_obj(breakout_sgp30_BreakoutSGP30_obj_t);
         self->base.type = &breakout_sgp30_BreakoutSGP30_type;
@@ -115,7 +115,7 @@ mp_obj_t BreakoutSGP30_start_measurement(size_t n_args, const mp_obj_t *pos_args
 
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
-    
+
     breakout_sgp30_BreakoutSGP30_obj_t *self = MP_OBJ_TO_PTR2(args[ARG_self].u_obj, breakout_sgp30_BreakoutSGP30_obj_t);
     self->breakout->start_measurement(args[ARG_wait_for_setup].u_bool);
 
@@ -153,7 +153,7 @@ mp_obj_t BreakoutSGP30_get_air_quality_raw(mp_obj_t self_in) {
 mp_obj_t BreakoutSGP30_soft_reset(mp_obj_t self_in) {
     breakout_sgp30_BreakoutSGP30_obj_t *self = MP_OBJ_TO_PTR2(self_in, breakout_sgp30_BreakoutSGP30_obj_t);
     self->breakout->soft_reset();
-    
+
     return mp_const_none;
 }
 
@@ -183,7 +183,7 @@ mp_obj_t BreakoutSGP30_set_baseline(size_t n_args, const mp_obj_t *pos_args, mp_
 
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
-    
+
     breakout_sgp30_BreakoutSGP30_obj_t *self = MP_OBJ_TO_PTR2(args[ARG_self].u_obj, breakout_sgp30_BreakoutSGP30_obj_t);
     self->breakout->set_baseline(args[ARG_eco2].u_int, args[ARG_tvoc].u_int);
 
@@ -199,7 +199,7 @@ mp_obj_t BreakoutSGP30_set_humidity(size_t n_args, const mp_obj_t *pos_args, mp_
 
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
-    
+
     breakout_sgp30_BreakoutSGP30_obj_t *self = MP_OBJ_TO_PTR2(args[ARG_self].u_obj, breakout_sgp30_BreakoutSGP30_obj_t);
     self->breakout->set_humidity(args[ARG_absolute_humidity].u_int);
 

--- a/micropython/modules/breakout_sgp30/breakout_sgp30.cpp
+++ b/micropython/modules/breakout_sgp30/breakout_sgp30.cpp
@@ -41,49 +41,45 @@ void BreakoutSGP30_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kin
 mp_obj_t BreakoutSGP30_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     breakout_sgp30_BreakoutSGP30_obj_t *self = nullptr;
 
-    if(n_args + n_kw == 0) {
-        mp_arg_check_num(n_args, n_kw, 0, 0, true);
-        self = m_new_obj(breakout_sgp30_BreakoutSGP30_obj_t);
-        self->base.type = &breakout_sgp30_BreakoutSGP30_type;
-        self->breakout = new BreakoutSGP30();
+    enum { ARG_i2c, ARG_sda, ARG_scl };
+    static const mp_arg_t allowed_args[] = {
+        { MP_QSTR_i2c, MP_ARG_INT, {.u_int = -1} },
+        { MP_QSTR_sda, MP_ARG_INT, {.u_int = 20} },
+        { MP_QSTR_scl, MP_ARG_INT, {.u_int = 21} },
+    };
+
+    // Parse args.
+    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+
+    // Get I2C bus.
+    int i2c_id = args[ARG_i2c].u_int;
+    int sda = args[ARG_sda].u_int;
+    int scl = args[ARG_scl].u_int;
+
+    if(i2c_id == -1) {
+        i2c_id = sda & 1;
     }
-    else {
-        enum { ARG_i2c, ARG_sda, ARG_scl };
-        static const mp_arg_t allowed_args[] = {
-            { MP_QSTR_i2c, MP_ARG_REQUIRED | MP_ARG_INT },
-            { MP_QSTR_sda, MP_ARG_REQUIRED | MP_ARG_INT },
-            { MP_QSTR_scl, MP_ARG_REQUIRED | MP_ARG_INT },
-        };
-
-        // Parse args.
-        mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
-        mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
-
-        // Get I2C bus.
-        int i2c_id = args[ARG_i2c].u_int;
-        if(i2c_id < 0 || i2c_id > 1) {
-            mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("I2C(%d) doesn't exist"), i2c_id);
-        }
-
-        int sda = args[ARG_sda].u_int;
-        if (!IS_VALID_SDA(i2c_id, sda)) {
-            mp_raise_ValueError(MP_ERROR_TEXT("bad SDA pin"));
-        }
-
-        int scl = args[ARG_scl].u_int;
-        if (!IS_VALID_SCL(i2c_id, scl)) {
-            mp_raise_ValueError(MP_ERROR_TEXT("bad SCL pin"));
-        }
-
-        self = m_new_obj(breakout_sgp30_BreakoutSGP30_obj_t);
-        self->base.type = &breakout_sgp30_BreakoutSGP30_type;
-        
-        i2c_inst_t *i2c = (i2c_id == 0) ? i2c0 : i2c1;
-        self->breakout = new BreakoutSGP30(i2c, sda, scl);
+    if(i2c_id < 0 || i2c_id > 1) {
+        mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("I2C(%d) doesn't exist"), i2c_id);
     }
+
+    if(!IS_VALID_SDA(i2c_id, sda)) {
+        mp_raise_ValueError(MP_ERROR_TEXT("bad SDA pin"));
+    }
+
+    if(!IS_VALID_SCL(i2c_id, scl)) {
+        mp_raise_ValueError(MP_ERROR_TEXT("bad SCL pin"));
+    }
+
+    self = m_new_obj(breakout_sgp30_BreakoutSGP30_obj_t);
+    self->base.type = &breakout_sgp30_BreakoutSGP30_type;
+    
+    i2c_inst_t *i2c = (i2c_id == 0) ? i2c0 : i2c1;
+    self->breakout = new BreakoutSGP30(i2c, sda, scl);
 
     if(!self->breakout->init()) {
-        mp_raise_msg(&mp_type_RuntimeError, "SGP30 not found when initialising");
+        mp_raise_msg(&mp_type_RuntimeError, "SGP30 breakout not found when initialising");
     }
 
     return MP_OBJ_FROM_PTR(self);

--- a/micropython/modules/breakout_sgp30/breakout_sgp30.cpp
+++ b/micropython/modules/breakout_sgp30/breakout_sgp30.cpp
@@ -58,7 +58,7 @@ mp_obj_t BreakoutSGP30_make_new(const mp_obj_type_t *type, size_t n_args, size_t
     int scl = args[ARG_scl].u_int;
 
     if(i2c_id == -1) {
-        i2c_id = sda & 1;
+        i2c_id = (sda >> 1) & 0b1;  // If no i2c specified, choose the one for the given SDA pin
     }
     if(i2c_id < 0 || i2c_id > 1) {
         mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("I2C(%d) doesn't exist"), i2c_id);

--- a/micropython/modules/breakout_trackball/breakout_trackball.cpp
+++ b/micropython/modules/breakout_trackball/breakout_trackball.cpp
@@ -50,65 +50,48 @@ void BreakoutTrackball_print(const mp_print_t *print, mp_obj_t self_in, mp_print
 mp_obj_t BreakoutTrackball_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     breakout_trackball_BreakoutTrackball_obj_t *self = nullptr;
 
-    if(n_args + n_kw == 0) {
-        mp_arg_check_num(n_args, n_kw, 0, 0, true);
-        self = m_new_obj(breakout_trackball_BreakoutTrackball_obj_t);
-        self->base.type = &breakout_trackball_BreakoutTrackball_type;
-        self->breakout = new BreakoutTrackball();
+    enum { ARG_i2c, ARG_address, ARG_sda, ARG_scl, ARG_interrupt };
+    static const mp_arg_t allowed_args[] = {
+        { MP_QSTR_i2c, MP_ARG_INT, {.u_int = -1} },
+        { MP_QSTR_address, MP_ARG_INT, {.u_int = BreakoutTrackball::DEFAULT_I2C_ADDRESS} },
+        { MP_QSTR_sda, MP_ARG_INT, {.u_int = 20} },
+        { MP_QSTR_scl, MP_ARG_INT, {.u_int = 21} },
+        { MP_QSTR_interrupt, MP_ARG_INT, {.u_int = BreakoutTrackball::PIN_UNUSED} },
+    };
+
+    // Parse args.
+    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+
+    // Get I2C bus.
+    int i2c_id = args[ARG_i2c].u_int;
+    int sda = args[ARG_sda].u_int;
+    int scl = args[ARG_scl].u_int;
+
+    if(i2c_id == -1) {
+        i2c_id = sda & 1;
     }
-    else if(n_args + n_kw == 1) {
-        enum { ARG_address };
-        static const mp_arg_t allowed_args[] = {
-            { MP_QSTR_address, MP_ARG_REQUIRED | MP_ARG_INT },
-        };
-
-        // Parse args.
-        mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
-        mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
-
-        self = m_new_obj(breakout_trackball_BreakoutTrackball_obj_t);
-        self->base.type = &breakout_trackball_BreakoutTrackball_type;
-
-        self->breakout = new BreakoutTrackball(args[ARG_address].u_int);
-    }
-    else {
-        enum { ARG_i2c, ARG_address, ARG_sda, ARG_scl, ARG_interrupt };
-        static const mp_arg_t allowed_args[] = {
-            { MP_QSTR_i2c, MP_ARG_REQUIRED | MP_ARG_INT },
-            { MP_QSTR_address, MP_ARG_REQUIRED | MP_ARG_INT },
-            { MP_QSTR_sda, MP_ARG_REQUIRED | MP_ARG_INT },
-            { MP_QSTR_scl, MP_ARG_REQUIRED | MP_ARG_INT },
-            { MP_QSTR_interrupt, MP_ARG_INT, {.u_int = BreakoutTrackball::PIN_UNUSED} },
-        };
-
-        // Parse args.
-        mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
-        mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
-
-        // Get I2C bus.
-        int i2c_id = args[ARG_i2c].u_int;
-        if(i2c_id < 0 || i2c_id > 1) {
-            mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("I2C(%d) doesn't exist"), i2c_id);
-        }
-
-        int sda = args[ARG_sda].u_int;
-        if (!IS_VALID_SDA(i2c_id, sda)) {
-            mp_raise_ValueError(MP_ERROR_TEXT("bad SDA pin"));
-        }
-
-        int scl = args[ARG_scl].u_int;
-        if (!IS_VALID_SCL(i2c_id, scl)) {
-            mp_raise_ValueError(MP_ERROR_TEXT("bad SCL pin"));
-        }
-
-        self = m_new_obj(breakout_trackball_BreakoutTrackball_obj_t);
-        self->base.type = &breakout_trackball_BreakoutTrackball_type;
-        
-        i2c_inst_t *i2c = (i2c_id == 0) ? i2c0 : i2c1;
-        self->breakout = new BreakoutTrackball(i2c, args[ARG_address].u_int, sda, scl, args[ARG_interrupt].u_int);
+    if(i2c_id < 0 || i2c_id > 1) {
+        mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("I2C(%d) doesn't exist"), i2c_id);
     }
 
-    self->breakout->init();
+    if(!IS_VALID_SDA(i2c_id, sda)) {
+        mp_raise_ValueError(MP_ERROR_TEXT("bad SDA pin"));
+    }
+
+    if(!IS_VALID_SCL(i2c_id, scl)) {
+        mp_raise_ValueError(MP_ERROR_TEXT("bad SCL pin"));
+    }
+
+    self = m_new_obj(breakout_trackball_BreakoutTrackball_obj_t);
+    self->base.type = &breakout_trackball_BreakoutTrackball_type;
+
+    i2c_inst_t *i2c = (i2c_id == 0) ? i2c0 : i2c1;
+    self->breakout = new BreakoutTrackball(i2c, args[ARG_address].u_int, sda, scl, args[ARG_interrupt].u_int);
+
+    if(!self->breakout->init()) {
+        mp_raise_msg(&mp_type_RuntimeError, "Trackball breakout not found when initialising");
+    }
 
     return MP_OBJ_FROM_PTR(self);
 }

--- a/micropython/modules/breakout_trackball/breakout_trackball.cpp
+++ b/micropython/modules/breakout_trackball/breakout_trackball.cpp
@@ -1,4 +1,5 @@
 #include "libraries/breakout_trackball/breakout_trackball.hpp"
+#include <cstdio>
 
 #define MP_OBJ_TO_PTR2(o, t) ((t *)(uintptr_t)(o))
 
@@ -27,6 +28,11 @@ void BreakoutTrackball_print(const mp_print_t *print, mp_obj_t self_in, mp_print
 
     mp_print_str(print, "i2c = ");
     mp_obj_print_helper(print, mp_obj_new_int((breakout->get_i2c() == i2c0) ? 0 : 1), PRINT_REPR);
+
+    mp_print_str(print, ", address = 0x");
+    char buf[3];
+    sprintf(buf, "%02X", breakout->get_address());
+    mp_print_str(print, buf);
 
     mp_print_str(print, ", sda = ");
     mp_obj_print_helper(print, mp_obj_new_int(breakout->get_sda()), PRINT_REPR);

--- a/micropython/modules/breakout_trackball/breakout_trackball.cpp
+++ b/micropython/modules/breakout_trackball/breakout_trackball.cpp
@@ -69,7 +69,7 @@ mp_obj_t BreakoutTrackball_make_new(const mp_obj_type_t *type, size_t n_args, si
     int scl = args[ARG_scl].u_int;
 
     if(i2c_id == -1) {
-        i2c_id = sda & 1;
+        i2c_id = (sda >> 1) & 0b1;  // If no i2c specified, choose the one for the given SDA pin
     }
     if(i2c_id < 0 || i2c_id > 1) {
         mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("I2C(%d) doesn't exist"), i2c_id);

--- a/micropython/modules/breakout_trackball/breakout_trackball.cpp
+++ b/micropython/modules/breakout_trackball/breakout_trackball.cpp
@@ -44,13 +44,13 @@ void BreakoutTrackball_print(const mp_print_t *print, mp_obj_t self_in, mp_print
 mp_obj_t BreakoutTrackball_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     breakout_trackball_BreakoutTrackball_obj_t *self = nullptr;
 
-    if(n_args == 0) {
+    if(n_args + n_kw == 0) {
         mp_arg_check_num(n_args, n_kw, 0, 0, true);
         self = m_new_obj(breakout_trackball_BreakoutTrackball_obj_t);
         self->base.type = &breakout_trackball_BreakoutTrackball_type;
-        self->breakout = new BreakoutTrackball();        
+        self->breakout = new BreakoutTrackball();
     }
-    else if(n_args == 1) {
+    else if(n_args + n_kw == 1) {
         enum { ARG_address };
         static const mp_arg_t allowed_args[] = {
             { MP_QSTR_address, MP_ARG_REQUIRED | MP_ARG_INT },
@@ -62,8 +62,8 @@ mp_obj_t BreakoutTrackball_make_new(const mp_obj_type_t *type, size_t n_args, si
 
         self = m_new_obj(breakout_trackball_BreakoutTrackball_obj_t);
         self->base.type = &breakout_trackball_BreakoutTrackball_type;
-        
-        self->breakout = new BreakoutTrackball(args[ARG_address].u_int);     
+
+        self->breakout = new BreakoutTrackball(args[ARG_address].u_int);
     }
     else {
         enum { ARG_i2c, ARG_address, ARG_sda, ARG_scl, ARG_interrupt };
@@ -93,7 +93,7 @@ mp_obj_t BreakoutTrackball_make_new(const mp_obj_type_t *type, size_t n_args, si
         int scl = args[ARG_scl].u_int;
         if (!IS_VALID_SCL(i2c_id, scl)) {
             mp_raise_ValueError(MP_ERROR_TEXT("bad SCL pin"));
-        }        
+        }
 
         self = m_new_obj(breakout_trackball_BreakoutTrackball_obj_t);
         self->base.type = &breakout_trackball_BreakoutTrackball_type;
@@ -117,7 +117,7 @@ mp_obj_t BreakoutTrackball_change_address(size_t n_args, const mp_obj_t *pos_arg
 
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
-    
+
     breakout_trackball_BreakoutTrackball_obj_t *self = MP_OBJ_TO_PTR2(args[ARG_self].u_obj, breakout_trackball_BreakoutTrackball_obj_t);
 
     self->breakout->change_address(args[ARG_address].u_int);
@@ -134,7 +134,7 @@ mp_obj_t BreakoutTrackball_enable_interrupt(size_t n_args, const mp_obj_t *pos_a
 
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
-    
+
     breakout_trackball_BreakoutTrackball_obj_t *self = MP_OBJ_TO_PTR2(args[ARG_self].u_obj, breakout_trackball_BreakoutTrackball_obj_t);
 
     self->breakout->enable_interrupt(args[ARG_interrupt].u_bool);
@@ -191,7 +191,7 @@ mp_obj_t BreakoutTrackball_set_red(size_t n_args, const mp_obj_t *pos_args, mp_m
 
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
-    
+
     breakout_trackball_BreakoutTrackball_obj_t *self = MP_OBJ_TO_PTR2(args[ARG_self].u_obj, breakout_trackball_BreakoutTrackball_obj_t);
 
     int value = args[ARG_value].u_int;
@@ -213,7 +213,7 @@ mp_obj_t BreakoutTrackball_set_green(size_t n_args, const mp_obj_t *pos_args, mp
 
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
-    
+
     breakout_trackball_BreakoutTrackball_obj_t *self = MP_OBJ_TO_PTR2(args[ARG_self].u_obj, breakout_trackball_BreakoutTrackball_obj_t);
 
     int value = args[ARG_value].u_int;
@@ -235,7 +235,7 @@ mp_obj_t BreakoutTrackball_set_blue(size_t n_args, const mp_obj_t *pos_args, mp_
 
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
-    
+
     breakout_trackball_BreakoutTrackball_obj_t *self = MP_OBJ_TO_PTR2(args[ARG_self].u_obj, breakout_trackball_BreakoutTrackball_obj_t);
 
     int value = args[ARG_value].u_int;
@@ -257,7 +257,7 @@ mp_obj_t BreakoutTrackball_set_white(size_t n_args, const mp_obj_t *pos_args, mp
 
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
-    
+
     breakout_trackball_BreakoutTrackball_obj_t *self = MP_OBJ_TO_PTR2(args[ARG_self].u_obj, breakout_trackball_BreakoutTrackball_obj_t);
 
     int value = args[ARG_value].u_int;
@@ -281,7 +281,7 @@ mp_obj_t BreakoutTrackball_read(mp_obj_t self_in) {
     tuple[DOWN] = mp_obj_new_int(state.down);
     tuple[SW_CHANGED] = mp_obj_new_int(state.sw_changed);
     tuple[SW_PRESSED] = mp_obj_new_int(state.sw_pressed);
-    
+
     return mp_obj_new_tuple(6, tuple);
 }
 }


### PR DESCRIPTION
And removed some whitespace