### PR TITLE
Fix ordering of tuple returned by WS2812.get

### DIFF
--- a/micropython/modules/plasma/plasma.c
+++ b/micropython/modules/plasma/plasma.c
@@ -14,7 +14,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(PlasmaWS2812___del___obj, PlasmaWS2812___del__);
 MP_DEFINE_CONST_FUN_OBJ_KW(PlasmaWS2812_set_rgb_obj, 5, PlasmaWS2812_set_rgb);
 MP_DEFINE_CONST_FUN_OBJ_KW(PlasmaWS2812_set_hsv_obj, 3, PlasmaWS2812_set_hsv);
 MP_DEFINE_CONST_FUN_OBJ_KW(PlasmaWS2812_start_obj, 1, PlasmaWS2812_start);
-MP_DEFINE_CONST_FUN_OBJ_KW(PlasmaWS2812_get_obj, 2, PlasmaAPA102_get);
+MP_DEFINE_CONST_FUN_OBJ_KW(PlasmaWS2812_get_obj, 2, PlasmaWS2812_get);
 MP_DEFINE_CONST_FUN_OBJ_1(PlasmaWS2812_clear_obj, PlasmaWS2812_clear);
 
 /***** Binding of Methods *****/

--- a/micropython/modules/plasma/plasma.cpp
+++ b/micropython/modules/plasma/plasma.cpp
@@ -188,6 +188,15 @@ mp_obj_t PlasmaWS2812_set_hsv(size_t n_args, const mp_obj_t *pos_args, mp_map_t 
     return mp_const_none;
 }
 
+const int get_orders[6][4] = {                //  r  g  b  w
+    [static_cast<int>(WS2812::COLOR_ORDER::RGB)]={0, 1, 2, 3},
+    [static_cast<int>(WS2812::COLOR_ORDER::RBG)]={0, 2, 1, 3},
+    [static_cast<int>(WS2812::COLOR_ORDER::GRB)]={1, 0, 2, 3},
+    [static_cast<int>(WS2812::COLOR_ORDER::GBR)]={1, 2, 0, 3},
+    [static_cast<int>(WS2812::COLOR_ORDER::BRG)]={2, 0, 1, 3},
+    [static_cast<int>(WS2812::COLOR_ORDER::BGR)]={2, 1, 0, 3},
+};
+
 mp_obj_t PlasmaWS2812_get(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_self, ARG_index };
     static const mp_arg_t allowed_args[] = {
@@ -202,12 +211,13 @@ mp_obj_t PlasmaWS2812_get(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_
 
     _PlasmaWS2812_obj_t *self = MP_OBJ_TO_PTR2(args[ARG_self].u_obj, _PlasmaWS2812_obj_t);
     WS2812::RGB rgb = self->ws2812->get(index);
+    const int *get_order = get_orders[static_cast<int>(self->ws2812->color_order)];
 
     mp_obj_t tuple[4];
-    tuple[0] = mp_obj_new_int(rgb.r);
-    tuple[1] = mp_obj_new_float(rgb.g);
-    tuple[2] = mp_obj_new_float(rgb.b);
-    tuple[3] = mp_obj_new_float(rgb.w);
+    tuple[get_order[0]] = mp_obj_new_int(rgb.r);
+    tuple[get_order[1]] = mp_obj_new_int(rgb.g);
+    tuple[get_order[2]] = mp_obj_new_int(rgb.b);
+    tuple[get_order[3]] = mp_obj_new_int(rgb.w);
     return mp_obj_new_tuple(4, tuple);
 }
 
@@ -410,9 +420,9 @@ mp_obj_t PlasmaAPA102_get(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_
 
     mp_obj_t tuple[4];
     tuple[0] = mp_obj_new_int(rgb.r);
-    tuple[1] = mp_obj_new_float(rgb.g);
-    tuple[2] = mp_obj_new_float(rgb.b);
-    tuple[3] = mp_obj_new_float(rgb.sof);
+    tuple[1] = mp_obj_new_int(rgb.g);
+    tuple[2] = mp_obj_new_int(rgb.b);
+    tuple[3] = mp_obj_new_int(rgb.sof);
     return mp_obj_new_tuple(4, tuple);
 }
 


### PR DESCRIPTION
There are a few problems with `WS2812.get`:

* The tuple returned contains the types `(int, float, float, float)` instead of `(int, int, int, int)` (which is slightly more efficient and also consistent with the types used by `set_rgb`, and the internal structures); `APA102.get` had the same issue so I fixed that up at the same time.
* The tuple returned simply copies the rgbw fields directly, but in the case of WS2812 (though not APA102) these aren't *necessarily* in the rgbw order (i.e. `set_rgb` corrects for color_order, but `get` doesn't "undo" this correction).
* Finally, the internal implementation is pointing at `APA102.get` (which *really* confused me while working on this as every alteration I made to `WS2812.get` didn't seem to do anything! :)

This commit should fix things up, though I must apologize for my dreadful C++ knowledge; I'm sure there must be a more elegant way to declare the `get_orders` array than with a whole pile of `static_cast`, but alas I don't know it!