### PR TITLE
Updated path to esp32 drivers in /libraries/pico_wireless/pico_wireless.cmake

### DIFF
--- a/libraries/pico_wireless/pico_wireless.cmake
+++ b/libraries/pico_wireless/pico_wireless.cmake
@@ -1,4 +1,4 @@
-include(${CMAKE_CURRENT_LIST_DIR}/../../drivers/esp32wireless/esp32wireless.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/../../drivers/esp32spi/esp32spi.cmake)
 add_library(pico_wireless INTERFACE)
 
 target_sources(pico_wireless INTERFACE


### PR DESCRIPTION
I updated the path to the esp32 drivers, responsible for the error specified in Issue #311 