### PR TITLE
Badger2040: Improve help, info, qrgen

### DIFF
--- a/micropython/examples/badger2040/help.py
+++ b/micropython/examples/badger2040/help.py
@@ -2,7 +2,7 @@ import badger2040
 from badger2040 import WIDTH
 
 TEXT_SIZE = 0.45
-LINE_HEIGHT = 16
+LINE_HEIGHT = 20
 
 display = badger2040.Badger2040()
 display.led(128)
@@ -12,29 +12,31 @@ display.rectangle(0, 0, WIDTH, 16)
 display.thickness(1)
 display.pen(15)
 display.text("badgerOS", 3, 8, 0.4)
+display.text("help", WIDTH - display.measure_text("help", 0.4) - 4, 8, 0.4)
 
 display.pen(0)
 
-y = 16 + int(LINE_HEIGHT / 2)
+TEXT_SIZE = 0.62
+y = 20 + int(LINE_HEIGHT / 2)
 
 display.thickness(2)
-display.text("Normal:", 0, y, TEXT_SIZE)
-display.thickness(1)
-y += LINE_HEIGHT
-display.text("Up / Down - Change launcher page", 0, y, TEXT_SIZE)
+display.font("sans")
+display.text("Up/Down - Change page", 0, y, TEXT_SIZE)
 y += LINE_HEIGHT
 display.text("a, b or c - Launch app", 0, y, TEXT_SIZE)
 y += LINE_HEIGHT
+display.text("a & c - Exit app", 0, y, TEXT_SIZE)
 y += LINE_HEIGHT
 
-display.thickness(2)
-display.text("Hold USER after:", 0, y, TEXT_SIZE)
-display.thickness(1)
+y += 8
+display.text("Up/Down & User - Font size", 0, y, TEXT_SIZE)
 y += LINE_HEIGHT
-display.text("Up / Down - Change font size", 0, y, TEXT_SIZE)
-y += LINE_HEIGHT
-display.text("a  - Toggle invert", 0, y, TEXT_SIZE)
+display.text("a & User - Toggle invert", 0, y, TEXT_SIZE)
 y += LINE_HEIGHT
 
 display.update()
-display.halt()
+
+# Call halt in a loop, on battery this switches off power.
+# On USB, the app will exit when A+C is pressed because the launcher picks that up.
+while True:
+    display.halt()

--- a/micropython/examples/badger2040/info.py
+++ b/micropython/examples/badger2040/info.py
@@ -12,6 +12,7 @@ display.rectangle(0, 0, WIDTH, 16)
 display.thickness(1)
 display.pen(15)
 display.text("badgerOS", 3, 8, 0.4)
+display.text("info", WIDTH - display.measure_text("help", 0.4) - 4, 8, 0.4)
 
 display.pen(0)
 
@@ -34,4 +35,8 @@ y += LINE_HEIGHT
 display.text("https://pimoroni.com/badger2040", 0, y, TEXT_SIZE)
 
 display.update()
-display.halt()
+
+# Call halt in a loop, on battery this switches off power.
+# On USB, the app will exit when A+C is pressed because the launcher picks that up.
+while True:
+    display.halt()

--- a/micropython/examples/badger2040/qrgen.py
+++ b/micropython/examples/badger2040/qrgen.py
@@ -65,4 +65,8 @@ for line in detail_text:
     top += 10
 
 display.update()
-display.halt()
+
+# Call halt in a loop, on battery this switches off power.
+# On USB, the app will exit when A+C is pressed because the launcher picks that up.
+while True:
+    display.halt()


### PR DESCRIPTION
This fixes #317.  I've also tweaked help to try and improve readability and add the a&c exit combo.  

This has lost the subtlety of USER needing to be pressed after the other buttons on battery, but I'm not sure how clear that was anyway.

One thought I had was that new users are likely to go into an app and have no way of knowing how to exit.  Reset no longer gets you out.  So maybe the default launcher state on a fresh Badger should be to launch the help app?