### PR TITLE
I2C Library for boilerplate projects?

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -1,9 +1,1 @@
-add_library(pimoroni_i2c INTERFACE)
-
-target_sources(pimoroni_i2c INTERFACE
-  ${CMAKE_CURRENT_LIST_DIR}/pimoroni_i2c.cpp)
-
-target_include_directories(pimoroni_i2c INTERFACE ${CMAKE_CURRENT_LIST_DIR})
-
-# Pull in pico libraries that we need
-target_link_libraries(pimoroni_i2c INTERFACE pico_stdlib)
+include(pimoroni_i2c.cmake)

--- a/common/pimoroni_i2c.cmake
+++ b/common/pimoroni_i2c.cmake
@@ -1,0 +1,11 @@
+set(LIB_NAME pimoroni_i2c)
+add_library(${LIB_NAME} INTERFACE)
+
+target_sources(${LIB_NAME} INTERFACE
+    ${CMAKE_CURRENT_LIST_DIR}/${LIB_NAME}.cpp
+)
+
+target_include_directories(${LIB_NAME} INTERFACE ${CMAKE_CURRENT_LIST_DIR})
+
+# Pull in pico libraries that we need
+target_link_libraries(${LIB_NAME} INTERFACE pico_stdlib hardware_i2c)


### PR DESCRIPTION
So I was trying [the boilerplate project](https://github.com/pimoroni/pico-boilerplate) with the [plasma2040 rotary encoder example](https://github.com/pimoroni/pimoroni-pico/blob/main/examples/plasma2040/plasma2040_rotary.cpp) and it looked like it was trying to link with a library called `pimoroni-i2c` 

There wasn't one, so I made this cmake file to create one, and then could compile the example boilerplate. 

You can check out my boilerplate project [here](https://github.com/lordmortis/pimoroni-plasma-test) - maybe I was setting it up wrong? 

I think the linker is trying to link that library because of [this line](https://github.com/pimoroni/pimoroni-pico/blob/91b3ffb7d81d94009b5ca16ccaf9f0f23d808041/drivers/ioexpander/ioexpander.cmake#L10) in `ioexpander.cmake` ? 