### PR TITLE
Badger2040 C++ library and example fixes

### DIFF
--- a/examples/badger2040/badger2040_image.cpp
+++ b/examples/badger2040/badger2040_image.cpp
@@ -56,6 +56,9 @@ int main() {
   }
 
   badger.update();
+  while (badger.is_busy()) {
+    sleep_ms(10);
+  }
   badger.halt();
 
 }

--- a/examples/badger2040/badger2040_sleep.cpp
+++ b/examples/badger2040/badger2040_sleep.cpp
@@ -54,6 +54,10 @@ int main() {
   badger.text("(press any button to wake up.)", 10, 70, 0.4f);
   badger.update();
 
+  while (badger.is_busy()) {
+    sleep_ms(10);
+  }
+
   badger.halt();
 
   // proof we halted, the LED will not turn on

--- a/libraries/badger2040/badger2040.cpp
+++ b/libraries/badger2040/badger2040.cpp
@@ -33,6 +33,10 @@ namespace pimoroni {
     gpio_set_dir(D, GPIO_IN);
     gpio_set_pulls(D, false, true);
 
+    gpio_set_function(E, GPIO_FUNC_SIO);
+    gpio_set_dir(E, GPIO_IN);
+    gpio_set_pulls(E, false, true);
+
     gpio_set_function(USER, GPIO_FUNC_SIO);
     gpio_set_dir(USER, GPIO_IN);
     gpio_set_pulls(USER, false, true);
@@ -41,11 +45,11 @@ namespace pimoroni {
     gpio_set_dir(VBUS_DETECT, GPIO_IN);
     gpio_put(VBUS_DETECT, 1);
 
-/*
     // read initial button states
     uint32_t mask = (1UL << A) | (1UL << B) | (1UL << C) | (1UL << D) | (1UL << E);
     _wake_button_states |= gpio_get_all() & mask;
 
+/*
     // wait for button to be released before continuing
     while(gpio_get_all() & mask) {
       tight_loop_contents();
@@ -184,7 +188,11 @@ namespace pimoroni {
 
   void Badger2040::update_button_states() {
     uint32_t mask = (1UL << A) | (1UL << B) | (1UL << C) | (1UL << D) | (1UL << E);
-    _button_states |= gpio_get_all() & mask;
+    _button_states = gpio_get_all() & mask;
+  }
+
+  uint32_t Badger2040::button_states() {
+    return _button_states;
   }
 
   bool Badger2040::is_busy() {
@@ -335,7 +343,6 @@ namespace pimoroni {
   }
 
   void Badger2040::wait_for_press() {
-    _button_states = 0;
     update_button_states();
     while(_button_states == 0) {
       update_button_states();


### PR DESCRIPTION
Hi,

I'm not sure if you take pull requests, but I've made a couple of fixes to the Badger2040 library to make the C++ examples work correctly.

Main fix is that because `badger.update()` doesn't block, before halting the example should spin waiting for `badger.is_busy()` to return false before powering down, otherwise the last update effectively doesn't happen when running off battery.

The other fixes I've made are to:
- Set pull down on button E, this didn't obviously seem to be causing me a problem but it was odd that it was missing.
- Set the wake button states, as used by the image example (but I don't block waiting for the button to be released)
- Change `update_button_states()` to set the button states to the current value, rather than ORing in pressed buttons to the existing value, so that it is possible to check if a button is currently pressed without using `wait_for_press()`
- Implement the `button_states()` function so it is possible to test the masked states as a user.

Note I haven't tested if these fixes cause any problems in python land (if this library is even used by python - I haven't looked at that at all).

Cheers, Mike