### PR TITLE
Error handling for data_to_py import

### DIFF
--- a/examples/badger2040/image_converter/convert.py
+++ b/examples/badger2040/image_converter/convert.py
@@ -11,7 +11,7 @@ from PIL import Image, ImageEnhance
 from pathlib import Path
 try:
     import data_to_py
-except ImportError as error:
+except ImportError:
     pass
 
 parser = argparse.ArgumentParser(description='Converts images into the format used by Badger2040.')

--- a/examples/badger2040/image_converter/convert.py
+++ b/examples/badger2040/image_converter/convert.py
@@ -9,7 +9,10 @@ import io
 import argparse
 from PIL import Image, ImageEnhance
 from pathlib import Path
-import data_to_py
+try:
+    import data_to_py
+except ImportError as error:
+    pass
 
 parser = argparse.ArgumentParser(description='Converts images into the format used by Badger2040.')
 parser.add_argument('file', nargs="+", help='input files to convert')


### PR DESCRIPTION
Lets you run `convert.py` without `data_to_py` being present.

Fixes #283 