### PR TITLE
Badger2040: Allow builtin demos to be replaced

### DIFF
--- a/.github/workflows/micropython-badger2040.yml
+++ b/.github/workflows/micropython-badger2040.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Copy modules & examples
       run: |
         cp -r pimoroni-pico-${GITHUB_SHA}/micropython/badger2040_modules_py/* micropython/ports/rp2/modules/
-        cp pimoroni-pico-${GITHUB_SHA}/micropython/examples/badger2040/launcher.py micropython/ports/rp2/modules/
+        cp pimoroni-pico-${GITHUB_SHA}/micropython/examples/badger2040/launcher.py micropython/ports/rp2/modules/_launcher.py
         cp pimoroni-pico-${GITHUB_SHA}/micropython/examples/badger2040/clock.py micropython/ports/rp2/modules/_clock.py
         cp pimoroni-pico-${GITHUB_SHA}/micropython/examples/badger2040/fonts.py micropython/ports/rp2/modules/_fonts.py
         cp pimoroni-pico-${GITHUB_SHA}/micropython/examples/badger2040/e-reader.py micropython/ports/rp2/modules/_ebook.py

--- a/micropython/badger2040_modules_py/boot.py
+++ b/micropython/badger2040_modules_py/boot.py
@@ -1,19 +1,6 @@
-#import gc
-#import machine
-#
-#a = machine.Pin(12, machine.Pin.IN, machine.Pin.PULL_DOWN)
-#b = machine.Pin(13, machine.Pin.IN, machine.Pin.PULL_DOWN)
-#c = machine.Pin(14, machine.Pin.IN, machine.Pin.PULL_DOWN)
-#
-#if a.value() or b.value() or c.value():
-#    for k in locals().keys():
-#        if k not in ("gc"):
-#            del locals()[k]
-#    gc.collect()
-#    __import__("launcher.py")
 try:
     open("main.py", "r")
 except OSError:
     with open("main.py", "w") as f:
-        f.write("import launcher")
+        f.write("import _launcher")
         f.flush()

--- a/micropython/examples/badger2040/launcher.py
+++ b/micropython/examples/badger2040/launcher.py
@@ -171,7 +171,10 @@ def launch(file):
         if k not in ("gc", "file"):
             del locals()[k]
     gc.collect()
-    __import__(file)
+    try:
+        __import__(file[1:])  # Try to import _[file] (drop underscore prefix)
+    except ImportError:
+        __import__(file)      # Failover to importing [_file]
     sys.exit(0)
 
 

--- a/micropython/examples/badger2040/launcher.py
+++ b/micropython/examples/badger2040/launcher.py
@@ -1,6 +1,5 @@
 import gc
 import os
-import sys
 import time
 import math
 import machine
@@ -19,14 +18,14 @@ inverted = False
 icons = bytearray(launchericons.data())
 
 examples = [
-    ("_clock.py", 0),
-    ("_fonts.py", 1),
-    ("_ebook.py", 2),
-    ("_image.py", 3),
-    ("_list.py", 4),
-    ("_badge.py", 5),
-    ("_info.py", 6),
-    ("_help.py", 7)
+    ("_clock", 0),
+    ("_fonts", 1),
+    ("_ebook", 2),
+    ("_image", 3),
+    ("_list", 4),
+    ("_badge", 5),
+    ("_info", 6),
+    ("_help", 7)
 ]
 
 font_sizes = (0.5, 0.7, 0.9)
@@ -140,7 +139,7 @@ def render():
     for i in range(max_icons):
         x = centers[i]
         label, icon = examples[i + (page * 3)]
-        label = label[1:-3]
+        label = label[1:]
         display.pen(0)
         display.icon(icons, icon, 512, 64, x - 32, 24)
         w = display.measure_text(label, font_sizes[font_size])
@@ -168,14 +167,14 @@ def render():
 
 def launch(file):
     for k in locals().keys():
-        if k not in ("gc", "file"):
+        if k not in ("gc", "file", "machine"):
             del locals()[k]
     gc.collect()
     try:
         __import__(file[1:])  # Try to import _[file] (drop underscore prefix)
     except ImportError:
         __import__(file)      # Failover to importing [_file]
-    sys.exit(0)
+    machine.reset()           # Exit back to launcher
 
 
 def launch_example(index):


### PR DESCRIPTION
Attempt to load .py files without the underscore prefix used by their builtin counterparts.

This allows you to override the builtin demos by saving one of the following files on your device:

* `clock.py`
* `fonts.py`
* `ebook.py`
* `image.py`
* `list.py`
* `badge.py`
* `help.py`
* `info.py`