### PR TITLE
Badger2040: system_speed call, plus performance improvements

### DIFF
--- a/drivers/uc8151/uc8151.cpp
+++ b/drivers/uc8151/uc8151.cpp
@@ -481,15 +481,15 @@ namespace pimoroni {
   uint32_t UC8151::update_time() {
     switch(_update_speed) {
       case 0:
-        return 5500;
+        return 4500;
       case 1:
-        return 2600;
+        return 2000;
       case 2:
-        return 1000;
+        return 800;
       case 3:
-        return 300;
+        return 250;
       default:
-        return 5500;
+        return 4500;
     }
   }
 

--- a/drivers/uc8151/uc8151.cpp
+++ b/drivers/uc8151/uc8151.cpp
@@ -461,6 +461,10 @@ namespace pimoroni {
     *p |= b; // set bit value
   }
 
+  uint8_t* UC8151::get_frame_buffer() {
+	  return frame_buffer;
+  }
+
   void UC8151::invert(bool inv) {
     inverted = inv;
     command(CDI, {(uint8_t)(inverted ? 0b01'01'1100 : 0b01'00'1100)}); // vcom and data interval

--- a/drivers/uc8151/uc8151.hpp
+++ b/drivers/uc8151/uc8151.hpp
@@ -208,6 +208,7 @@ namespace pimoroni {
     void off();
 
     void pixel(int x, int y, int v);
+    uint8_t* get_frame_buffer();
   };
 
 }

--- a/libraries/badger2040/badger2040.cpp
+++ b/libraries/badger2040/badger2040.cpp
@@ -177,7 +177,7 @@ namespace pimoroni {
           
           // Set bit in val if set in source data
           if (data[o] & bm) {
-            val |= 1 << cy;
+            val |= 0b10000000 >> cy;
           }
         }
         *ptr++ = val;
@@ -187,7 +187,12 @@ namespace pimoroni {
 
   // Display an image smaller than the screen (sw*sh) at dx, dy
   void Badger2040::image(const uint8_t *data, int w, int h, int x, int y) {
-    image(data, w, 0, 0, w, h, x, y);
+    if (x == 0 && y == 0 && w == 296 && h == 128) {
+      image(data);
+    }
+    else {
+      image(data, w, 0, 0, w, h, x, y);
+    }
   }
 
   void Badger2040::image(const uint8_t *data, int stride, int sx, int sy, int dw, int dh, int dx, int dy) {

--- a/micropython/examples/badger2040/clock.py
+++ b/micropython/examples/badger2040/clock.py
@@ -2,6 +2,8 @@ import time
 import machine
 import badger2040
 
+# We're going to keep the badger on, so slow down the system clock if on battery
+badger2040.system_speed(badger2040.SYSTEM_SLOW)
 
 rtc = machine.RTC()
 display = badger2040.Badger2040()

--- a/micropython/examples/badger2040/conway.py
+++ b/micropython/examples/badger2040/conway.py
@@ -6,6 +6,9 @@ import machine
 
 import badger2040
 
+# Overclock the RP2040 to run the sim faster
+badger2040.system_speed(badger2040.SYSTEM_TURBO)
+
 # ------------------------------
 #        Program setup
 # ------------------------------
@@ -16,6 +19,7 @@ INITIAL_DENSITY = 0.3  # Density of cells at start
 
 # Create a new Badger and set it to update TURBO
 screen = badger2040.Badger2040()
+screen.led(128)
 screen.update_speed(badger2040.UPDATE_TURBO)
 
 restart = False  # should sim be restarted

--- a/micropython/examples/badger2040/launcher.py
+++ b/micropython/examples/badger2040/launcher.py
@@ -1,7 +1,6 @@
 import gc
 import time
 import math
-import machine
 import badger2040
 from badger2040 import WIDTH
 import launchericons

--- a/micropython/examples/badger2040/launcher.py
+++ b/micropython/examples/badger2040/launcher.py
@@ -7,8 +7,8 @@ from badger2040 import WIDTH
 import launchericons
 import badger_os
 
-# Reduce clock speed to 48MHz, that's fast enough!
-machine.freq(48000000)
+# Reduce clock speed to 48MHz if on USB or 12MHz if on battery
+badger2040.system_speed(badger2040.SYSTEM_SLOW)
 
 changed = False
 exited_to_launcher = False

--- a/micropython/examples/badger2040/launcher.py
+++ b/micropython/examples/badger2040/launcher.py
@@ -7,8 +7,8 @@ from badger2040 import WIDTH
 import launchericons
 import badger_os
 
-# Reduce clock speed to 48MHz if on USB or 12MHz if on battery
-badger2040.system_speed(badger2040.SYSTEM_SLOW)
+# Reduce clock speed to 48MHz
+badger2040.system_speed(badger2040.SYSTEM_NORMAL)
 
 changed = False
 exited_to_launcher = False

--- a/micropython/modules/badger2040/README.md
+++ b/micropython/modules/badger2040/README.md
@@ -71,7 +71,7 @@ Badger 2040 features five buttons on its front, labelled A, B, C, ↑ (up), ↓ 
 
 The system clock speed of the RP2040 can be controlled, allowing power to be saved if on battery, or faster computations to be performed.  Use `badger2040.system_speed(speed)` where `speed` is one of the following constants:
 
-* `SYSTEM_VERY_SLOW` = `0`  _3 MHz if on battery, 48 MHz if connected to USB_
+* `SYSTEM_VERY_SLOW` = `0`  _4 MHz if on battery, 48 MHz if connected to USB_
 * `SYSTEM_SLOW` = `1`  _12 MHz if on battery, 48 MHz if connected to USB_
 * `SYSTEM_NORMAL` = `2`  _48 MHz_
 * `SYSTEM_FAST` = `3`  _133 MHz_

--- a/micropython/modules/badger2040/README.md
+++ b/micropython/modules/badger2040/README.md
@@ -67,7 +67,19 @@ Badger 2040 features five buttons on its front, labelled A, B, C, ↑ (up), ↓ 
 * `BUTTON_DOWN` = `11`
 * `BUTTON_USER` = `23`
 
-Note, due to the BOOT/USR button performing both BOOT and USER functions, the output of reading it with `pressed()` will be inverted from the others.
+## System speed
+
+The system clock speed of the RP2040 can be controlled, allowing power to be saved if on battery, or faster computations to be performed.  Use `badger2040.system_speed(speed)` where `speed` is one of the following constants:
+
+* `SYSTEM_VERY_SLOW` = `0`  _3 MHz if on battery, 48 MHz if connected to USB_
+* `SYSTEM_SLOW` = `1`  _12 MHz if on battery, 48 MHz if connected to USB_
+* `SYSTEM_NORMAL` = `2`  _48 MHz_
+* `SYSTEM_FAST` = `3`  _133 MHz_
+* `SYSTEM_TURBO` = `4`  _250 MHz_
+
+On USB, the system will not run slower than 48MHz, as that is the minimum clock speed required to keep the USB connection stable.
+
+Note that `SYSTEM_TURBO` overclocks the RP2040 to 250MHz, and applies a small over voltage to ensure this is stable.  We've found that every RP2040 we've tested is happy to run at this speed without any issues.
 
 ## Other Functions
 
@@ -95,7 +107,6 @@ icon(data, icon_index, sheet_size, icon_size)
 clear()
 update()
 partial_update(x, y, w, h)
-update_speed(speed)
 invert(inverted)
 ```
 

--- a/micropython/modules/badger2040/badger2040.c
+++ b/micropython/modules/badger2040/badger2040.c
@@ -35,6 +35,7 @@ MP_DEFINE_CONST_FUN_OBJ_3(Badger2040_command_obj, Badger2040_command);
 MP_DEFINE_CONST_FUN_OBJ_1(Badger2040_pressed_to_wake_obj, Badger2040_pressed_to_wake);
 MP_DEFINE_CONST_FUN_OBJ_1(Badger2040_halt_obj, Badger2040_halt);
 MP_DEFINE_CONST_FUN_OBJ_0(Badger2040_woken_by_button_obj, Badger2040_woken_by_button);
+MP_DEFINE_CONST_FUN_OBJ_1(Badger2040_system_speed_obj, Badger2040_system_speed);
 
 /***** Binding of Methods *****/
 STATIC const mp_rom_map_elem_t Badger2040_locals_dict_table[] = {
@@ -90,12 +91,19 @@ STATIC const mp_rom_map_elem_t badger2040_globals_table[] = {
 
     { MP_ROM_QSTR(MP_QSTR_pressed_to_wake), MP_ROM_PTR(&Badger2040_pressed_to_wake_obj) },
     { MP_ROM_QSTR(MP_QSTR_woken_by_button), MP_ROM_PTR(&Badger2040_woken_by_button_obj) },
+    { MP_ROM_QSTR(MP_QSTR_system_speed), MP_ROM_PTR(&Badger2040_system_speed_obj) },
 
     { MP_ROM_QSTR(MP_QSTR_UPDATE_NORMAL), MP_ROM_INT(0) },
     { MP_ROM_QSTR(MP_QSTR_UPDATE_MEDIUM), MP_ROM_INT(1) },
     { MP_ROM_QSTR(MP_QSTR_UPDATE_FAST), MP_ROM_INT(2) },
     { MP_ROM_QSTR(MP_QSTR_UPDATE_TURBO), MP_ROM_INT(3) },
     { MP_ROM_QSTR(MP_QSTR_UPDATE_SUPER_EXTRA_TURBO), MP_ROM_INT(3) }, // ho ho placebo!
+
+    { MP_ROM_QSTR(MP_QSTR_SYSTEM_VERY_SLOW), MP_ROM_INT(0) },
+    { MP_ROM_QSTR(MP_QSTR_SYSTEM_SLOW), MP_ROM_INT(1) },
+    { MP_ROM_QSTR(MP_QSTR_SYSTEM_NORMAL), MP_ROM_INT(2) },
+    { MP_ROM_QSTR(MP_QSTR_SYSTEM_FAST), MP_ROM_INT(3) },
+    { MP_ROM_QSTR(MP_QSTR_SYSTEM_TURBO), MP_ROM_INT(4) },
 
     { MP_ROM_QSTR(MP_QSTR_WIDTH), MP_ROM_INT(296) },
     { MP_ROM_QSTR(MP_QSTR_HEIGHT), MP_ROM_INT(128) },

--- a/micropython/modules/badger2040/badger2040.cpp
+++ b/micropython/modules/badger2040/badger2040.cpp
@@ -551,8 +551,8 @@ mp_obj_t Badger2040_system_speed(mp_obj_t speed) {
         sys_freq = 12 * MHZ;
         break;
 
-    case 0: // VERY_SLOW: 3 MHZ, 1.0V
-        sys_freq = 3 * MHZ;
+    case 0: // VERY_SLOW: 4 MHZ, 1.0V
+        sys_freq = 4 * MHZ;
         break;
     }
 

--- a/micropython/modules/badger2040/badger2040.h
+++ b/micropython/modules/badger2040/badger2040.h
@@ -43,3 +43,5 @@ extern mp_obj_t Badger2040_command(mp_obj_t self_in, mp_obj_t reg, mp_obj_t data
 
 extern mp_obj_t Badger2040_pressed_to_wake(mp_obj_t button);
 extern mp_obj_t Badger2040_woken_by_button();
+
+extern mp_obj_t Badger2040_system_speed(mp_obj_t speed);

--- a/micropython/modules/badger2040/micropython.cmake
+++ b/micropython/modules/badger2040/micropython.cmake
@@ -20,4 +20,7 @@ target_compile_definitions(usermod_${MOD_NAME} INTERFACE
     MODULE_BADGER2040_ENABLED=1
 )
 
-target_link_libraries(usermod INTERFACE usermod_${MOD_NAME})
+target_link_libraries(usermod INTERFACE usermod_${MOD_NAME}
+  hardware_vreg
+  hardware_pll
+  hardware_resets)


### PR DESCRIPTION
I've added a `badger2040.system_speed()` call to allow the user to easily adjust the clock speed to 5 settings, from 3MHz to 250MHz in sensible steps, applying under/over voltage as appropriate.  Lower clock frequencies are not available when USB is connected, but can be used to save power when on battery.

Clearing the screen and drawing large rectangles were relatively inefficient, so I now do these by editing the framebuffer directly.  Rectangles honour the odd behaviour of being affected by the current thickness setting, to preserve backwards compatibility.