### PR TITLE
Cleanup i2c pins and deinit i2c on init failure

### DIFF
--- a/drivers/ioexpander/ioexpander.cpp
+++ b/drivers/ioexpander/ioexpander.cpp
@@ -348,6 +348,11 @@ namespace pimoroni {
         if(debug) {
           printf("Chip ID invalid: %04x expected: %04x\n", chip_id, CHIP_ID);
         }
+        i2c_deinit(i2c);
+        gpio_disable_pulls(sda);
+        gpio_set_function(sda, GPIO_FUNC_NULL);
+        gpio_disable_pulls(scl);
+        gpio_set_function(scl, GPIO_FUNC_NULL);
         succeeded = false;
       }
     }

--- a/drivers/rv3028/rv3028.cpp
+++ b/drivers/rv3028/rv3028.cpp
@@ -77,6 +77,11 @@ namespace pimoroni {
     uint8_t chip_id = 0;
     read_bytes(RV3028_ID, &chip_id, 1);
     if(chip_id != (RV3028_CHIP_ID | RV3028_VERSION)) {
+      i2c_deinit(i2c);
+      gpio_disable_pulls(sda);
+      gpio_set_function(sda, GPIO_FUNC_NULL);
+      gpio_disable_pulls(scl);
+      gpio_set_function(scl, GPIO_FUNC_NULL);
       return false;
     }
 

--- a/drivers/trackball/trackball.cpp
+++ b/drivers/trackball/trackball.cpp
@@ -40,8 +40,6 @@ namespace pimoroni {
   };
 
   bool Trackball::init() {
-    bool succeeded = false;
-
     i2c_init(i2c, 100000);
 
     gpio_set_function(sda, GPIO_FUNC_I2C);
@@ -58,10 +56,16 @@ namespace pimoroni {
     uint16_t chip_id = ((uint16_t)i2c_reg_read_uint8(reg::CHIP_ID_H) << 8) | (uint16_t)i2c_reg_read_uint8(reg::CHIP_ID_L);
     if(chip_id == CHIP_ID) {
       enable_interrupt();
-      succeeded = true;
+      return true;
     }
 
-    return succeeded;
+    // Setup failed, clean up after ourselves
+    i2c_deinit(i2c);
+    gpio_disable_pulls(sda);
+    gpio_set_function(sda, GPIO_FUNC_NULL);
+    gpio_disable_pulls(scl);
+    gpio_set_function(scl, GPIO_FUNC_NULL);
+    return false;
   }
 
   i2c_inst_t* Trackball::get_i2c() const {

--- a/drivers/vl53l1x/vl53l1x.cpp
+++ b/drivers/vl53l1x/vl53l1x.cpp
@@ -67,6 +67,11 @@ namespace pimoroni {
       if (checkTimeoutExpired())
       {
         did_timeout = true;
+        i2c_deinit(i2c);
+        gpio_disable_pulls(sda);
+        gpio_set_function(sda, GPIO_FUNC_NULL);
+        gpio_disable_pulls(scl);
+        gpio_set_function(scl, GPIO_FUNC_NULL);
         return false;
       }
     }


### PR DESCRIPTION
MicroPython doesn't offer any way for C modules to clean up after themselves and often requires a hard reset to get out of a bad state.

This patch attempts to deinit i2c and pins when a device init fails, this allows a user to fail to init a device (with the wrong pins)
and continue to try the correct initialisation without first having to *hard* reset their board.