### PR TITLE
PicoWireless: move HTTP code to ppwhttp library

### DIFF
--- a/micropython/examples/.gitignore
+++ b/micropython/examples/.gitignore
@@ -1,0 +1,1 @@
+secrets.py

--- a/micropython/examples/pico_wireless/cheerlights.py
+++ b/micropython/examples/pico_wireless/cheerlights.py
@@ -1,105 +1,24 @@
 import time
-import picowireless
 from micropython import const
 
-WIFI_SSID = "Your SSID here!"
-WIFI_PASS = "Your PSK here!"
+try:
+    import ppwhttp
+except ImportError:
+    raise RuntimeError("Cannot find ppwhttp. Have you copied ppwhttp.py to your Pico?")
 
-CLOUDFLARE_DNS = (1, 1, 1, 1)
-GOOGLE_DNS = (8, 8, 8, 8)
-USE_DNS = CLOUDFLARE_DNS
 
-TCP_MODE = const(0)
-HTTP_REQUEST_DELAY = const(30)
-HTTP_PORT = 80
+HTTP_REQUEST_DELAY = const(60)
+HTTP_REQUEST_PORT = const(80)
 HTTP_REQUEST_HOST = "api.thingspeak.com"
 HTTP_REQUEST_PATH = "/channels/1417/field/2/last.txt"
 
 
-def connect(host_address, port, client_sock, timeout=1000):
-    picowireless.client_start(host_address, port, client_sock, TCP_MODE)
-
-    t_start = time.time()
-    timeout /= 1000.0
-
-    while time.time() - t_start < timeout:
-        state = picowireless.get_client_state(client_sock)
-        if state == 4:
-            return True
-        time.sleep(1.0)
-
-    return False
-
-
-def http_request(client_sock, host_address, port, request_host, request_path, handler, timeout=5000):
-    print("Connecting to {1}.{2}.{3}.{4}:{0}...".format(port, *host_address))
-    if not connect(host_address, port, client_sock):
-        print("Connection failed!")
-        return False
-    print("Connected!")
-
-    http_request = """GET {} HTTP/1.1
-Host: {}
-Connection: close
-
-""".format(request_path, request_host).replace("\n", "\r\n")
-
-    picowireless.send_data(client_sock, http_request)
-
-    t_start = time.time()
-
-    while True:
-        if time.time() - t_start > timeout:
-            picowireless.client_stop(client_sock)
-            print("HTTP request to {}:{} timed out...".format(host_address, port))
-            return False
-
-        avail_length = picowireless.avail_data(client_sock)
-        if avail_length > 0:
-            break
-
-    print("Got response: {} bytes".format(avail_length))
-
-    response = b""
-
-    while len(response) < avail_length:
-        data = picowireless.get_data_buf(client_sock)
-        response += data
-
-    response = response.decode("utf-8")
-
-    head, body = response.split("\r\n\r\n", 1)
-    dhead = {}
-
-    for line in head.split("\r\n")[1:]:
-        key, value = line.split(": ", 1)
-        dhead[key] = value
-
-    handler(dhead, body)
-
-    picowireless.client_stop(client_sock)
-
-
-picowireless.init()
-
-print("Connecting to {}...".format(WIFI_SSID))
-picowireless.wifi_set_passphrase(WIFI_SSID, WIFI_PASS)
-
-while True:
-    if picowireless.get_connection_status() == 3:
-        break
-print("Connected!")
+ppwhttp.start_wifi()
+ppwhttp.set_dns(ppwhttp.GOOGLE_DNS)
 
 # Get our own local IP!
-my_ip = picowireless.get_ip_address()
+my_ip = ppwhttp.get_ip_address()
 print("Local IP: {}.{}.{}.{}".format(*my_ip))
-
-# Resolve and cache the IP address
-picowireless.set_dns(USE_DNS)
-http_address = picowireless.get_host_by_name(HTTP_REQUEST_HOST)
-print("Resolved {} to {}.{}.{}.{}".format(HTTP_REQUEST_HOST, *http_address))
-
-client_sock = picowireless.get_socket()
 
 
 def handler(head, body):
@@ -108,12 +27,12 @@ def handler(head, body):
         r = int(color[0:2], 16)
         g = int(color[2:4], 16)
         b = int(color[4:6], 16)
-        picowireless.set_led(r, g, b)
+        ppwhttp.set_led(r, g, b)
         print("Set LED to {} {} {}".format(r, g, b))
     else:
         print("Error: {}".format(head["Status"]))
 
 
 while True:
-    http_request(client_sock, http_address, HTTP_PORT, HTTP_REQUEST_HOST, HTTP_REQUEST_PATH, handler)
-    time.sleep(60.0)
+    ppwhttp.http_request(HTTP_REQUEST_HOST, HTTP_REQUEST_PORT, HTTP_REQUEST_HOST, HTTP_REQUEST_PATH, handler)
+    time.sleep(HTTP_REQUEST_DELAY)

--- a/micropython/examples/pico_wireless/plasma_ws2812_http.py
+++ b/micropython/examples/pico_wireless/plasma_ws2812_http.py
@@ -1,14 +1,27 @@
 import time
+import plasma
 
 try:
     import ppwhttp
 except ImportError:
     raise RuntimeError("Cannot find ppwhttp. Have you copied ppwhttp.py to your Pico?")
 
+"""
+This example uses the Plasma WS2812 LED library to drive a string of LEDs alongside the built-in RGB LED.
+You should wire your LEDs to VBUS/GND and connect the data pin to pin 27 (unused by Pico Wireless).
+"""
+
+NUM_LEDS = 30  # Number of connected LEDs
+LED_PIN = 27   # LED data pin (27 is unused by Pico Wireless)
+LED_PIO = 0    # Hardware PIO (0 or 1)
+LED_SM = 0     # PIO State-Machine (0 to 3)
+
 
 r = 0
 g = 0
 b = 0
+
+led_strip = plasma.WS2812(NUM_LEDS, LED_PIO, LED_SM, LED_PIN)
 
 
 # Edit your routes here
@@ -21,6 +34,8 @@ def get_home(method, url, data=None):
         g = int(data.get("g", 0))
         b = int(data.get("b", 0))
         ppwhttp.set_led(r, g, b)
+        for i in range(NUM_LEDS):
+            led_strip.set_rgb(i, r, g, b)
         print("Set LED to {} {} {}".format(r, g, b))
 
     return """<form method="post" action="/">
@@ -37,6 +52,8 @@ def get_test(method, url):
 
 
 ppwhttp.start_wifi()
+
+led_strip.start()
 
 server_sock = ppwhttp.start_server()
 while True:

--- a/micropython/examples/pico_wireless/ppwhttp.py
+++ b/micropython/examples/pico_wireless/ppwhttp.py
@@ -158,6 +158,14 @@ Connection: close
         key, value = line.split(": ", 1)
         dhead[key] = value
 
+    # Fudge to handle JSON data type, which is prefixed with a content length.
+    # This ignores the charset, if specified, since we've already assumed utf-8 above!
+    # TODO maybe pay attention to Content-Type charset
+    if "Content-Type" in dhead and dhead["Content-Type"].startswith("application/json"):
+        length, body = body.split("\n", 1)
+        length = int(length, 16)
+        body = body[:length]
+
     handler(dhead, body)
 
     picowireless.client_stop(client_sock)

--- a/micropython/examples/pico_wireless/ppwhttp.py
+++ b/micropython/examples/pico_wireless/ppwhttp.py
@@ -1,0 +1,240 @@
+"""Pimoroni Pico Wireless HTTP
+
+A super-simple HTTP server library for Pico Wireless.
+"""
+import time
+import picowireless
+
+from micropython import const
+
+try:
+    from secrets import WIFI_SSID, WIFI_PASS
+except ImportError:
+    WIFI_SSID = None
+    WIFI_PASS = None
+
+
+TCP_CLOSED = const(0)
+TCP_LISTEN = const(1)
+
+CLOUDFLARE_DNS = (1, 1, 1, 1)
+GOOGLE_DNS = (8, 8, 8, 8)
+
+DEFAULT_HTTP_PORT = const(80)
+
+
+routes = {}
+sockets = []
+hosts = {}
+
+
+def set_led(r, g, b):
+    """Set """
+    picowireless.set_led(r, g, b)
+
+
+def get_socket(force_new=False):
+    global sockets
+    if force_new or len(sockets) == 0:
+        socket = picowireless.get_socket()
+        sockets.append(socket)
+        return socket
+    return sockets[0]
+
+
+def get_ip_address():
+    return picowireless.get_ip_address()
+
+
+def set_dns(dns):
+    picowireless.set_dns(dns)
+
+
+def get_host_by_name(hostname, no_cache=False):
+    # Already an IP
+    if type(hostname) is tuple and len(hostname) == 4:
+        return hostname
+
+    # Get from cached hosts
+    if hostname in hosts and not no_cache:
+        return hosts[hostname]
+
+    ip = picowireless.get_host_by_name(hostname)
+    hosts[hostname] = ip
+    return ip
+
+
+def start_wifi(wifi_ssid=WIFI_SSID, wifi_pass=WIFI_PASS):
+    if wifi_ssid is None or wifi_pass is None:
+        raise RuntimeError("WiFi SSID/PASS required. Set them in secrets.py and copy it to your Pico, or pass them as arguments.")
+    picowireless.init()
+
+    print("Connecting to {}...".format(wifi_ssid))
+    picowireless.wifi_set_passphrase(wifi_ssid, wifi_pass)
+
+    while True:
+        if picowireless.get_connection_status() == 3:
+            break
+    print("Connected!")
+
+
+def start_server(http_port=DEFAULT_HTTP_PORT, timeout=5000):
+    my_ip = picowireless.get_ip_address()
+    print("Starting server...")
+    server_sock = picowireless.get_socket()
+    picowireless.server_start(http_port, server_sock, 0)
+
+    t_start = time.ticks_ms()
+
+    while time.ticks_ms() - t_start < timeout:
+        state = picowireless.get_server_state(server_sock)
+        if state == TCP_LISTEN:
+            print("Server listening on {1}.{2}.{3}.{4}:{0}".format(http_port, *my_ip))
+            return server_sock
+
+    return None
+
+
+def connect_to_server(host_address, port, client_sock, timeout=5000):
+    picowireless.client_start(host_address, port, client_sock, TCP_CLOSED)
+
+    t_start = time.ticks_ms()
+
+    while time.ticks_ms() - t_start < timeout:
+        state = picowireless.get_client_state(client_sock)
+        if state == 4:
+            return True
+        time.sleep(1.0)
+
+    return False
+
+
+def http_request(host_address, port, request_host, request_path, handler, timeout=5000, client_sock=None):
+    if client_sock is None:
+        client_sock = get_socket()
+
+    host_address = get_host_by_name(host_address)
+
+    print("Connecting to {1}.{2}.{3}.{4}:{0}...".format(port, *host_address))
+    if not connect_to_server(host_address, port, client_sock):
+        print("Connection failed!")
+        return False
+    print("Connected!")
+
+    http_request = """GET {} HTTP/1.1
+Host: {}
+Connection: close
+
+""".format(request_path, request_host).replace("\n", "\r\n")
+
+    picowireless.send_data(client_sock, http_request)
+
+    t_start = time.ticks_ms()
+
+    while True:
+        if time.ticks_ms() - t_start > timeout:
+            picowireless.client_stop(client_sock)
+            print("HTTP request to {}:{} timed out...".format(host_address, port))
+            return False
+
+        avail_length = picowireless.avail_data(client_sock)
+        if avail_length > 0:
+            break
+
+    print("Got response: {} bytes".format(avail_length))
+
+    response = b""
+
+    while len(response) < avail_length:
+        data = picowireless.get_data_buf(client_sock)
+        response += data
+
+    response = response.decode("utf-8")
+
+    head, body = response.split("\r\n\r\n", 1)
+    dhead = {}
+
+    for line in head.split("\r\n")[1:]:
+        key, value = line.split(": ", 1)
+        dhead[key] = value
+
+    handler(dhead, body)
+
+    picowireless.client_stop(client_sock)
+
+
+def handle_http_request(server_sock, timeout=5000):
+    t_start = time.ticks_ms()
+
+    client_sock = picowireless.avail_server(server_sock)
+    if client_sock in [server_sock, 255, -1]:
+        return False
+
+    print("Client connected!")
+
+    avail_length = picowireless.avail_data(client_sock)
+    if avail_length == 0:
+        picowireless.client_stop(client_sock)
+        return False
+
+    request = b""
+
+    while len(request) < avail_length:
+        data = picowireless.get_data_buf(client_sock)
+        request += data
+        if time.ticks_ms() - t_start > timeout:
+            print("Client timed out getting data!")
+            picowireless.client_stop(client_sock)
+            return False
+
+    request = request.decode("utf-8")
+
+    if len(request) > 0:
+        head, body = request.split("\r\n\r\n", 1)
+        dhead = {}
+
+        for line in head.split("\r\n")[1:]:
+            key, value = line.split(": ", 1)
+            dhead[key] = value
+
+    method, url, _ = head.split("\r\n", 1)[0].split(" ")
+
+    print("Serving {} on {}...".format(method, url))
+
+    response = None
+
+    # Dispatch the request to the relevant route
+    if url in routes and method in routes[url] and callable(routes[url][method]):
+        if method == "POST":
+            data = {}
+            for var in body.split("&"):
+                key, value = var.split("=")
+                data[key] = value
+            response = routes[url][method](method, url, data)
+        else:
+            response = routes[url][method](method, url)
+
+    if response is not None:
+        response = "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nContent-Type: text/html\r\n\r\n".format(len(response)) + response
+        picowireless.send_data(client_sock, response)
+        picowireless.client_stop(client_sock)
+        print("Success! Sending 200 OK")
+        return True
+    else:
+        picowireless.send_data(client_sock, "HTTP/1.1 501 Not Implemented\r\nContent-Length: 19\r\n\r\n501 Not Implemented")
+        picowireless.client_stop(client_sock)
+        print("Unhandled Request! Sending 501 OK")
+        return False
+
+
+def route(url, methods="GET"):
+    if type(methods) is str:
+        methods = [methods]
+
+    def decorate(handler):
+        for method in methods:
+            if url not in routes:
+                routes[url] = {}
+            routes[url][method] = handler
+
+    return decorate

--- a/micropython/examples/pico_wireless/scan_networks.py
+++ b/micropython/examples/pico_wireless/scan_networks.py
@@ -1,0 +1,15 @@
+import picowireless
+import time
+
+picowireless.init()
+
+picowireless.start_scan_networks()
+
+while True:
+    networks = picowireless.get_scan_networks()
+    print("Found {} network(s)...".format(networks))
+    for network in range(networks):
+        ssid = picowireless.get_ssid_networks(network)
+        print("{}: {}".format(network, ssid))
+    print("\n")
+    time.sleep(10)

--- a/micropython/examples/pico_wireless/secrets.py
+++ b/micropython/examples/pico_wireless/secrets.py
@@ -1,0 +1,2 @@
+WIFI_SSID = "your SSID here!"
+WIFI_PASS = "Your PSK here!"

--- a/micropython/modules/pico_wireless/pico_wireless.cpp
+++ b/micropython/modules/pico_wireless/pico_wireless.cpp
@@ -370,8 +370,7 @@ mp_obj_t picowireless_get_ssid_networks(size_t n_args, const mp_obj_t *pos_args,
         uint8_t network_item = args[ARG_network_item].u_int;
         const char* ssid = wireless->get_ssid_networks(network_item);
         if(ssid != nullptr) {
-            std::string str_ssid(ssid, WL_SSID_MAX_LENGTH);
-            return mp_obj_new_str(str_ssid.c_str(), str_ssid.length());
+            return mp_obj_new_str(ssid, strnlen(ssid, WL_SSID_MAX_LENGTH));
         }
     }
     else
@@ -516,8 +515,7 @@ mp_obj_t picowireless_get_host_by_name(size_t n_args, const mp_obj_t *pos_args, 
 mp_obj_t picowireless_get_fw_version() {
     if(wireless != nullptr) {
         const char* fw_ver = wireless->get_fw_version();
-        std::string str_fw_ver(fw_ver, WL_FW_VER_LENGTH);
-        return mp_obj_new_str(str_fw_ver.c_str(), str_fw_ver.length());
+        return mp_obj_new_str(fw_ver, strnlen(fw_ver, WL_FW_VER_LENGTH));
     }
     else
         mp_raise_msg(&mp_type_RuntimeError, NOT_INITIALISED_MSG);


### PR DESCRIPTION
Creates a new ppwhttp library to hide the implementation detail of HTTP clients/servers from the examples.

Adds a new example - plasma_ws2812_http.py - showing how to expand rgb_http.py to use a WS2812 pixel strip.

Adds "secrets.py" and moves WIFI connection information there. ppwhttp will throw an error if it's missing.