### PR TITLE
Make USB powered and battery powered Badger2040 work the same

### DIFF
--- a/examples/badger2040/image_converter/convert.py
+++ b/examples/badger2040/image_converter/convert.py
@@ -24,8 +24,11 @@ options = parser.parse_args()
 def convert_image(img):
     if options.resize:
         img = img.resize((296, 128)) # resize
-    enhancer = ImageEnhance.Contrast(img)
-    img = enhancer.enhance(2.0)
+    try:
+      enhancer = ImageEnhance.Contrast(img)
+      img = enhancer.enhance(2.0)
+    except ValueError:
+      pass
     img = img.convert("1") # convert to black and white
     return img
 

--- a/libraries/badger2040/badger2040.cpp
+++ b/libraries/badger2040/badger2040.cpp
@@ -82,7 +82,12 @@ namespace pimoroni {
 
     // If running on USB we will not actually power down, so emulate the behaviour
     // of battery powered badge by listening for a button press and then resetting
-    wait_for_press();
+    // Note: Don't use wait_for_press as that waits for the button to be release and
+    //       we want the reboot to complete before the button is released.
+    update_button_states();
+    while(_button_states == 0) {
+      update_button_states();
+    }
     watchdog_reboot(0, 0, 0);
   }
 

--- a/libraries/badger2040/badger2040.cpp
+++ b/libraries/badger2040/badger2040.cpp
@@ -2,6 +2,7 @@
 #include <math.h>
 
 #include "hardware/pwm.h"
+#include "hardware/watchdog.h"
 
 #include "badger2040.hpp"
 
@@ -79,8 +80,10 @@ namespace pimoroni {
   void Badger2040::halt() {
     gpio_put(ENABLE_3V3, 0);
 
-    // don't allow any more code to execute while power rail drops
-    while(true) {}
+    // If running on USB we will not actually power down, so emulate the behaviour
+    // of battery powered badge by listening for a button press and then resetting
+    wait_for_press();
+    watchdog_reboot(0, 0, 0);
   }
 
   uint8_t _dither_value(int32_t x, int32_t y, uint8_t p) {

--- a/libraries/badger2040/badger2040.hpp
+++ b/libraries/badger2040/badger2040.hpp
@@ -9,7 +9,7 @@
 namespace pimoroni {
 
   class Badger2040 {
-  private:
+  protected:
     UC8151 uc8151;
     const hershey_font_t *_font = &futural;
     uint8_t _pen = 0;


### PR DESCRIPTION
One annoyance with the badger is difference in the behaviour of `halt()` between running with power connected and without.

I realised this would be simple to fix - instead of just looping forever in halt(), instead wait for a button press and then reset - this should give you exactly the same behaviour as when running from battery.

I've also included a couple of other small changes:
- A fix to make convert.py handle images that are already black and white
- And I hope you might indulge me and allow a change from the internal state of the Badger2040 class from private to protected, which would help me continue to use your class as a base for my LowPowerBadger.