### PR TITLE
Reset unused I2C pins to default when an instance is initialised

### DIFF
--- a/common/pimoroni_i2c.hpp
+++ b/common/pimoroni_i2c.hpp
@@ -47,6 +47,8 @@ namespace pimoroni {
           gpio_set_function(scl, GPIO_FUNC_NULL);
         }
 
+        i2c_inst_t* pin_to_inst(uint pin);
+
         void reg_write_uint8(uint8_t address, uint8_t reg, uint8_t value);
         uint8_t reg_read_uint8(uint8_t address, uint8_t reg);
         uint16_t reg_read_uint16(uint8_t address, uint8_t reg);


### PR DESCRIPTION
This change is specifically intended to avoid a pitfall in MicroPython and will likely have no effect in C++.

When using the REPL in MicroPython it's possible to set up an I2C instance on two pins - ie: 20, 21 - and then subsequently realise these are the wrong pins for your board.

Before this change, these pins would be left hanging even if you created a new I2C instance with new pins - ie: 4, 5 - this would lead to communications failures where they really shouldn't happen. Confusing!