### PR TITLE
Extending qrgen.py to allow multiple QR Code files

### DIFF
--- a/micropython/examples/badger2040/qrgen.py
+++ b/micropython/examples/badger2040/qrgen.py
@@ -1,13 +1,22 @@
 import badger2040
 import qrcode
+import time
+import machine
+import os
+import badger_os
 
-
-# Open the qrcode file
+# Check that the qrcodes directory exists, if not, make it
 try:
-    text = open("qrcode.txt", "r")
+    os.mkdir("qrcodes")
 except OSError:
-    with open("qrcode.txt", "w") as text:
-        text.write("""https://pimoroni.com/badger2040
+    pass
+
+# Check that there is a qrcode.txt, if not preload
+try:
+    text = open("qrcodes/qrcode.txt", "r")
+except OSError:
+    text = open("qrcodes/qrcode.txt", "w")
+    text.write("""https://pimoroni.com/badger2040
 Badger 2040
 * 296x128 1-bit e-ink
 * six user buttons
@@ -17,18 +26,37 @@ Badger 2040
 Scan this code to learn
 more about Badger 2040.
 """)
-        text.flush()
-    text = open("qrcode.txt", "r")
+    text.flush()
+    text.seek(0)
+
+# Load all available QR Code Files
+try:
+    CODES = [f for f in os.listdir("/qrcodes") if f.endswith(".txt")]
+    TOTAL_CODES = len(CODES)
+except OSError:
+    pass
 
 
-lines = text.read().strip().split("\n")
-code_text = lines.pop(0)
-title_text = lines.pop(0)
-detail_text = lines
+print(f'There are {TOTAL_CODES} QR Codes available:')
+for codename in CODES:
+    print(f'File: {codename}')
 
 display = badger2040.Badger2040()
-display.led(128)
+
 code = qrcode.QRCode()
+
+
+button_a = machine.Pin(badger2040.BUTTON_A, machine.Pin.IN, machine.Pin.PULL_DOWN)
+button_b = machine.Pin(badger2040.BUTTON_B, machine.Pin.IN, machine.Pin.PULL_DOWN)
+button_c = machine.Pin(badger2040.BUTTON_C, machine.Pin.IN, machine.Pin.PULL_DOWN)
+
+button_up = machine.Pin(badger2040.BUTTON_UP, machine.Pin.IN, machine.Pin.PULL_DOWN)
+button_down = machine.Pin(badger2040.BUTTON_DOWN, machine.Pin.IN, machine.Pin.PULL_DOWN)
+
+
+state = {
+    "current_qr": 0
+}
 
 
 def measure_qr_code(size, code):
@@ -48,21 +76,75 @@ def draw_qr_code(ox, oy, size, code):
                 display.rectangle(ox + x * module_size, oy + y * module_size, module_size, module_size)
 
 
-code.set_text(code_text)
-size, _ = measure_qr_code(128, code)
-left = top = int((badger2040.HEIGHT / 2) - (size / 2))
-draw_qr_code(left, top, 128, code)
+def draw_qr_file(n):
+    display.led(128)
+    file = CODES[n]
+    codetext = open("qrcodes/{}".format(file), "r")
 
-left = 128 + 5
+    lines = codetext.read().strip().split("\n")
+    code_text = lines.pop(0)
+    title_text = lines.pop(0)
+    detail_text = lines
 
-display.thickness(2)
-display.text(title_text, left, 20, 0.5)
-display.thickness(1)
+    # Clear the Display
+    display.pen(15)  # Change this to 0 if a white background is used
+    display.clear()
+    display.pen(0)
 
-top = 40
-for line in detail_text:
-    display.text(line, left, top, 0.4)
-    top += 10
+    code.set_text(code_text)
+    size, _ = measure_qr_code(128, code)
+    left = top = int((badger2040.HEIGHT / 2) - (size / 2))
+    draw_qr_code(left, top, 128, code)
 
-display.update()
-display.halt()
+    left = 128 + 5
+
+    display.thickness(2)
+    display.text(title_text, left, 20, 0.5)
+    display.thickness(1)
+
+    top = 40
+    for line in detail_text:
+        display.text(line, left, top, 0.4)
+        top += 10
+
+    if(TOTAL_CODES > 1):
+        for i in range(TOTAL_CODES):
+            x = 286
+            y = int((128 / 2) - (TOTAL_CODES * 10 / 2) + (i * 10))
+            display.pen(0)
+            display.rectangle(x, y, 8, 8)
+            if state["current_qr"] != i:
+                display.pen(15)
+                display.rectangle(x + 1, y + 1, 6, 6)
+    display.update()
+
+
+badger_os.state_load("qrcodes", state)
+changed = not badger2040.woken_by_button()
+
+while True:
+    if(TOTAL_CODES > 1):
+        if button_up.value():
+            if state["current_qr"] > 0:
+                state["current_qr"] -= 1
+                changed = True
+
+        if button_down.value():
+            if state["current_qr"] < TOTAL_CODES - 1:
+                state["current_qr"] += 1
+                changed = True
+
+    if button_b.value() or button_c.value():
+        display.pen(15)
+        display.clear()
+        badger_os.warning(display, "To add QR codes, connect Badger2040 to a PC, load up Thonny, and see qrgen.py.")
+        time.sleep(4)
+        changed = True
+
+    if changed:
+        badger_os.state_save("qrcodes", state)
+        draw_qr_file(state["current_qr"])
+        changed = False
+
+    # Halt the Badger to save power, it will wake up if any of the front buttons are pressed
+    display.halt()


### PR DESCRIPTION
I made a mess of the merge in PR #297, so have run a clean branch with the new changes on top.

This is a remix on qrgen.py, pulling in features from image.py that would allow for multiple qr code files that could be cycled through. I don't know if you'd rather keep the qrgen.py example "clean", but I'm using this personally on my badger2040 so thought others might like to as well.

On first start, it creates a qrcodes directory, then adds the example file in there instead, the acts just like the image example where it draws dots on the right hand side and allows you to cycle through with the up and down buttons.

Signed-off-by: James Sutton <1068763+jpwsutton@users.noreply.github.com>