### PR TITLE
SCD41: Add i2c pins to MicroPython example

### DIFF
--- a/micropython/examples/breakout_scd41/scd41_demo.py
+++ b/micropython/examples/breakout_scd41/scd41_demo.py
@@ -3,7 +3,10 @@ import time
 import pimoroni_i2c
 import breakout_scd41
 
-i2c = pimoroni_i2c.PimoroniI2C(4, 5)
+PINS_BREAKOUT_GARDEN = {"sda": 4, "scl": 5}
+PINS_PICO_EXPLORER = {"sda": 20, "scl": 21}
+
+i2c = pimoroni_i2c.PimoroniI2C(**PINS_PICO_EXPLORER)
 
 breakout_scd41.init(i2c)
 breakout_scd41.start()

--- a/micropython/modules_py/pimoroni.py
+++ b/micropython/modules_py/pimoroni.py
@@ -2,6 +2,10 @@ import time
 from machine import Pin, PWM, ADC
 
 
+BREAKOUT_GARDEN_I2C_PINS = {"sda": 4, "scl": 5}
+PICO_EXPLORER_I2C_PINS = {"sda": 20, "scl": 21}
+
+
 class Analog:
     def __init__(self, pin, amplifier_gain=1, resistor=0):
         self.gain = amplifier_gain


### PR DESCRIPTION
Also adds pins into `pimoroni.py` so they don't need to be repeated in every example. Albeit that's quite handy for making it clear what the pins are.