### PR TITLE
Badger weather recorder using BME68x

### DIFF
--- a/drivers/bme68x/bme68x.cpp
+++ b/drivers/bme68x/bme68x.cpp
@@ -48,6 +48,32 @@ namespace pimoroni {
         return true;
     }
 
+    bool BME68X::read_tph(bme68x_data *data) {
+        int8_t result = 0;
+        uint8_t n_fields;
+        uint32_t delay_period;
+
+        heatr_conf.enable = BME68X_DISABLE;
+        heatr_conf.heatr_temp = 0;
+        heatr_conf.heatr_dur = 0;
+        result = bme68x_set_heatr_conf(BME68X_FORCED_MODE, &heatr_conf, &device);
+        bme68x_check_rslt("bme68x_set_heatr_conf", result);
+        if(result != BME68X_OK) return false;
+
+        result = bme68x_set_op_mode(BME68X_FORCED_MODE, &device);
+        bme68x_check_rslt("bme68x_set_op_mode", result);
+        if(result != BME68X_OK) return false;
+        delay_period = bme68x_get_meas_dur(BME68X_FORCED_MODE, &conf, &device);
+        // Could probably just call sleep_us here directly, I guess the API uses this internally
+        device.delay_us(delay_period, device.intf_ptr);
+
+        result = bme68x_get_data(BME68X_FORCED_MODE, data, &n_fields, &device);
+        bme68x_check_rslt("bme68x_get_data", result);
+        if(result != BME68X_OK) return false;
+
+        return true;
+    }
+
     bool BME68X::read_forced(bme68x_data *data, uint16_t heater_temp, uint16_t heater_duration) {
         int8_t result = 0;
         uint8_t n_fields;

--- a/drivers/bme68x/bme68x.hpp
+++ b/drivers/bme68x/bme68x.hpp
@@ -22,6 +22,7 @@ namespace pimoroni {
 
             bool init();
             bool configure(uint8_t filter, uint8_t odr, uint8_t os_humidity, uint8_t os_pressure, uint8_t os_temp);
+            bool read_tph(bme68x_data *data);
             bool read_forced(bme68x_data *data, uint16_t heater_temp=300, uint16_t heater_duration=100);
             bool read_parallel(bme68x_data *results, uint16_t *profile_temps, uint16_t *profile_durations, size_t profile_length);
 

--- a/micropython/examples/badger2040/bme.py
+++ b/micropython/examples/badger2040/bme.py
@@ -1,0 +1,140 @@
+import time
+
+from breakout_bme68x import BreakoutBME68X, OVERSAMPLING_4X
+from pimoroni_i2c import PimoroniI2C
+import badger2040
+
+badger2040.system_speed(badger2040.SYSTEM_SLOW)
+
+i2c = PimoroniI2C(sda=4, scl=5)
+bme = BreakoutBME68X(i2c)
+bme.configure(os_humidity=OVERSAMPLING_4X)
+
+display = badger2040.Badger2040()
+display.led(128)
+display.update_speed(badger2040.UPDATE_FAST)
+
+HIST_LEN = 288
+temp_hist = [[-1] * HIST_LEN, [-1] * HIST_LEN, [-1] * HIST_LEN]
+pres_hist = [[-1] * HIST_LEN, [-1] * HIST_LEN, [-1] * HIST_LEN]
+humid_hist = [[-1] * HIST_LEN, [-1] * HIST_LEN, [-1] * HIST_LEN]
+hist_idx = [0] * 3
+
+DISPLAY_TEXT = 0
+DISPLAY_TEMP = 1
+DISPLAY_PRES = 2
+DISPLAY_HUMID = 3
+DISPLAY_MAX = 3
+display_screen = 0
+display_hist = 0
+
+X_OFFSET = 296 - HIST_LEN
+
+while True:
+    temp, pres, humidity = bme.read_tph()
+    pres /= 100
+    temp_hist[0][hist_idx[0]], pres_hist[0][hist_idx[0]], humid_hist[0][hist_idx[0]] = temp, pres, humidity
+    
+    hist_idx[0] += 1
+    if (hist_idx[0] % 12) == 0:
+        temp_hist[1][hist_idx[1]] = sum(temp_hist[0][hist_idx[0]-12:hist_idx[0]]) / 12
+        pres_hist[1][hist_idx[1]] = sum(pres_hist[0][hist_idx[0]-12:hist_idx[0]]) / 12
+        humid_hist[1][hist_idx[1]] = sum(humid_hist[0][hist_idx[0]-12:hist_idx[0]]) / 12
+        hist_idx[1] += 1
+        if (hist_idx[1] % 12) == 0:
+            temp_hist[2][hist_idx[2]] = sum(temp_hist[1][hist_idx[1]-12:hist_idx[1]]) / 12
+            pres_hist[2][hist_idx[2]] = sum(pres_hist[1][hist_idx[1]-12:hist_idx[1]]) / 12
+            humid_hist[2][hist_idx[2]] = sum(humid_hist[1][hist_idx[1]-12:hist_idx[1]]) / 12
+            hist_idx[2] += 1
+            if hist_idx[2] >= HIST_LEN: hist_idx[2] = 0
+        if hist_idx[1] >= HIST_LEN: hist_idx[1] = 0
+    if hist_idx[0] >= HIST_LEN: hist_idx[0] = 0
+    
+    update = (hist_idx[0] % 12) == 1
+    if display_screen != DISPLAY_TEXT and display_hist == 2:
+        update = update and (hist_idx[1] % 12) == 1
+    
+    if display.pressed(badger2040.BUTTON_A):
+        display_screen -= 1
+        if display_screen < 0: display_screen = DISPLAY_MAX
+        update = True
+    if display.pressed(badger2040.BUTTON_C):
+        display_screen += 1
+        if display_screen > DISPLAY_MAX: display_screen = 0
+        update = True
+    if display.pressed(badger2040.BUTTON_B) and display_screen != DISPLAY_TEXT:
+        display_hist += 1
+        if display_hist > 2: display_hist = 0
+        update = True
+
+    if update:
+        if display_screen == DISPLAY_TEXT:
+            display.pen(15)
+            display.clear()
+            display.pen(0)
+            
+            display.font("sans")
+            display.text("Temp: {:.2f}C".format(temp), 5, 20, 1)
+            display.text("Press: {:.1f}mB".format(pres), 5, 60, 1)
+            display.text("Humid: {:.1f}%".format(humidity), 5, 100, 1)
+            display.update()
+        else:
+            if display_screen == DISPLAY_TEMP:
+                hist_head = "Temperature (C)"
+                hist_values = temp_hist[display_hist]
+            elif display_screen == DISPLAY_PRES:
+                hist_head = "Pressure (mB)"
+                hist_values = pres_hist[display_hist]
+            elif display_screen == DISPLAY_HUMID:
+                hist_head = "Humidity (%)"
+                hist_values = humid_hist[display_hist]
+                
+            if display_hist == 0:
+                hist_head = "5 min - " + hist_head
+            elif display_hist == 1:
+                hist_head = "1 hour - " + hist_head
+            elif display_hist == 2:
+                hist_head = "12 hour - " + hist_head
+
+            hist_min = 10000
+            hist_max = 0
+            for i in range(HIST_LEN):
+                if hist_values[i] >= 0 and hist_values[i] < hist_min: hist_min = hist_values[i]
+                if hist_values[i] > hist_max: hist_max = hist_values[i]
+                
+            if hist_max - hist_min < 1:
+                extra = (1 - (hist_max - hist_min)) / 2
+                hist_max += extra
+                hist_min -= extra
+
+            display.pen(15)
+            display.clear()
+            display.pen(0)
+            
+            display.font("bitmap8")
+            display.text(hist_head, 148 - display.measure_text(hist_head, 1) // 2, 0, 1)
+            
+            if hist_min > 2000:
+                display.font("sans")
+                display.text("No data", 148 - display.measure_text("No data", 1) // 2, 64, 1)
+            else:
+                display.text("{:.1f}".format(hist_max), 0, 10, 1)
+                display.text("{:.1f}".format(hist_min), 0, 120, 1)
+                
+                for i in range(HIST_LEN):
+                    val = hist_values[i]
+                    if val >= hist_min and val <= hist_max:
+                        y = (val - hist_min) / (hist_max - hist_min)
+                        y = 127 - 117 * y
+                        display.pixel(i + X_OFFSET, int(y))
+                        
+                display.line(hist_idx[display_hist] + X_OFFSET, 10, hist_idx[display_hist] + X_OFFSET, 127)
+                val = hist_values[hist_idx[display_hist] - 1]
+                y = (val - hist_min) / (hist_max - hist_min)
+                y = 127 - 117 * y
+                val_text = "{:.1f}".format(hist_values[hist_idx[display_hist] - 1])
+                display.text(val_text, max(0, hist_idx[display_hist] + X_OFFSET - display.measure_text(val_text, 1)), int(y) - 10, 1)
+            
+            display.update()
+    else:
+        time.sleep(1)

--- a/micropython/examples/badger2040/bme.py
+++ b/micropython/examples/badger2040/bme.py
@@ -1,3 +1,5 @@
+# BME68x Temperature, Pressure and Humidity recorder for Badger2040
+
 import time
 
 from breakout_bme68x import BreakoutBME68X, OVERSAMPLING_4X
@@ -6,20 +8,24 @@ import badger2040
 
 badger2040.system_speed(badger2040.SYSTEM_SLOW)
 
+# Setup the BME
 i2c = PimoroniI2C(sda=4, scl=5)
 bme = BreakoutBME68X(i2c)
 bme.configure(os_humidity=OVERSAMPLING_4X)
 
+# Setup the Badger display
 display = badger2040.Badger2040()
 display.led(128)
 display.update_speed(badger2040.UPDATE_FAST)
 
+# Global data history.  Lists are used for 5 minute, 1 hour and 12 hour displays
 HIST_LEN = 288
-temp_hist = [[-1] * HIST_LEN, [-1] * HIST_LEN, [-1] * HIST_LEN]
-pres_hist = [[-1] * HIST_LEN, [-1] * HIST_LEN, [-1] * HIST_LEN]
-humid_hist = [[-1] * HIST_LEN, [-1] * HIST_LEN, [-1] * HIST_LEN]
+temp_hist = [[-100] * HIST_LEN, [-100] * HIST_LEN, [-100] * HIST_LEN]
+pres_hist = [[-100] * HIST_LEN, [-100] * HIST_LEN, [-100] * HIST_LEN]
+humid_hist = [[-100] * HIST_LEN, [-100] * HIST_LEN, [-100] * HIST_LEN]
 hist_idx = [0] * 3
 
+# Display mode constants
 DISPLAY_TEXT = 0
 DISPLAY_TEMP = 1
 DISPLAY_PRES = 2
@@ -30,41 +36,63 @@ display_hist = 0
 
 X_OFFSET = 296 - HIST_LEN
 
+
+def average_hist(hist, hist_idx, summary_idx, hist_period):
+    # Record an averaged entry into the summary history
+    from_idx = summary_idx - 1
+    hist[summary_idx][hist_idx[summary_idx]] = sum(hist[from_idx][hist_idx[from_idx] - hist_period:hist_idx[from_idx]]) / hist_period
+
+
 while True:
+    # Read and store current sample in 5 minute history
     temp, pres, humidity = bme.read_tph()
     pres /= 100
     temp_hist[0][hist_idx[0]], pres_hist[0][hist_idx[0]], humid_hist[0][hist_idx[0]] = temp, pres, humidity
-    
+
+    # Add to 1 hour and 12 hour history if on the appropriate boundary
     hist_idx[0] += 1
     if (hist_idx[0] % 12) == 0:
-        temp_hist[1][hist_idx[1]] = sum(temp_hist[0][hist_idx[0]-12:hist_idx[0]]) / 12
-        pres_hist[1][hist_idx[1]] = sum(pres_hist[0][hist_idx[0]-12:hist_idx[0]]) / 12
-        humid_hist[1][hist_idx[1]] = sum(humid_hist[0][hist_idx[0]-12:hist_idx[0]]) / 12
+        average_hist(temp_hist, hist_idx, 1, 12)
+        average_hist(pres_hist, hist_idx, 1, 12)
+        average_hist(humid_hist, hist_idx, 1, 12)
         hist_idx[1] += 1
         if (hist_idx[1] % 12) == 0:
-            temp_hist[2][hist_idx[2]] = sum(temp_hist[1][hist_idx[1]-12:hist_idx[1]]) / 12
-            pres_hist[2][hist_idx[2]] = sum(pres_hist[1][hist_idx[1]-12:hist_idx[1]]) / 12
-            humid_hist[2][hist_idx[2]] = sum(humid_hist[1][hist_idx[1]-12:hist_idx[1]]) / 12
+            average_hist(temp_hist, hist_idx, 2, 12)
+            average_hist(pres_hist, hist_idx, 2, 12)
+            average_hist(humid_hist, hist_idx, 2, 12)
             hist_idx[2] += 1
-            if hist_idx[2] >= HIST_LEN: hist_idx[2] = 0
-        if hist_idx[1] >= HIST_LEN: hist_idx[1] = 0
-    if hist_idx[0] >= HIST_LEN: hist_idx[0] = 0
-    
+            if hist_idx[2] >= HIST_LEN:
+                hist_idx[2] = 0
+        if hist_idx[1] >= HIST_LEN:
+            hist_idx[1] = 0
+    if hist_idx[0] >= HIST_LEN:
+        hist_idx[0] = 0
+
+    # Update display once every 12 seconds ...
     update = (hist_idx[0] % 12) == 1
     if display_screen != DISPLAY_TEXT and display_hist == 2:
+        # ... except on 12 hour view when we only update if it has changed
         update = update and (hist_idx[1] % 12) == 1
-    
+
+    # A scrolls back through the displays
     if display.pressed(badger2040.BUTTON_A):
         display_screen -= 1
-        if display_screen < 0: display_screen = DISPLAY_MAX
+        if display_screen < 0:
+            display_screen = DISPLAY_MAX
         update = True
+
+    # C scrolls forward through the displays
     if display.pressed(badger2040.BUTTON_C):
         display_screen += 1
-        if display_screen > DISPLAY_MAX: display_screen = 0
+        if display_screen > DISPLAY_MAX:
+            display_screen = 0
         update = True
+
+    # B changes between 5 minute, 1 hour and 12 hour displays
     if display.pressed(badger2040.BUTTON_B) and display_screen != DISPLAY_TEXT:
         display_hist += 1
-        if display_hist > 2: display_hist = 0
+        if display_hist > 2:
+            display_hist = 0
         update = True
 
     if update:
@@ -72,7 +100,7 @@ while True:
             display.pen(15)
             display.clear()
             display.pen(0)
-            
+
             display.font("sans")
             display.text("Temp: {:.2f}C".format(temp), 5, 20, 1)
             display.text("Press: {:.1f}mB".format(pres), 5, 60, 1)
@@ -88,7 +116,7 @@ while True:
             elif display_screen == DISPLAY_HUMID:
                 hist_head = "Humidity (%)"
                 hist_values = humid_hist[display_hist]
-                
+
             if display_hist == 0:
                 hist_head = "5 min - " + hist_head
             elif display_hist == 1:
@@ -96,12 +124,16 @@ while True:
             elif display_hist == 2:
                 hist_head = "12 hour - " + hist_head
 
+            # Determine the graph range
             hist_min = 10000
-            hist_max = 0
+            hist_max = -100
             for i in range(HIST_LEN):
-                if hist_values[i] >= 0 and hist_values[i] < hist_min: hist_min = hist_values[i]
-                if hist_values[i] > hist_max: hist_max = hist_values[i]
-                
+                if hist_values[i] > -100 and hist_values[i] < hist_min:
+                    hist_min = hist_values[i]
+                if hist_values[i] > hist_max:
+                    hist_max = hist_values[i]
+
+            # Always have at least 1 unit between min and max
             if hist_max - hist_min < 1:
                 extra = (1 - (hist_max - hist_min)) / 2
                 hist_max += extra
@@ -110,31 +142,31 @@ while True:
             display.pen(15)
             display.clear()
             display.pen(0)
-            
+
             display.font("bitmap8")
             display.text(hist_head, 148 - display.measure_text(hist_head, 1) // 2, 0, 1)
-            
+
             if hist_min > 2000:
                 display.font("sans")
                 display.text("No data", 148 - display.measure_text("No data", 1) // 2, 64, 1)
             else:
                 display.text("{:.1f}".format(hist_max), 0, 10, 1)
                 display.text("{:.1f}".format(hist_min), 0, 120, 1)
-                
+
                 for i in range(HIST_LEN):
                     val = hist_values[i]
                     if val >= hist_min and val <= hist_max:
                         y = (val - hist_min) / (hist_max - hist_min)
                         y = 127 - 117 * y
                         display.pixel(i + X_OFFSET, int(y))
-                        
+
                 display.line(hist_idx[display_hist] + X_OFFSET, 10, hist_idx[display_hist] + X_OFFSET, 127)
                 val = hist_values[hist_idx[display_hist] - 1]
                 y = (val - hist_min) / (hist_max - hist_min)
                 y = 127 - 117 * y
                 val_text = "{:.1f}".format(hist_values[hist_idx[display_hist] - 1])
                 display.text(val_text, max(0, hist_idx[display_hist] + X_OFFSET - display.measure_text(val_text, 1)), int(y) - 10, 1)
-            
+
             display.update()
     else:
         time.sleep(1)

--- a/micropython/modules/breakout_bme68x/breakout_bme68x.c
+++ b/micropython/modules/breakout_bme68x/breakout_bme68x.c
@@ -6,12 +6,14 @@
 
 /***** Methods *****/
 MP_DEFINE_CONST_FUN_OBJ_KW(BreakoutBME68X_read_obj, 1, BreakoutBME68X_read);
+MP_DEFINE_CONST_FUN_OBJ_1(BreakoutBME68X_read_tph_obj, BreakoutBME68X_read_tph);
 MP_DEFINE_CONST_FUN_OBJ_KW(BreakoutBME68X_configure_obj, 1, BreakoutBME68X_configure);
 
 /***** Binding of Methods *****/
 STATIC const mp_rom_map_elem_t BreakoutBME68X_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_read), MP_ROM_PTR(&BreakoutBME68X_read_obj) },
     { MP_ROM_QSTR(MP_QSTR_configure), MP_ROM_PTR(&BreakoutBME68X_configure_obj) },
+    { MP_ROM_QSTR(MP_QSTR_read_tph), MP_ROM_PTR(&BreakoutBME68X_read_tph_obj) },
 };
 STATIC MP_DEFINE_CONST_DICT(BreakoutBME68X_locals_dict, BreakoutBME68X_locals_dict_table);
 

--- a/micropython/modules/breakout_bme68x/breakout_bme68x.cpp
+++ b/micropython/modules/breakout_bme68x/breakout_bme68x.cpp
@@ -76,6 +76,23 @@ mp_obj_t BreakoutBME68X_read(size_t n_args, const mp_obj_t *pos_args, mp_map_t *
     }
 }
 
+mp_obj_t BreakoutBME68X_read_tph(mp_obj_t self_in) {
+    breakout_bme68x_BreakoutBME68X_obj_t *self = MP_OBJ_TO_PTR2(self_in, breakout_bme68x_BreakoutBME68X_obj_t);
+
+    bme68x_data result;
+    if(self->breakout->read_tph(&result)){
+        mp_obj_t tuple[3];
+        tuple[0] = mp_obj_new_float(result.temperature);
+        tuple[1] = mp_obj_new_float(result.pressure);
+        tuple[2] = mp_obj_new_float(result.humidity);
+        return mp_obj_new_tuple(3, tuple);
+    }
+    else {
+        mp_raise_msg(&mp_type_RuntimeError, "BreakoutBME68X: failed read_tph");
+        return mp_const_none;
+    }
+}
+
 mp_obj_t BreakoutBME68X_configure(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_self, ARG_filter, ARG_standby_time, ARG_os_pressure, ARG_os_temp, ARG_os_humidity };
     static const mp_arg_t allowed_args[] = {

--- a/micropython/modules/breakout_bme68x/breakout_bme68x.h
+++ b/micropython/modules/breakout_bme68x/breakout_bme68x.h
@@ -10,4 +10,5 @@ extern const mp_obj_type_t breakout_bme68x_BreakoutBME68X_type;
 /***** Extern of Class Methods *****/
 extern mp_obj_t BreakoutBME68X_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args);
 extern mp_obj_t BreakoutBME68X_read(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args);
+extern mp_obj_t BreakoutBME68X_read_tph(mp_obj_t self_in);
 extern mp_obj_t BreakoutBME68X_configure(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args);


### PR DESCRIPTION
Add an example app of a weather recorder using the BME680 module (although it doesn't use the volatile gas functionality, so really just using it like a BME280).

I've added functionality to the BME68x Micropython module to allow the configuration to be changed (this code existed but wasn't exposed in Micropython), and a new `read_tph` function to both the Micropython and the driver to just get the Temperature Pressure and Humidity, which is faster and consumes less power than getting the gas readings.

The new `read_tph` returns arguments in the same order as the BME280 module read function, so it should be super easy to make this example work with a BME280, but I don't have one of those.