### PR TITLE
Badger2040: Fix builtin module depends typo.

### DIFF
--- a/micropython/examples/badger2040/micropython-builtins.cmake
+++ b/micropython/examples/badger2040/micropython-builtins.cmake
@@ -29,7 +29,7 @@ function (copy_module TARGET SRC DST)
         COMMAND
             cp ${SRC} ${CMAKE_CURRENT_BINARY_DIR}/../modules/${DST}.py
 
-        DEPENDS ${src}
+        DEPENDS ${SRC}
     )
 
     target_sources(${TARGET} INTERFACE ${CMAKE_CURRENT_BINARY_DIR}/../modules/${DST}.py)


### PR DESCRIPTION
40 minutes of bashing my head against CMake custom targets and custom commands only to suddenly notice this typo...

:grimacing: 