### PR TITLE
badger2040: Set default clock to a valid date

### DIFF
--- a/micropython/examples/badger2040/clock.py
+++ b/micropython/examples/badger2040/clock.py
@@ -127,7 +127,7 @@ def draw_clock():
 year, month, day, wd, hour, minute, second, _ = rtc.datetime()
 
 if (year, month, day) == (2021, 1, 1):
-    rtc.datetime((2022, 2, 29, 3, 12, 0, 0, 0))
+    rtc.datetime((2022, 2, 28, 0, 12, 0, 0, 0))
 
 last_second = second
 


### PR DESCRIPTION
2022 isn't a leap year, so there is no 29th February!