### PR TITLE
Fix display buffer being trampled for #89

### DIFF
--- a/drivers/st7789/st7789.cpp
+++ b/drivers/st7789/st7789.cpp
@@ -86,7 +86,7 @@ namespace pimoroni {
       pwm_set_wrap(pwm_gpio_to_slice_num(bl), 65535);
       pwm_init(pwm_gpio_to_slice_num(bl), &cfg, true);
       gpio_set_function(bl, GPIO_FUNC_PWM);
-      set_backlight(255); // Turn backlight on by default to avoid nasty surprises
+      set_backlight(0); // Turn backlight off initially to avoid nasty surprises
     }
 
     // if auto_init_sequence then send initialisation sequence
@@ -176,6 +176,12 @@ namespace pimoroni {
       command(reg::CASET,     4, (char *)caset);
       command(reg::RASET,     4, (char *)raset);
       command(reg::MADCTL,    1, (char *)&madctl);
+
+      if(bl != PIN_UNUSED) {
+        update(); // Send the new buffer to the display to clear any previous content
+        sleep_ms(50); // Wait for the update to apply
+        set_backlight(255); // Turn backlight on now surprises have passed
+      }
     }
 
     // the dma transfer works but without vsync it's not that useful as you could

--- a/micropython/modules/pico_display/pico_display.cpp
+++ b/micropython/modules/pico_display/pico_display.cpp
@@ -20,9 +20,16 @@ mp_obj_t picodisplay_init(mp_obj_t buf_obj) {
     mp_buffer_info_t bufinfo;
     mp_get_buffer_raise(buf_obj, &bufinfo, MP_BUFFER_RW);
     picodisplay_buf_obj = buf_obj;
-    if(display == nullptr)
-        display = new PicoDisplay((uint16_t *)bufinfo.buf);
+
+    // If a display already exists, delete it
+    if(display != nullptr) {
+        delete display;
+    }
+
+    // Create a new display pointing to the newly provided buffer
+    display = new PicoDisplay((uint16_t *)bufinfo.buf);
     display->init();
+
     return mp_const_none;
 }
 

--- a/micropython/modules/pico_display_2/pico_display_2.cpp
+++ b/micropython/modules/pico_display_2/pico_display_2.cpp
@@ -20,9 +20,16 @@ mp_obj_t picodisplay2_init(mp_obj_t buf_obj) {
     mp_buffer_info_t bufinfo;
     mp_get_buffer_raise(buf_obj, &bufinfo, MP_BUFFER_RW);
     picodisplay2_buf_obj = buf_obj;
-    if(display2 == nullptr)
-        display2 = new PicoDisplay2((uint16_t *)bufinfo.buf);
+
+    // If a display already exists, delete it
+    if(display2 != nullptr) {
+        delete display2;
+    }
+
+    // Create a new display pointing to the newly provided buffer
+    display2 = new PicoDisplay2((uint16_t *)bufinfo.buf);
     display2->init();
+
     return mp_const_none;
 }
 

--- a/micropython/modules/pico_explorer/pico_explorer.cpp
+++ b/micropython/modules/pico_explorer/pico_explorer.cpp
@@ -20,9 +20,16 @@ mp_obj_t picoexplorer_init(mp_obj_t buf_obj) {
     mp_buffer_info_t bufinfo;
     mp_get_buffer_raise(buf_obj, &bufinfo, MP_BUFFER_RW);
     picoexplorer_buf_obj = buf_obj;
-    if(explorer == nullptr)
-        explorer = new PicoExplorer((uint16_t *)bufinfo.buf);
+
+    // If a display already exists, delete it
+    if(explorer != nullptr) {
+        delete explorer;
+    }
+
+    // Create a new display pointing to the newly provided buffer
+    explorer = new PicoExplorer((uint16_t *)bufinfo.buf);
     explorer->init();
+
     return mp_const_none;
 }
 


### PR DESCRIPTION
MicroPython was storing a singleton instance of the Pico Display library pointing to the address of the *first* buffer allocated. Subsequent soft resets would allocate a new buffer in MicroPython but not update the C++  library with its location.