### PR TITLE
Bump MicroPython to v1.18

### DIFF
--- a/.github/workflows/micropython-with-blinka.yml
+++ b/.github/workflows/micropython-with-blinka.yml
@@ -8,9 +8,9 @@ on:
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
-  MICROPYTHON_VERSION: v1.17
-  BLINKA_VERSION: 6.14.1
-  PLATFORMDETECT_VERSION: 3.15.3
+  MICROPYTHON_VERSION: v1.18
+  BLINKA_VERSION: 6.20.1
+  PLATFORMDETECT_VERSION: 3.19.3
   BUILD_TYPE: Release
   BOARD_TYPE: PICO
 

--- a/.github/workflows/micropython.yml
+++ b/.github/workflows/micropython.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
-  MICROPYTHON_VERSION: v1.17
+  MICROPYTHON_VERSION: v1.18
   BUILD_TYPE: Release
   BOARD_TYPE: PICO
 

--- a/README.md
+++ b/README.md
@@ -1,29 +1,101 @@
-# Pimoroni Pico Libraries and Examples
+# Pimoroni Pico Libraries and Examples <!-- omit in toc -->
 
-Welcome to the brave new world of Pico! This repository contains the C/C++ and MicroPython libraries for our range of Raspberry Pi Pico addons.
+Welcome to the brave new world of Pico!
 
-First of all you need to decide if your project is going to be done in MicroPython or using C/C++ with the Pico SDK. We have instructions for both here:
+This repository contains the C/C++ and MicroPython libraries for our range of RP2040-based boards, Raspberry Pi Pico addons & [supported Breakout Garden sensors](#supported-breakouts).
 
-- **MicroPython**: The easiest way to get start, setup is a breeze! [Click here to view instructions for MicroPython](setting-up-micropython.md)
-- **C/C++**: For more advanced users that want to unleash the full power of Pico! [Click here to view instructions for C/C++](setting-up-the-pico-sdk.md)
+[![CMake Build Status](https://img.shields.io/github/workflow/status/pimoroni/pimoroni-pico/CMake?label=C%2B%2B)](https://github.com/pimoroni/pimoroni-pico/actions/workflows/cmake.yml)
+[![MicroPython Build Status](https://img.shields.io/github/workflow/status/pimoroni/pimoroni-pico/MicroPython?label=MicroPython)](https://github.com/pimoroni/pimoroni-pico/actions/workflows/micropython.yml)
+[![MicroPython+Blinka Status](https://img.shields.io/github/workflow/status/pimoroni/pimoroni-pico/MicroPython+Blinka?label=MicroPython%2BBlinka)](https://github.com/pimoroni/pimoroni-pico/actions/workflows/micropython-with-blinka.yml)
+[![GitHub release (latest by date)](https://img.shields.io/github/v/release/pimoroni/pimoroni-pico)](https://github.com/pimoroni/pimoroni-pico/releases/latest/)
 
-# Software support for our Pico range
 
-It's very early days for Pico and we've been working our little socks off to get everything ready for launch.
+- [MicroPython](#micropython)
+  - [MicroPython Examples](#micropython-examples)
+- [C/C++](#cc)
+  - [C++ Examples](#c-examples)
+  - [Boilerplate for C++ Projects](#boilerplate-for-c-projects)
+- [Supported Breakouts](#supported-breakouts)
+- [Tutorials & Guides](#tutorials--guides)
 
-Most of our Pico addons have support for both C/C++ and MicroPython but we're still catching up a little bit in places.
+# MicroPython
 
-The table below shows the current state of compatibly and some notes to set expectations:
+The easiest way to get started. If you're new to Pico, we recommend you read our [getting started with Pico](https://learn.pimoroni.com/article/getting-started-with-pico) tutorial.
 
-|Product|C/C++ Library|MicroPython Library|Notes
-|---|---|---|---
-|[Pico Explorer Base](https://shop.pimoroni.com/products/pico-explorer-base)|Yes|Yes|
-|[Pico RGB Keypad](https://shop.pimoroni.com/products/pico-rgb-keypad-base)|Yes|Yes|
-|[Pico Unicorn Pack](https://shop.pimoroni.com/products/pico-unicorn-pack)|Yes|Yes|MicroPython support added in v0.0.3 Alpha
-|[Pico Audio Pack](https://shop.pimoroni.com/products/pico-audio-pack)|Yes|No|Limited support for MicroPython planned
-|[Pico Scroll Pack](https://shop.pimoroni.com/products/pico-scroll-pack)|Yes|Yes|
-|[Pico Display Pack](https://shop.pimoroni.com/products/pico-display-pack)|Yes|Yes|
+:warning: all of our MicroPython libraries are baked into a batteries-included, custom version of MicroPython which you can grab from releases: [https://github.com/pimoroni/pimoroni-pico/releases/latest/](https://github.com/pimoroni/pimoroni-pico/releases/latest/)
 
-We will keep this information updated as things develop.
+New releases are issued regularly with new libraries, bugfixes to our existing libraries and new features inherited from MicroPython upstream. Be sure to check back!
 
-**Note:** It's very early days for Raspberry Pi Pico and it's likely that our libraries will undergo quite a lot of changes over the next couple of weeks as we take in feedback and expand the functionality.
+* :link: [Tutorial: Getting started with Pico](https://learn.pimoroni.com/article/getting-started-with-pico)
+* [Readme: Instructions for setting up MicroPython](setting-up-micropython.md)
+* [Pimoroni Pico MicroPython + Drivers Releases](https://github.com/pimoroni/pimoroni-pico/releases)
+
+## MicroPython Examples
+
+You can find MicroPython examples for supported sensors, packs and bases in the "micropython/examples" directory:
+
+* [micropython/examples](MicroPython Examples)
+
+
+# C/C++
+
+For more advanced users that want to unleash the full power of Pico, you can use our C++ libraries. If you know what you're doing and want to build your own Pimoroni Pico project then start with the [Pimoroni Pico SDK Boilerplate](https://github.com/pimoroni/pico-boilerplate).
+
+* :link: [Tutorial: Pico C++ Development on Windows](https://learn.pimoroni.com/article/pico-development-using-wsl)
+* [Readme: Instructions for setting up the C/C++ SDK](setting-up-the-pico-sdk.md)
+
+## C++ Examples
+
+You can find examples for supported sensors, packs and bases in the "examples" directory:
+
+* [examples](C++ Examples)
+
+
+## Boilerplate for C++ Projects
+
+We also maintain a C++/CMake boilerplate with GitHub workflows configured for testing and a basic skeleton project.
+
+* [Pimoroni Pico SDK Boilerplate](https://github.com/pimoroni/pico-boilerplate)
+
+
+# Supported Breakouts
+
+* AS7262 - 6-channel Spectral Sensor - https://shop.pimoroni.com/products/as7262-6-channel-spectral-sensor-spectrometer-breakout
+* MSA301 - 3DoF Motion Sensor - https://shop.pimoroni.com/products/msa301-3dof-motion-sensor-breakout
+* MICS6814 - Gas Sensor - https://shop.pimoroni.com/products/mics6814-gas-sensor-breakout
+* RGB Potentiometer - https://shop.pimoroni.com/products/rgb-potentiometer-breakout
+* RGB Encoder - https://shop.pimoroni.com/products/rgb-encoder-breakout
+* IO Expander - https://shop.pimoroni.com/products/io-expander
+* RV3028 - RTC - https://shop.pimoroni.com/products/rv3028-real-time-clock-rtc-breakout
+* ST7735 - 0.96" LCD - https://shop.pimoroni.com/products/0-96-spi-colour-lcd-160x80-breakout
+* IS31FL3730 - LTP-305 dual matrix breakout - https://shop.pimoroni.com/products/led-dot-matrix-breakout?variant=32274405654611
+* LTR559 - Proximity/Presence/Light Sensor - https://shop.pimoroni.com/products/ltr-559-light-proximity-sensor-breakout
+* IS31FL3731 - 11x7 and 5x5 matrix displays 
+  - https://shop.pimoroni.com/products/11x7-led-matrix-breakout 
+  - https://shop.pimoroni.com/products/5x5-rgb-matrix-breakout
+* TrackBall - https://shop.pimoroni.com/products/trackball-breakout
+* SGP30 - Air Quality Sensor - https://shop.pimoroni.com/products/sgp30-air-quality-sensor-breakout
+* ST7789 - 1.3" LCD, 1.54" LCD and 1.3" round LCD
+  - https://shop.pimoroni.com/products/1-3-spi-colour-lcd-240x240-breakout
+  - https://shop.pimoroni.com/products/1-3-spi-colour-round-lcd-240x240-breakout
+  - https://shop.pimoroni.com/products/1-54-spi-colour-square-lcd-240x240-breakout
+  - Pico Display 2.0"
+* BME680 - Temperature, Pressure, Humidity & Gas Sensor - https://shop.pimoroni.com/products/bme680-breakout
+* BME688 - Temperature, Pressure, Humidity & Gas Sensor - https://shop.pimoroni.com/products/bme688-breakout
+* BH1745 - Luminance & Colour Sensor - https://shop.pimoroni.com/products/bh1745-luminance-and-colour-sensor-breakout
+* BME280 - Temperature, Pressure & Humidity Sensor - https://shop.pimoroni.com/products/bme280-breakout
+* BMP280 - Temperature & Pressure Sensor - https://shop.pimoroni.com/products/bmp280-breakout-temperature-pressure-altitude-sensor
+* PWM3901/PAA5100JE - Near Optical Flow Sensor - https://shop.pimoroni.com/products/paa5100je-optical-tracking-spi-breakout
+* ICP10125 - High Accuracy Pressure / Altitude / Temperature Sensor - https://shop.pimoroni.com/products/icp10125-air-pressure-breakout
+* Interstate 75 - HUB75 driver https://shop.pimoroni.com/products/interstate-75
+* Plasma 2040 - https://shop.pimoroni.com/products/plasma-2040
+* SCD40 - TBC
+
+
+# Tutorials & Guides
+
+- :link: [Getting started with (MicroPython on) Pico](https://learn.pimoroni.com/article/getting-started-with-pico)
+- :link: [Pico C++ Development on Windows / WSL](https://learn.pimoroni.com/article/pico-development-using-wsl)
+- :link: [Getting Started with Interstate 75](https://learn.pimoroni.com/article/getting-started-with-interstate-75)
+- :link: [Getting Started with Plasma 2040](https://learn.pimoroni.com/article/plasma-2040)
+- :link: [Assembling Keybow 2040](https://learn.pimoroni.com/article/assembling-keybow-2040)

--- a/common/pimoroni_i2c.cpp
+++ b/common/pimoroni_i2c.cpp
@@ -68,7 +68,7 @@ namespace pimoroni {
         return value;
     }
 
-    int I2C::write_bytes(uint8_t address, uint8_t reg, uint8_t *buf, int len) {
+    int I2C::write_bytes(uint8_t address, uint8_t reg, const uint8_t *buf, int len) {
         uint8_t buffer[len + 1];
         buffer[0] = reg;
         for(int x = 0; x < len; x++) {

--- a/common/pimoroni_i2c.hpp
+++ b/common/pimoroni_i2c.hpp
@@ -55,7 +55,7 @@ namespace pimoroni {
         int16_t reg_read_int16(uint8_t address, uint8_t reg);
         uint32_t reg_read_uint32(uint8_t address, uint8_t reg);
 
-        int write_bytes(uint8_t address, uint8_t reg, uint8_t *buf, int len);
+        int write_bytes(uint8_t address, uint8_t reg, const uint8_t *buf, int len);
         int read_bytes(uint8_t address, uint8_t reg, uint8_t *buf, int len);
         uint8_t get_bits(uint8_t address, uint8_t reg, uint8_t shift, uint8_t mask=0b1);
         void set_bits(uint8_t address, uint8_t reg, uint8_t shift, uint8_t mask=0b1);

--- a/drivers/is31fl3731/is31fl3731.cpp
+++ b/drivers/is31fl3731/is31fl3731.cpp
@@ -77,14 +77,7 @@ namespace pimoroni {
 
   void IS31FL3731::enable(std::initializer_list<uint8_t> pattern, uint8_t frame) {
     i2c->reg_write_uint8(address, reg::BANK, frame);
-    uint8_t enable_buf[19];
-    enable_buf[0] = ENABLE_OFFSET;
-    uint8_t offset = 1;
-    for(auto byte : pattern) {
-      enable_buf[offset] = byte;
-      offset++;
-    }
-    i2c->write_blocking(address, enable_buf, sizeof(enable_buf), false);
+    i2c->write_bytes(address, ENABLE_OFFSET, pattern.begin(), pattern.size());
   }
 
   void IS31FL3731::set(uint8_t index, uint8_t brightness) {

--- a/libraries/pico_explorer/README.md
+++ b/libraries/pico_explorer/README.md
@@ -13,7 +13,6 @@ We've included helper functions to handle every aspect of drawing to the screen 
     - [GPIO](#gpio)
   - [Functions](#functions)
     - [init](#init)
-    - [set_backlight](#set_backlight)
     - [set_motor](#set_motor)
     - [get_adc](#get_adc)
     - [set_audio_pin](#set_audio_pin)

--- a/libraries/pico_rgb_keypad/README.md
+++ b/libraries/pico_rgb_keypad/README.md
@@ -36,8 +36,8 @@ int main() {
     while(true) {
         current_buttons = get_button_states();
         changed_buttons = current_buttons ^ last_buttons;
-        pressed_buttons = current_buttons & changed;
-        released_buttons =  last_buttons & changed;
+        pressed_buttons = current_buttons & changed_buttons;
+        released_buttons =  last_buttons & changed_buttons;
 
         // Toggle the LED states when a button is pressed
         led_states ^= pressed_buttons;


### PR DESCRIPTION
* Bump Blinka to 6.20.1 (from 6.14.1)
* Bump PlatformDetetc to 3.19.3 (from 3.15.3)

See MicroPython release notes here: https://github.com/micropython/micropython/releases/tag/v1.18

Grab tests builds from artifacts:

* MicroPython - https://github.com/pimoroni/pimoroni-pico/actions/runs/1745323714
* MicroPython + Blinka - https://github.com/pimoroni/pimoroni-pico/actions/runs/1745323719

Or here:

* MicroPython - [pimoroni-pico--micropython-v1.18.uf2.zip](https://github.com/pimoroni/pimoroni-pico/files/7933561/pimoroni-pico--micropython-v1.18.uf2.zip)
* MicroPython + Blinka - [pimoroni-pico--micropython-v1.18-blinka-6.20.1-platformdetect-3.19.3.uf2.zip](https://github.com/pimoroni/pimoroni-pico/files/7933563/pimoroni-pico--micropython-v1.18-blinka-6.20.1-platformdetect-3.19.3.uf2.zip)
 