### PR TITLE
Build MicroPython for multiple boards

### DIFF
--- a/.github/workflows/micropython.yml
+++ b/.github/workflows/micropython.yml
@@ -14,8 +14,19 @@ jobs:
     runs-on: ubuntu-20.04
     name: Dependencies
     steps:
+    - name: Workspace Cache
+      id: cache
+      uses: actions/cache@v2
+      with:
+        path: ${{runner.workspace}}
+        key: workspace-micropython-${{github.ref}}-${{github.sha}}
+        restore-keys: |
+          workspace-${{github.ref}}
+          workspace-micropython-
+
     # Check out MicroPython
     - name: Checkout MicroPython
+      if: steps.cache.outputs.cache-hit != 'true'
       uses: actions/checkout@v2
       with:
         repository: micropython/micropython
@@ -24,38 +35,34 @@ jobs:
         path: micropython
 
     - uses: actions/checkout@v2
+      if: steps.cache.outputs.cache-hit != 'true'
       with:
         submodules: true
         path: pimoroni-pico-${{ github.sha }}
 
     # Copy Python module files
     - name: Copy modules
+      if: steps.cache.outputs.cache-hit != 'true'
       run: |
         cp -r pimoroni-pico-${GITHUB_SHA}/micropython/modules_py/* micropython/ports/rp2/modules/
 
     - name: Fetch base MicroPython submodules
+      if: steps.cache.outputs.cache-hit != 'true'
       shell: bash
       working-directory: micropython
       run: git submodule update --init
 
     - name: Fetch Pico SDK submodules
+      if: steps.cache.outputs.cache-hit != 'true'
       shell: bash
       working-directory: micropython/lib/pico-sdk
       run: git submodule update --init
 
     - name: Build mpy-cross
+      if: steps.cache.outputs.cache-hit != 'true'
       shell: bash
       working-directory: micropython/mpy-cross
       run: make
-
-    - name: Cache
-      uses: actions/cache@v2
-      with:
-        path: ${{runner.workspace}}
-        key: workspace-micropython-${{github.ref}}-${{github.sha}}
-        restore-keys: |
-          workspace-${{github.ref}}
-          workspace-micropython-
 
   build:
     needs: deps

--- a/.github/workflows/micropython.yml
+++ b/.github/workflows/micropython.yml
@@ -10,22 +10,11 @@ env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   MICROPYTHON_VERSION: v1.18
   BUILD_TYPE: Release
-  BOARD_TYPE: PICO
 
 jobs:
-  build:
-    name: ${{matrix.name}}
-    strategy:
-      matrix:
-        include:
-          - os: ubuntu-20.04
-            name: Linux
-            cache-key: linux
-            cmake-args: '-DPICO_SDK_PATH=$GITHUB_WORKSPACE/pico-sdk'
-            apt-packages: clang-tidy gcc-arm-none-eabi libnewlib-arm-none-eabi libstdc++-arm-none-eabi-newlib
-
-    runs-on: ${{matrix.os}}
-
+  deps:
+    runs-on: ubuntu-20.04
+    name: Dependencies
     steps:
     # Check out MicroPython
     - name: Checkout MicroPython
@@ -46,12 +35,6 @@ jobs:
       run: |
         cp -r pimoroni-pico-${GITHUB_SHA}/micropython/modules_py/* micropython/ports/rp2/modules/
 
-    # Linux deps
-    - name: Install deps
-      if: runner.os == 'Linux'
-      run: |
-        sudo apt update && sudo apt install ${{matrix.apt-packages}}
-
     - name: Fetch base MicroPython submodules
       shell: bash
       working-directory: micropython
@@ -67,21 +50,62 @@ jobs:
       working-directory: micropython/mpy-cross
       run: make
 
+    - name: Cache
+      uses: actions/cache@v2
+      with:
+        path: ${{runner.workspace}}
+        key: workspace-micropython-${{github.ref}}-${{github.sha}}
+        restore-keys: |
+          workspace-${{github.ref}}
+          workspace-micropython-
+
+  build:
+    needs: deps
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        board: [PICO, PIMORONI_TINY2040, PIMORONI_PICOLIPO_16MB]
+
+    steps:
+    - name: Cache
+      uses: actions/cache@v2
+      with:
+        path: /home/runner/.ccache
+        key: ccache-micropython-${{github.ref}}-${{github.sha}}
+        restore-keys: |
+          ccache-micropython-${{github.ref}}
+          ccache-micropython-
+  
+    - name: Cache
+      uses: actions/cache@v2
+      with:
+        path: ${{runner.workspace}}
+        key: workspace-micropython-${{github.ref}}-${{github.sha}}
+        restore-keys: |
+          workspace-${{github.ref}}
+          workspace-micropython-
+
+    - name: Install Compiler & CCache
+      if: runner.os == 'Linux'
+      run: |
+        sudo apt update && sudo apt install ccache gcc-arm-none-eabi
+  
     - name: Build MicroPython
       shell: bash
       working-directory: micropython/ports/rp2
-      run: make USER_C_MODULES=../../../pimoroni-pico-${GITHUB_SHA}/micropython/modules/micropython.cmake -j2
+      run: |
+        make USER_C_MODULES=../../../pimoroni-pico-${GITHUB_SHA}/micropython/modules/micropython.cmake BOARD=${{matrix.board}} -j2
 
     - name: Rename .uf2 for artifact
       shell: bash
-      working-directory: micropython/ports/rp2/build-${{env.BOARD_TYPE}}
-      run: cp firmware.uf2 ${{github.event.repository.name}}-${{github.event.release.tag_name}}-micropython-${{env.MICROPYTHON_VERSION}}.uf2
+      working-directory: micropython/ports/rp2/build-${{matrix.board}}
+      run: cp firmware.uf2 ${{github.event.repository.name}}-${{github.event.release.tag_name}}-${{matrix.board}}-micropython-${{env.MICROPYTHON_VERSION}}.uf2
 
     - name: Store .uf2 as artifact
       uses: actions/upload-artifact@v2
       with:
-        name: ${{github.event.repository.name}}-${{github.event.release.tag_name}}-micropython-${{env.MICROPYTHON_VERSION}}.uf2
-        path: micropython/ports/rp2/build-${{env.BOARD_TYPE}}/${{github.event.repository.name}}-${{github.event.release.tag_name}}-micropython-${{env.MICROPYTHON_VERSION}}.uf2
+        name: ${{github.event.repository.name}}-${{github.event.release.tag_name}}-${{matrix.board}}-micropython-${{env.MICROPYTHON_VERSION}}.uf2
+        path: micropython/ports/rp2/build-${{matrix.board}}/${{github.event.repository.name}}-${{github.event.release.tag_name}}-${{matrix.board}}-micropython-${{env.MICROPYTHON_VERSION}}.uf2
 
     - name: Upload .uf2
       if: github.event_name == 'release'
@@ -89,7 +113,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       with:
-        asset_path: micropython/ports/rp2/build-${{env.BOARD_TYPE}}/firmware.uf2
+        asset_path: micropython/ports/rp2/build-${{matrix.board}}/firmware.uf2
         upload_url: ${{github.event.release.upload_url}}
-        asset_name: ${{github.event.repository.name}}-${{github.event.release.tag_name}}-micropython-${{env.MICROPYTHON_VERSION}}.uf2
+        asset_name: ${{github.event.repository.name}}-${{github.event.release.tag_name}}-${{matrix.board}}-micropython-${{env.MICROPYTHON_VERSION}}.uf2
         asset_content_type: application/octet-stream

--- a/.github/workflows/micropython.yml
+++ b/.github/workflows/micropython.yml
@@ -7,9 +7,7 @@ on:
     types: [created]
 
 env:
-  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   MICROPYTHON_VERSION: v1.18
-  BUILD_TYPE: Release
 
 jobs:
   deps:
@@ -61,13 +59,24 @@ jobs:
 
   build:
     needs: deps
+    name: Build ${{matrix.board}}
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        board: [PICO, PIMORONI_TINY2040, PIMORONI_PICOLIPO_16MB]
+        include:
+        - name: pico
+          board: PICO
+        - name: tiny2040
+          board: PIMORONI_TINY2040
+        - name: picolipo_16mb
+          board: PIMORONI_PICOLIPO_16MB
+
+    env:
+      # MicroPython version will be contained in github.event.release.tag_name for releases
+      RELEASE_FILE: pimoroni-${{matrix.name}}-${{github.event.release.tag_name || github.sha}}-micropython.uf2
 
     steps:
-    - name: Cache
+    - name: Compiler Cache
       uses: actions/cache@v2
       with:
         path: /home/runner/.ccache
@@ -76,7 +85,7 @@ jobs:
           ccache-micropython-${{github.ref}}
           ccache-micropython-
   
-    - name: Cache
+    - name: Workspace Cache
       uses: actions/cache@v2
       with:
         path: ${{runner.workspace}}
@@ -89,23 +98,31 @@ jobs:
       if: runner.os == 'Linux'
       run: |
         sudo apt update && sudo apt install ccache gcc-arm-none-eabi
-  
+
+    - name: Configure MicroPython
+      shell: bash
+      working-directory: micropython/ports/rp2
+      run: |
+        cmake -S . -B build-${{matrix.board}} -DPICO_BUILD_DOCS=0 -DUSER_C_MODULES=../../../pimoroni-pico-${GITHUB_SHA}/micropython/modules/micropython.cmake -DMICROPY_BOARD=${{matrix.board}}
+
     - name: Build MicroPython
       shell: bash
       working-directory: micropython/ports/rp2
       run: |
-        make USER_C_MODULES=../../../pimoroni-pico-${GITHUB_SHA}/micropython/modules/micropython.cmake BOARD=${{matrix.board}} -j2
+        ccache --zero-stats || true
+        cmake --build build-${{matrix.board}} -j 2
+        ccache --show-stats || true
 
     - name: Rename .uf2 for artifact
       shell: bash
       working-directory: micropython/ports/rp2/build-${{matrix.board}}
-      run: cp firmware.uf2 ${{github.event.repository.name}}-${{github.event.release.tag_name}}-${{matrix.board}}-micropython-${{env.MICROPYTHON_VERSION}}.uf2
+      run: cp firmware.uf2 $RELEASE_FILE
 
     - name: Store .uf2 as artifact
       uses: actions/upload-artifact@v2
       with:
-        name: ${{github.event.repository.name}}-${{github.event.release.tag_name}}-${{matrix.board}}-micropython-${{env.MICROPYTHON_VERSION}}.uf2
-        path: micropython/ports/rp2/build-${{matrix.board}}/${{github.event.repository.name}}-${{github.event.release.tag_name}}-${{matrix.board}}-micropython-${{env.MICROPYTHON_VERSION}}.uf2
+        name: ${{env.RELEASE_FILE}}
+        path: micropython/ports/rp2/build-${{matrix.board}}/${{env.RELEASE_FILE}}
 
     - name: Upload .uf2
       if: github.event_name == 'release'
@@ -115,5 +132,5 @@ jobs:
       with:
         asset_path: micropython/ports/rp2/build-${{matrix.board}}/firmware.uf2
         upload_url: ${{github.event.release.upload_url}}
-        asset_name: ${{github.event.repository.name}}-${{github.event.release.tag_name}}-${{matrix.board}}-micropython-${{env.MICROPYTHON_VERSION}}.uf2
+        asset_name: ${{env.RELEASE_FILE}}
         asset_content_type: application/octet-stream

--- a/.github/workflows/micropython.yml
+++ b/.github/workflows/micropython.yml
@@ -62,6 +62,8 @@ jobs:
           board: PICO
         - name: tiny2040
           board: PIMORONI_TINY2040
+        - name: picolipo_4mb
+          board: PIMORONI_PICOLIPO_4MB
         - name: picolipo_16mb
           board: PIMORONI_PICOLIPO_16MB
 

--- a/.github/workflows/micropython.yml
+++ b/.github/workflows/micropython.yml
@@ -19,10 +19,9 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ${{runner.workspace}}
-        key: workspace-micropython-${{github.ref}}-${{github.sha}}
+        key: workspace-micropython-${{env.MICROPYTHON_VERSION}}
         restore-keys: |
-          workspace-${{github.ref}}
-          workspace-micropython-
+          workspace-micropython-${{env.MICROPYTHON_VERSION}}
 
     # Check out MicroPython
     - name: Checkout MicroPython
@@ -84,10 +83,9 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ${{runner.workspace}}
-        key: workspace-micropython-${{github.ref}}-${{github.sha}}
+        key: workspace-micropython-${{env.MICROPYTHON_VERSION}}
         restore-keys: |
-          workspace-${{github.ref}}
-          workspace-micropython-
+          workspace-micropython-${{env.MICROPYTHON_VERSION}}
 
     - name: Install Compiler & CCache
       if: runner.os == 'Linux'

--- a/.github/workflows/micropython.yml
+++ b/.github/workflows/micropython.yml
@@ -80,10 +80,10 @@ jobs:
       uses: actions/cache@v2
       with:
         path: /home/runner/.ccache
-        key: ccache-micropython-${{github.ref}}-${{github.sha}}
+        key: ccache-micropython-${{matrix.name}}-${{github.ref}}-${{github.sha}}
         restore-keys: |
-          ccache-micropython-${{github.ref}}
-          ccache-micropython-
+          ccache-micropython-${{matrix.name}}-${{github.ref}}
+          ccache-micropython-${{matrix.name}}-
   
     - name: Workspace Cache
       uses: actions/cache@v2
@@ -103,7 +103,7 @@ jobs:
       shell: bash
       working-directory: micropython/ports/rp2
       run: |
-        cmake -S . -B build-${{matrix.board}} -DPICO_BUILD_DOCS=0 -DUSER_C_MODULES=../../../pimoroni-pico-${GITHUB_SHA}/micropython/modules/micropython.cmake -DMICROPY_BOARD=${{matrix.board}}
+        cmake -S . -B build-${{matrix.board}} -DPICO_BUILD_DOCS=0 -DUSER_C_MODULES=../../../pimoroni-pico-${GITHUB_SHA}/micropython/modules/micropython.cmake -DMICROPY_BOARD=${{matrix.board}} -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 
     - name: Build MicroPython
       shell: bash

--- a/.github/workflows/micropython.yml
+++ b/.github/workflows/micropython.yml
@@ -34,18 +34,6 @@ jobs:
         submodules: false  # MicroPython submodules are hideously broken
         path: micropython
 
-    - uses: actions/checkout@v2
-      if: steps.cache.outputs.cache-hit != 'true'
-      with:
-        submodules: true
-        path: pimoroni-pico-${{ github.sha }}
-
-    # Copy Python module files
-    - name: Copy modules
-      if: steps.cache.outputs.cache-hit != 'true'
-      run: |
-        cp -r pimoroni-pico-${GITHUB_SHA}/micropython/modules_py/* micropython/ports/rp2/modules/
-
     - name: Fetch base MicroPython submodules
       if: steps.cache.outputs.cache-hit != 'true'
       shell: bash
@@ -105,6 +93,16 @@ jobs:
       if: runner.os == 'Linux'
       run: |
         sudo apt update && sudo apt install ccache gcc-arm-none-eabi
+  
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+        path: pimoroni-pico-${{ github.sha }}
+
+    # Copy Python module files
+    - name: Copy modules
+      run: |
+        cp -r pimoroni-pico-${GITHUB_SHA}/micropython/modules_py/* micropython/ports/rp2/modules/
 
     - name: Configure MicroPython
       shell: bash

--- a/.github/workflows/micropython.yml
+++ b/.github/workflows/micropython.yml
@@ -97,11 +97,6 @@ jobs:
         submodules: true
         path: pimoroni-pico-${{ github.sha }}
 
-    # Copy Python module files
-    - name: Copy modules
-      run: |
-        cp -r pimoroni-pico-${GITHUB_SHA}/micropython/modules_py/* micropython/ports/rp2/modules/
-
     - name: Configure MicroPython
       shell: bash
       working-directory: micropython/ports/rp2

--- a/micropython/modules/micropython.cmake
+++ b/micropython/modules/micropython.cmake
@@ -1,6 +1,7 @@
 include_directories(${CMAKE_CURRENT_LIST_DIR}/../../)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/../")
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/../../")
 
 include(pimoroni_i2c/micropython)
@@ -41,3 +42,5 @@ include(pico_wireless/micropython)
 include(plasma/micropython)
 include(hub75/micropython)
 include(ulab/code/micropython)
+
+include(modules_py/modules_py)

--- a/micropython/modules_py/modules_py.cmake
+++ b/micropython/modules_py/modules_py.cmake
@@ -1,0 +1,20 @@
+function (copy_module TARGET SRC DST)
+    add_custom_command(
+        OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/../modules/${DST}.py
+
+        COMMAND
+            cp ${SRC} ${CMAKE_CURRENT_BINARY_DIR}/../modules/${DST}.py
+
+        DEPENDS ${src}
+    )
+
+    target_sources(${TARGET} INTERFACE ${CMAKE_CURRENT_BINARY_DIR}/../modules/${DST}.py)
+endfunction()
+
+# Create a dummy usermod to hang our .py copies from
+add_library(usermod_modules_py INTERFACE)
+target_link_libraries(usermod INTERFACE usermod_modules_py)
+
+# .py files to copy from modules_py to ports/rp2/modules
+copy_module(usermod_modules_py ${CMAKE_CURRENT_LIST_DIR}/picosystem.py picosystem)
+copy_module(usermod_modules_py ${CMAKE_CURRENT_LIST_DIR}/pimoroni.py pimoroni)


### PR DESCRIPTION
Upgrades the CI to output builds for:

* Pico (2MB)
* Tiny 2040 (8MB)
* Pico LiPo (4MB)
* Pico LiPo (16MB)

Provides the 16MB Flash build requested in #272

I've added some significant caching both via ccache (for caching compiler output) and GitHub Actions cache.

MicroPython and the Pico SDK are cloned, prepped and cached per version- this cache should probably be used by other workflows to speed up these stages since the MicroPython version changes very rarely.

Installing ARM GCC is still a huge time sink- it needs to be done for *each* port from the list above and can take anywhere between 1 and 2 minutes, even hanging for much, much longer- this quickly multiplies up across all builds. Could we grab the zipped toolchain and cache it?