### PR TITLE
Improve ST7789 frame rate ~4x

### DIFF
--- a/drivers/st7789/st7789.hpp
+++ b/drivers/st7789/st7789.hpp
@@ -29,7 +29,9 @@ namespace pimoroni {
     uint bl     = SPI_BG_FRONT_PWM;
     uint vsync  = PIN_UNUSED; // only available on some products
 
-    static const uint32_t SPI_BAUD = 16 * 1000 * 1000;
+    // The ST7789 requires 16 ns between SPI rising edges.
+    // 16 ns = 62,500,000 Hz
+    static const uint32_t SPI_BAUD = 62'500'000;
 
   public:
     // frame buffer where pixel data is stored

--- a/libraries/pico_display_2/pico_display_2.cpp
+++ b/libraries/pico_display_2/pico_display_2.cpp
@@ -49,7 +49,7 @@ namespace pimoroni {
     gpio_set_function(Y, GPIO_FUNC_SIO); gpio_set_dir(Y, GPIO_IN); gpio_pull_up(Y);
 
     // initialise the screen
-    screen.init(true, false, 74 * 1000 * 1000);
+    screen.init(true, false);
   }
 
   void PicoDisplay2::update() {


### PR DESCRIPTION
The ST7789's Tscycw (time between serial write clock cycles) is
16 ns. This can be found on page 44 of the datasheet I'm using:
https://www.waveshare.com/w/upload/a/ae/ST7789_Datasheet.pdf

(I do not know which manufacturer Pimoroni products use and if
their parts might be different. But it seems like this wouldn't
change.)

The existing code sets the SPI baud to 16 * 1000 * 1000. But baud
is Hz, not seconds. That 16 * 1000 * 1000 doesn't represent 16 ns.
It represents 16,000,000 Hz.

16 ns * (1 Hz / s) = 62,500,000 Hz.

This commit changes the baud from 16 * 1000 * 1000 to 62'500'000,
representing ~4x speed improvement in SPI and thus ~4x frame rate
improvement, since the display's frame rate is currently
SPI-limited.

A before & after video can be seen here:
https://www.youtube.com/watch?v=n2y19TCnATo

Note that also on page 44 of that datasheet Tscycr (the read speed)
is only 150 ns, not 16 ns. Right now, the Pimoroni code doesn't read
any values back from the ST7789 so it is safe to operate at the
higher speed.

Also note that the 16 * 1000 * 1000 is the requested baud. The actual
baud is the closest the Pico can get, which is 15,625,000.
The new requested baud of 62'500'000 results in an exact match.