### PR TITLE
Fix Pico Explorer SPI for #162

### DIFF
--- a/common/pimoroni_common.hpp
+++ b/common/pimoroni_common.hpp
@@ -31,7 +31,8 @@ namespace pimoroni {
 
     enum BG_SPI_SLOT {
       BG_SPI_FRONT,
-      BG_SPI_BACK
+      BG_SPI_BACK,
+      PICO_EXPLORER_ONBOARD
     };
 
     enum BOARD {

--- a/drivers/st7735/st7735.cpp
+++ b/drivers/st7735/st7735.cpp
@@ -79,13 +79,13 @@ namespace pimoroni {
     gpio_set_function(sck,  GPIO_FUNC_SPI);
     gpio_set_function(mosi, GPIO_FUNC_SPI);
 
-    if(miso != -1) {
+    if(miso != PIN_UNUSED) {
       gpio_set_function(miso, GPIO_FUNC_SPI);
     }
 
     // if supported by the display then the vsync pin is
     // toggled high during vertical blanking period
-    if(vsync != -1) {
+    if(vsync != PIN_UNUSED) {
       gpio_set_function(vsync, GPIO_FUNC_SIO);
       gpio_set_dir(vsync, GPIO_IN);
       gpio_set_pulls(vsync, false, true);
@@ -93,7 +93,7 @@ namespace pimoroni {
 
     // if a backlight pin is provided then set it up for
     // pwm control
-    if(bl != -1) {
+    if(bl != PIN_UNUSED) {
       pwm_config cfg = pwm_get_default_config();
       pwm_set_wrap(pwm_gpio_to_slice_num(bl), 65535);
       pwm_init(pwm_gpio_to_slice_num(bl), &cfg, true);

--- a/drivers/st7735/st7735.hpp
+++ b/drivers/st7735/st7735.hpp
@@ -40,13 +40,13 @@ namespace pimoroni {
     uint32_t dma_channel;
 
     // interface pins with our standard defaults where appropriate
-    int8_t cs     = DEFAULT_CS_PIN;
-    int8_t dc     = DEFAULT_DC_PIN;
-    int8_t sck    = DEFAULT_SCK_PIN;
-    int8_t mosi   = DEFAULT_MOSI_PIN;
-    int8_t miso   = -1; // we generally don't use this pin
-    int8_t bl     = DEFAULT_BL_PIN;
-    int8_t vsync  = -1; // only available on some products
+    uint cs     = DEFAULT_CS_PIN;
+    uint dc     = DEFAULT_DC_PIN;
+    uint sck    = DEFAULT_SCK_PIN;
+    uint mosi   = DEFAULT_MOSI_PIN;
+    uint miso   = PIN_UNUSED; // we generally don't use this pin
+    uint bl     = DEFAULT_BL_PIN;
+    uint vsync  = PIN_UNUSED; // only available on some products
 
     uint32_t spi_baud = 30 * 1024 * 1024;
 
@@ -61,13 +61,17 @@ namespace pimoroni {
     ST7735(uint16_t width, uint16_t height, uint16_t *frame_buffer, BG_SPI_SLOT slot) :
       width(width), height(height), frame_buffer(frame_buffer) {
       switch(slot) {
+        case PICO_EXPLORER_ONBOARD: // Don't read too much into this, the case is just here to avoid a compile error
+          cs = SPI_BG_FRONT_CS;
+          bl = PIN_UNUSED;
+          break;
         case BG_SPI_FRONT:
-          cs = 17;
-          bl = 20;
+          cs = SPI_BG_FRONT_CS;
+          bl = SPI_BG_FRONT_PWM;
           break;
         case BG_SPI_BACK:
-          cs = 22;
-          bl = 21;
+          cs = SPI_BG_BACK_CS;
+          bl = SPI_BG_BACK_PWM;
           break;
       }
     }

--- a/drivers/st7789/st7789.hpp
+++ b/drivers/st7789/st7789.hpp
@@ -38,6 +38,10 @@ namespace pimoroni {
     ST7789(uint16_t width, uint16_t height, uint16_t *frame_buffer, BG_SPI_SLOT slot) :
       width(width), height(height), frame_buffer(frame_buffer) {
       switch(slot) {
+        case PICO_EXPLORER_ONBOARD:
+          cs = SPI_BG_FRONT_CS;
+          bl = PIN_UNUSED;
+          break;
         case BG_SPI_FRONT:
           cs = SPI_BG_FRONT_CS;
           bl = SPI_BG_FRONT_PWM;

--- a/examples/pico_pot_explorer/demo.cpp
+++ b/examples/pico_pot_explorer/demo.cpp
@@ -4,6 +4,7 @@
 #include <sstream>
 #include <iomanip>
 
+#include "common/pimoroni_i2c.hpp"
 #include "pico_explorer.hpp"
 #include "breakout_potentiometer.hpp"
 
@@ -12,7 +13,8 @@ using namespace pimoroni;
 uint16_t buffer[PicoExplorer::WIDTH * PicoExplorer::HEIGHT];
 PicoExplorer pico_explorer(buffer);
 
-BreakoutPotentiometer pot;
+I2C i2c(PICO_EXPLORER);
+BreakoutPotentiometer pot(&i2c);
 bool toggle = false;
 
 // HSV Conversion expects float inputs in the range of 0.00-1.00 for each channel
@@ -43,6 +45,8 @@ int main() {
 
   pico_explorer.init();
   pico_explorer.update();
+
+  printf("Starting...\n");
 
   if(pot.init()) {
     printf("Potentiometer found...\n");
@@ -102,7 +106,7 @@ int main() {
     }
   }
   else {
-    printf("Encoder Potentiometer found :'(\n");
+    printf("No Potentiometer found :'(\n");
     gpio_put(PICO_DEFAULT_LED_PIN, true);
   }
 

--- a/libraries/pico_display/pico_display.cpp
+++ b/libraries/pico_display/pico_display.cpp
@@ -13,12 +13,12 @@ const uint8_t LED_B = 8;
 namespace pimoroni {
 
   PicoDisplay::PicoDisplay(uint16_t *buf)
-    : PicoGraphics(WIDTH, HEIGHT, buf), screen(WIDTH, HEIGHT, buf)  {
+    : PicoGraphics(WIDTH, HEIGHT, buf), screen(WIDTH, HEIGHT, buf, BG_SPI_FRONT)  {
       __fb = buf;
   }
 
   PicoDisplay::PicoDisplay(uint16_t *buf, int width, int height)
-    : PicoGraphics(width, height, buf), screen(width, height, buf)  {
+    : PicoGraphics(width, height, buf), screen(width, height, buf, BG_SPI_FRONT)  {
       __fb = buf;
   }
 

--- a/libraries/pico_explorer/pico_explorer.cpp
+++ b/libraries/pico_explorer/pico_explorer.cpp
@@ -15,7 +15,7 @@ const uint8_t MOTOR2P = 11;
 namespace pimoroni {
 
   PicoExplorer::PicoExplorer(uint16_t *buf)
-    : PicoGraphics(WIDTH, HEIGHT, buf), screen(WIDTH, HEIGHT, buf)  {
+    : PicoGraphics(WIDTH, HEIGHT, buf), screen(WIDTH, HEIGHT, buf, PICO_EXPLORER_ONBOARD)  {
     __fb = buf;
   }
 


### PR DESCRIPTION
The switch to common I2C and common definitions for SPI had broken an edge case in Pico Explorer where no backlight pin is used.

The backlight pin was inadvertently set to the front Breakout Garden SPI slot default, which is pin 20- this also happens to be the I2C SDA pin for Pico Explorer, breaking I2C comms.

This fix adds a new special case board "PICO_EXPLORER_ONBOARD" so that ST7789 can be initialised without the backlight pin.

This will be useful for anyone using ST7789 without the rest of the Pico Explorer library, although it feels a little contrived.