### PR TITLE
Bump MicroPython to v1.16

### DIFF
--- a/.github/workflows/micropython-with-blinka.yml
+++ b/.github/workflows/micropython-with-blinka.yml
@@ -8,9 +8,9 @@ on:
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
-  MICROPYTHON_VERSION: v1.15
-  BLINKA_VERSION: 6.10.1
-  PLATFORMDETECT_VERSION: 3.13.3
+  MICROPYTHON_VERSION: v1.16
+  BLINKA_VERSION: 6.10.2
+  PLATFORMDETECT_VERSION: 3.14.1
   BUILD_TYPE: Release
   BOARD_TYPE: PICO
 
@@ -80,15 +80,6 @@ jobs:
       if: runner.os == 'Linux'
       run: |
         sudo apt update && sudo apt install ${{matrix.apt-packages}}
-
-    - name: Hotfix lwip submodule
-      shell: bash
-      working-directory: micropython
-      run: |
-        git config --global user.email "hotfix@example.com"
-        git config --global user.name "Sassy McGuffin"
-        wget https://github.com/micropython/micropython/commit/43e7e5f00a601b36b5b39f1fef036d6c25d5562c.patch
-        git am 43e7e5f00a601b36b5b39f1fef036d6c25d5562c.patch
 
     - name: Fetch base MicroPython submodules
       shell: bash

--- a/.github/workflows/micropython.yml
+++ b/.github/workflows/micropython.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
-  MICROPYTHON_VERSION: v1.15
+  MICROPYTHON_VERSION: v1.16
   BUILD_TYPE: Release
   BOARD_TYPE: PICO
 
@@ -46,15 +46,6 @@ jobs:
       if: runner.os == 'Linux'
       run: |
         sudo apt update && sudo apt install ${{matrix.apt-packages}}
-
-    - name: Hotfix lwip submodule
-      shell: bash
-      working-directory: micropython
-      run: |
-        git config --global user.email "hotfix@example.com"
-        git config --global user.name "Sassy McGuffin"
-        wget https://github.com/micropython/micropython/commit/43e7e5f00a601b36b5b39f1fef036d6c25d5562c.patch
-        git am 43e7e5f00a601b36b5b39f1fef036d6c25d5562c.patch
 
     - name: Fetch base MicroPython submodules
       shell: bash


### PR DESCRIPTION
* Bump MicroPython from v1.15 to v1.16
* Bump Blinka from 6.10.1 to 6.10.2
* Bump PlatformDetect from 3.13.3 to 3.14.1
* Revert backport patch/hotfix for lwip submodule

Test build: https://github.com/pimoroni/pimoroni-pico/suites/3065698509/artifacts/69808049
Test build with Blinka & PlatformDetect: https://github.com/pimoroni/pimoroni-pico/suites/3065698507/artifacts/69807949