### PR TITLE
Fix: Build error from ioexpander.cpp

### DIFF
--- a/drivers/ioexpander/ioexpander.cpp
+++ b/drivers/ioexpander/ioexpander.cpp
@@ -1,3 +1,4 @@
+#include <cstdio>
 #include <cstdlib>
 #include <math.h>
 #include <map>
@@ -11,7 +12,7 @@ namespace pimoroni {
     CHIP_ID_L = 0xfa,
     CHIP_ID_H = 0xfb,
     VERSION = 0xfc,
-    
+
     // Rotary encoder
     ENC_EN = 0x04,
     // BIT_ENC_EN_1 = 0
@@ -215,7 +216,7 @@ namespace pimoroni {
     ADDRWR = 0x10,
   };
 
-  static const uint8_t NUM_BIT_ADDRESSED_REGISTERS = 4;  
+  static const uint8_t NUM_BIT_ADDRESSED_REGISTERS = 4;
   static const uint8_t BIT_ADDRESSED_REGS[NUM_BIT_ADDRESSED_REGISTERS] = {reg::P0, reg::P1, reg::P2, reg::P3};
   static const uint8_t ENC_CFG[4] = {reg::ENC_1_CFG, reg::ENC_2_CFG, reg::ENC_3_CFG, reg::ENC_4_CFG};
   static const uint8_t ENC_COUNT[4] = {reg::ENC_1_COUNT, reg::ENC_2_COUNT, reg::ENC_3_COUNT, reg::ENC_4_COUNT};
@@ -366,7 +367,7 @@ namespace pimoroni {
   uint16_t IOExpander::get_chip_id() {
       return ((uint16_t)i2c->reg_read_uint8(address, reg::CHIP_ID_H) << 8) | (uint16_t)i2c->reg_read_uint8(address, reg::CHIP_ID_L);
   }
-  
+
   void IOExpander::set_address(uint8_t address) {
     set_bit(reg::CTRL, 4);
     i2c->reg_write_uint8(address, reg::ADDR, address);
@@ -383,7 +384,7 @@ namespace pimoroni {
   void IOExpander::set_adc_vref(float vref) {
     this->vref = vref;
   }
-    
+
   void IOExpander::enable_interrupt_out(bool pin_swap) {
     set_bit(reg::INT, int_bit::OUT_EN);
     change_bit(reg::INT, int_bit::PIN_SWAP, pin_swap);
@@ -409,10 +410,10 @@ namespace pimoroni {
     if(pin >= 1 && pin <= NUM_PINS) {
       Pin& io_pin = pins[pin - 1];
       change_bit(io_pin.reg_int_mask_p, io_pin.pin, enabled);
-      
+
       succeeded = true;
     }
-    
+
     return succeeded;
   }
 
@@ -515,7 +516,7 @@ namespace pimoroni {
     }
 
     Pin& io_pin = pins[pin - 1];
-    
+
     uint8_t gpio_mode = mode & 0b11;
     uint8_t io_type = (mode >> 2) & 0b11;
     uint8_t initial_state = mode >> 4;
@@ -584,7 +585,7 @@ namespace pimoroni {
       if(debug) {
         printf("Reading ADC from pin %d\n", pin);
       }
-        
+
       clr_bits(reg::ADCCON0, 0x0f);
       set_bits(reg::ADCCON0, io_pin.adc_channel);
       i2c->reg_write_uint8(address, reg::AINDIDS, 0);
@@ -613,7 +614,7 @@ namespace pimoroni {
       if(debug) {
         printf("Reading IO from pin %d\n", pin);
       }
-      
+
       uint8_t pv = get_bit(io_pin.reg_p, io_pin.pin);
       return (pv) ? 1 : 0;
     }
@@ -632,7 +633,7 @@ namespace pimoroni {
       if(debug) {
         printf("Reading ADC from pin %d\n", pin);
       }
-        
+
       clr_bits(reg::ADCCON0, 0x0f);
       set_bits(reg::ADCCON0, io_pin.adc_channel);
       i2c->reg_write_uint8(address, reg::AINDIDS, 0);
@@ -662,12 +663,12 @@ namespace pimoroni {
       if(debug) {
         printf("Reading IO from pin %d\n", pin);
       }
-      
+
       uint8_t pv = get_bit(io_pin.reg_p, io_pin.pin);
       return (pv) ? vref : 0.0f;
     }
   }
-  
+
   void IOExpander::output(uint8_t pin, uint16_t value, bool load) {
     if(pin < 1 || pin > NUM_PINS) {
       printf("Pin should be in range 1-14.");
@@ -691,14 +692,14 @@ namespace pimoroni {
         if(debug) {
           printf("Outputting LOW to pin: %d\n", pin);
         }
-        
+
         clr_bit(io_pin.reg_p, io_pin.pin);
       }
       else if(value == HIGH) {
         if(debug) {
           printf("Outputting HIGH to pin: %d\n", pin);
         }
-        
+
         set_bit(io_pin.reg_p, io_pin.pin);
       }
     }
@@ -717,7 +718,7 @@ namespace pimoroni {
     i2c->reg_write_uint8(address, ENC_CFG[channel], pin_a | (pin_b << 4));
     change_bit(reg::ENC_EN, (channel * 2) + 1, count_microsteps);
     set_bit(reg::ENC_EN, channel * 2);
-    
+
     // Reset internal encoder count to zero
     uint8_t reg = ENC_COUNT[channel];
     i2c->reg_write_uint8(address, reg, 0x00);


### PR DESCRIPTION
The pull request fixes the build error from ioexpander when building micropython v1.15.

## Environment

- OS: Mac OS X 10.15.7
- Compiler: arm-none-eabi-gcc (GNU Arm Embedded Toolchain 10-2020-q4-major) 10.2.1 20201103 (release)

## Full text of the error message

```
[ 56%] Building CXX object CMakeFiles/firmware.dir/Users/davidlin/projects/rp2040/pimoroni-pico/drivers/ioexpander/ioexpander.cpp.obj
/Users/davidlin/projects/rp2040/pimoroni-pico/drivers/ioexpander/ioexpander.cpp In member function 'bool pimoroni::IOExpander::init(bool)':
/Users/davidlin/projects/rp2040/pimoroni-pico/drivers/ioexpander/ioexpander.cpp:337:11: error: 'printf' was not declared in this scope
  337 |           printf("Chip ID invalid: %04x expected: %04x\n", chip_id, CHIP_ID);
      |           ^~~~~~
/Users/davidlin/projects/rp2040/pimoroni-pico/drivers/ioexpander/ioexpander.cpp:7:1: note: 'printf' is defined in header '<cstdio>'; did you forget to '#include <cstdio>'?
    6 | #include "ioexpander.hpp"
  +++ |+#include <cstdio>
    7 | 
/Users/davidlin/projects/rp2040/pimoroni-pico/drivers/ioexpander/ioexpander.cpp In member function 'void pimoroni::IOExpander::pwm_load(bool)':
/Users/davidlin/projects/rp2040/pimoroni-pico/drivers/ioexpander/ioexpander.cpp:429:13: error: 'printf' was not declared in this scope
  429 |             printf("Timed out waiting for PWM load!");
      |             ^~~~~~
/Users/davidlin/projects/rp2040/pimoroni-pico/drivers/ioexpander/ioexpander.cpp:429:13: note: 'printf' is defined in header '<cstdio>'; did you forget to '#include <cstdio>'?
/Users/davidlin/projects/rp2040/pimoroni-pico/drivers/ioexpander/ioexpander.cpp In member function 'void pimoroni::IOExpander::pwm_clear(bool)':
/Users/davidlin/projects/rp2040/pimoroni-pico/drivers/ioexpander/ioexpander.cpp:448:13: error: 'printf' was not declared in this scope
  448 |             printf("Timed out waiting for PWM clear!");
      |             ^~~~~~
/Users/davidlin/projects/rp2040/pimoroni-pico/drivers/ioexpander/ioexpander.cpp:448:13: note: 'printf' is defined in header '<cstdio>'; did you forget to '#include <cstdio>'?
/Users/davidlin/projects/rp2040/pimoroni-pico/drivers/ioexpander/ioexpander.cpp In member function 'bool pimoroni::IOExpander::set_pwm_control(uint8_t)':
/Users/davidlin/projects/rp2040/pimoroni-pico/drivers/ioexpander/ioexpander.cpp:474:11: error: 'printf' was not declared in this scope
  474 |           printf("ValueError: A clock divider of %d\n", divider);
      |           ^~~~~~
/Users/davidlin/projects/rp2040/pimoroni-pico/drivers/ioexpander/ioexpander.cpp:474:11: note: 'printf' is defined in header '<cstdio>'; did you forget to '#include <cstdio>'?
/Users/davidlin/projects/rp2040/pimoroni-pico/drivers/ioexpander/ioexpander.cpp In member function 'uint8_t pimoroni::IOExpander::get_mode(uint8_t)':
/Users/davidlin/projects/rp2040/pimoroni-pico/drivers/ioexpander/ioexpander.cpp:504:7: error: 'printf' was not declared in this scope
  504 |       printf("ValueError: Pin should be in range 1-14.\n");
      |       ^~~~~~
/Users/davidlin/projects/rp2040/pimoroni-pico/drivers/ioexpander/ioexpander.cpp:504:7: note: 'printf' is defined in header '<cstdio>'; did you forget to '#include <cstdio>'?
/Users/davidlin/projects/rp2040/pimoroni-pico/drivers/ioexpander/ioexpander.cpp In member function 'void pimoroni::IOExpander::set_mode(uint8_t, uint8_t, bool, bool)':
/Users/davidlin/projects/rp2040/pimoroni-pico/drivers/ioexpander/ioexpander.cpp:513:7: error: 'printf' was not declared in this scope
  513 |       printf("ValueError: Pin should be in range 1-14.\n");
      |       ^~~~~~
/Users/davidlin/projects/rp2040/pimoroni-pico/drivers/ioexpander/ioexpander.cpp:513:7: note: 'printf' is defined in header '<cstdio>'; did you forget to '#include <cstdio>'?
/Users/davidlin/projects/rp2040/pimoroni-pico/drivers/ioexpander/ioexpander.cpp:525:9: error: 'printf' was not declared in this scope
  525 |         printf("Mode already is %s\n", MODE_NAMES[io_type]);
      |         ^~~~~~
/Users/davidlin/projects/rp2040/pimoroni-pico/drivers/ioexpander/ioexpander.cpp:525:9: note: 'printf' is defined in header '<cstdio>'; did you forget to '#include <cstdio>'?
/Users/davidlin/projects/rp2040/pimoroni-pico/drivers/ioexpander/ioexpander.cpp:532:9: error: 'printf' was not declared in this scope
  532 |         printf("Pin %d does not support %s!\n", pin, MODE_NAMES[io_type]);
      |         ^~~~~~
/Users/davidlin/projects/rp2040/pimoroni-pico/drivers/ioexpander/ioexpander.cpp:532:9: note: 'printf' is defined in header '<cstdio>'; did you forget to '#include <cstdio>'?
/Users/davidlin/projects/rp2040/pimoroni-pico/drivers/ioexpander/ioexpander.cpp:539:7: error: 'printf' was not declared in this scope
  539 |       printf("Setting pin %d to mode %s %s, state: %s\n", pin, MODE_NAMES[io_type], GPIO_NAMES[gpio_mode], STATE_NAMES[initial_state]);
      |       ^~~~~~
/Users/davidlin/projects/rp2040/pimoroni-pico/drivers/ioexpander/ioexpander.cpp:539:7: note: 'printf' is defined in header '<cstdio>'; did you forget to '#include <cstdio>'?
/Users/davidlin/projects/rp2040/pimoroni-pico/drivers/ioexpander/ioexpander.cpp In member function 'int16_t pimoroni::IOExpander::input(uint8_t, uint32_t)':
/Users/davidlin/projects/rp2040/pimoroni-pico/drivers/ioexpander/ioexpander.cpp:577:9: error: 'printf' was not declared in this scope
  577 |         printf("ValueError: Pin should be in range 1-14.\n");
      |         ^~~~~~
/Users/davidlin/projects/rp2040/pimoroni-pico/drivers/ioexpander/ioexpander.cpp:577:9: note: 'printf' is defined in header '<cstdio>'; did you forget to '#include <cstdio>'?
/Users/davidlin/projects/rp2040/pimoroni-pico/drivers/ioexpander/ioexpander.cpp:585:9: error: 'printf' was not declared in this scope
  585 |         printf("Reading ADC from pin %d\n", pin);
      |         ^~~~~~
/Users/davidlin/projects/rp2040/pimoroni-pico/drivers/ioexpander/ioexpander.cpp:585:9: note: 'printf' is defined in header '<cstdio>'; did you forget to '#include <cstdio>'?
/Users/davidlin/projects/rp2040/pimoroni-pico/drivers/ioexpander/ioexpander.cpp:603:13: error: 'printf' was not declared in this scope
  603 |             printf("Timeout waiting for ADC conversion!");
      |             ^~~~~~
/Users/davidlin/projects/rp2040/pimoroni-pico/drivers/ioexpander/ioexpander.cpp:603:13: note: 'printf' is defined in header '<cstdio>'; did you forget to '#include <cstdio>'?
/Users/davidlin/projects/rp2040/pimoroni-pico/drivers/ioexpander/ioexpander.cpp:614:9: error: 'printf' was not declared in this scope
  614 |         printf("Reading IO from pin %d\n", pin);
      |         ^~~~~~
/Users/davidlin/projects/rp2040/pimoroni-pico/drivers/ioexpander/ioexpander.cpp:614:9: note: 'printf' is defined in header '<cstdio>'; did you forget to '#include <cstdio>'?
/Users/davidlin/projects/rp2040/pimoroni-pico/drivers/ioexpander/ioexpander.cpp In member function 'float pimoroni::IOExpander::input_as_voltage(uint8_t, uint32_t)':
/Users/davidlin/projects/rp2040/pimoroni-pico/drivers/ioexpander/ioexpander.cpp:625:9: error: 'printf' was not declared in this scope
  625 |         printf("ValueError: Pin should be in range 1-14.\n");
      |         ^~~~~~
/Users/davidlin/projects/rp2040/pimoroni-pico/drivers/ioexpander/ioexpander.cpp:625:9: note: 'printf' is defined in header '<cstdio>'; did you forget to '#include <cstdio>'?
/Users/davidlin/projects/rp2040/pimoroni-pico/drivers/ioexpander/ioexpander.cpp:633:9: error: 'printf' was not declared in this scope
  633 |         printf("Reading ADC from pin %d\n", pin);
      |         ^~~~~~
/Users/davidlin/projects/rp2040/pimoroni-pico/drivers/ioexpander/ioexpander.cpp:633:9: note: 'printf' is defined in header '<cstdio>'; did you forget to '#include <cstdio>'?
/Users/davidlin/projects/rp2040/pimoroni-pico/drivers/ioexpander/ioexpander.cpp:652:13: error: 'printf' was not declared in this scope
  652 |             printf("Timeout waiting for ADC conversion!\n");
      |             ^~~~~~
/Users/davidlin/projects/rp2040/pimoroni-pico/drivers/ioexpander/ioexpander.cpp:652:13: note: 'printf' is defined in header '<cstdio>'; did you forget to '#include <cstdio>'?
/Users/davidlin/projects/rp2040/pimoroni-pico/drivers/ioexpander/ioexpander.cpp:663:9: error: 'printf' was not declared in this scope
  663 |         printf("Reading IO from pin %d\n", pin);
      |         ^~~~~~
/Users/davidlin/projects/rp2040/pimoroni-pico/drivers/ioexpander/ioexpander.cpp:663:9: note: 'printf' is defined in header '<cstdio>'; did you forget to '#include <cstdio>'?
/Users/davidlin/projects/rp2040/pimoroni-pico/drivers/ioexpander/ioexpander.cpp In member function 'void pimoroni::IOExpander::output(uint8_t, uint16_t, bool)':
/Users/davidlin/projects/rp2040/pimoroni-pico/drivers/ioexpander/ioexpander.cpp:673:7: error: 'printf' was not declared in this scope
  673 |       printf("Pin should be in range 1-14.");
      |       ^~~~~~
/Users/davidlin/projects/rp2040/pimoroni-pico/drivers/ioexpander/ioexpander.cpp:673:7: note: 'printf' is defined in header '<cstdio>'; did you forget to '#include <cstdio>'?
/Users/davidlin/projects/rp2040/pimoroni-pico/drivers/ioexpander/ioexpander.cpp:681:9: error: 'printf' was not declared in this scope
  681 |         printf("Outputting PWM to pin: %d\n", pin);
      |         ^~~~~~
/Users/davidlin/projects/rp2040/pimoroni-pico/drivers/ioexpander/ioexpander.cpp:681:9: note: 'printf' is defined in header '<cstdio>'; did you forget to '#include <cstdio>'?
/Users/davidlin/projects/rp2040/pimoroni-pico/drivers/ioexpander/ioexpander.cpp:692:11: error: 'printf' was not declared in this scope
  692 |           printf("Outputting LOW to pin: %d\n", pin);
      |           ^~~~~~
/Users/davidlin/projects/rp2040/pimoroni-pico/drivers/ioexpander/ioexpander.cpp:692:11: note: 'printf' is defined in header '<cstdio>'; did you forget to '#include <cstdio>'?
/Users/davidlin/projects/rp2040/pimoroni-pico/drivers/ioexpander/ioexpander.cpp:699:11: error: 'printf' was not declared in this scope
  699 |           printf("Outputting HIGH to pin: %d\n", pin);
      |           ^~~~~~
/Users/davidlin/projects/rp2040/pimoroni-pico/drivers/ioexpander/ioexpander.cpp:699:11: note: 'printf' is defined in header '<cstdio>'; did you forget to '#include <cstdio>'?
/Users/davidlin/projects/rp2040/pimoroni-pico/drivers/ioexpander/ioexpander.cpp In member function 'void pimoroni::IOExpander::wait_for_flash()':
/Users/davidlin/projects/rp2040/pimoroni-pico/drivers/ioexpander/ioexpander.cpp:818:9: error: 'printf' was not declared in this scope
  818 |         printf("Timed out waiting for interrupt!\n");
      |         ^~~~~~
/Users/davidlin/projects/rp2040/pimoroni-pico/drivers/ioexpander/ioexpander.cpp:818:9: note: 'printf' is defined in header '<cstdio>'; did you forget to '#include <cstdio>'?
/Users/davidlin/projects/rp2040/pimoroni-pico/drivers/ioexpander/ioexpander.cpp:827:9: error: 'printf' was not declared in this scope
  827 |         printf("Timed out waiting for interrupt!\n");
      |         ^~~~~~
/Users/davidlin/projects/rp2040/pimoroni-pico/drivers/ioexpander/ioexpander.cpp:827:9: note: 'printf' is defined in header '<cstdio>'; did you forget to '#include <cstdio>'?
```