### PR TITLE
Fix LTR559 duty cycle

### DIFF
--- a/drivers/ltr559/ltr559.cpp
+++ b/drivers/ltr559/ltr559.cpp
@@ -36,8 +36,8 @@ namespace pimoroni {
     reset();
     interrupts(true, true);
 
-    // 50mA, 1.0 duty cycle, 30Hz, 1 pulse
-    proximity_led(50, 1.0, 30, 1);
+    // 50mA, 100% duty cycle, 30Hz, 1 pulse
+    proximity_led(50, 100, 30, 1);
 
     // enabled, gain 4x
     light_control(true, 4);


### PR DESCRIPTION
Proximity LED duty cycle was being passed in as "1.0" intending to select 100%, but this snapped to 25% and skewed the proximity reading.