### PR TITLE
Sideload vl53l5cx firmware to avoid bloating MicroPython binary

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -20,4 +20,4 @@
 [submodule "drivers/vl53l5cx/src"]
 	path = drivers/vl53l5cx/src
 	url = https://github.com/ST-mirror/VL53L5CX_ULD_driver
-	branch = lite/en
+	branch = no-fw/lite/en

--- a/drivers/vl53l5cx/platform.h
+++ b/drivers/vl53l5cx/platform.h
@@ -84,6 +84,7 @@ typedef struct
 	/* Example for most standard platform : I2C address of sensor */
     uint16_t  			address;
     i2c_inst_t          *i2c;
+	uint8_t				*firmware;
 
 } VL53L5CX_Platform;
 

--- a/drivers/vl53l5cx/vl53l5cx.hpp
+++ b/drivers/vl53l5cx/vl53l5cx.hpp
@@ -33,11 +33,12 @@ namespace pimoroni {
             // 7-bit version of the default address (0x52)
             static const uint8_t DEFAULT_ADDRESS = VL53L5CX_DEFAULT_I2C_ADDRESS >> 1;
 
-            VL53L5CX(I2C *i2c, uint8_t i2c_addr=DEFAULT_ADDRESS) {
+            VL53L5CX(I2C *i2c, uint8_t *firmware, uint8_t i2c_addr=DEFAULT_ADDRESS) {
                 configuration = new VL53L5CX_Configuration{
                     .platform = VL53L5CX_Platform{
                         .address = i2c_addr,
-                        .i2c = i2c->get_i2c()
+                        .i2c = i2c->get_i2c(),
+                        .firmware = firmware
                     },
                 };
                 motion_configuration = new VL53L5CX_Motion_Configuration{};

--- a/examples/breakout_vl53l5cx/vl53l5cx_demo.cpp
+++ b/examples/breakout_vl53l5cx/vl53l5cx_demo.cpp
@@ -1,14 +1,15 @@
 #include <stdio.h>
 #include "pico/stdlib.h"
 #include "hardware/i2c.h"
-#include "drivers/vl53l5cx/vl53l5cx.hpp"
+#include "vl53l5cx.hpp"
+#include "src/vl53l5cx_firmware.h"
 
 #include "common/pimoroni_i2c.hpp"
 
 using namespace pimoroni;
 
 I2C i2c(4, 5);
-VL53L5CX vl53l5cx(&i2c);
+VL53L5CX vl53l5cx(&i2c, (uint8_t *)&vl53l5cx_firmware_bin);
 
 int main() {
   stdio_init_all();

--- a/micropython/examples/breakout_vl53l5cx/vl53l5cx_demo.py
+++ b/micropython/examples/breakout_vl53l5cx/vl53l5cx_demo.py
@@ -11,7 +11,7 @@ i2c = pimoroni_i2c.PimoroniI2C(**PINS_BREAKOUT_GARDEN, baudrate=2_000_000)
 
 print("Starting up sensor...")
 t_sta = time.ticks_ms()
-sensor = breakout_vl53l5cx.VL53L5CX(i2c)
+sensor = breakout_vl53l5cx.VL53L5CX(i2c, firmware=open("vl53l5cx_firmware.bin").read())
 t_end = time.ticks_ms()
 print("Done in {}ms...".format(t_end - t_sta))
 

--- a/micropython/examples/breakout_vl53l5cx/vl53l5cx_demo.py
+++ b/micropython/examples/breakout_vl53l5cx/vl53l5cx_demo.py
@@ -2,6 +2,10 @@ import pimoroni_i2c
 import breakout_vl53l5cx
 import time
 
+# The VL53L5CX requires a firmware blob to start up.
+# Make sure you upload "vl53l5cx_firmware.bin" via Thonny to the root of your filesystem
+# You can find it here: https://github.com/ST-mirror/VL53L5CX_ULD_driver/blob/no-fw/lite/en/vl53l5cx_firmware.bin
+
 PINS_BREAKOUT_GARDEN = {"sda": 4, "scl": 5}
 PINS_PICO_EXPLORER = {"sda": 20, "scl": 21}
 
@@ -11,7 +15,7 @@ i2c = pimoroni_i2c.PimoroniI2C(**PINS_BREAKOUT_GARDEN, baudrate=2_000_000)
 
 print("Starting up sensor...")
 t_sta = time.ticks_ms()
-sensor = breakout_vl53l5cx.VL53L5CX(i2c, firmware=open("vl53l5cx_firmware.bin").read())
+sensor = breakout_vl53l5cx.VL53L5CX(i2c)
 t_end = time.ticks_ms()
 print("Done in {}ms...".format(t_end - t_sta))
 

--- a/micropython/examples/breakout_vl53l5cx/vl53l5cx_motion.py
+++ b/micropython/examples/breakout_vl53l5cx/vl53l5cx_motion.py
@@ -3,6 +3,10 @@ import breakout_vl53l5cx
 import time
 from ulab import numpy
 
+# The VL53L5CX requires a firmware blob to start up.
+# Make sure you upload "vl53l5cx_firmware.bin" via Thonny to the root of your filesystem
+# You can find it here: https://github.com/ST-mirror/VL53L5CX_ULD_driver/blob/no-fw/lite/en/vl53l5cx_firmware.bin
+
 PINS_BREAKOUT_GARDEN = {"sda": 4, "scl": 5}
 PINS_PICO_EXPLORER = {"sda": 20, "scl": 21}
 
@@ -12,7 +16,7 @@ i2c = pimoroni_i2c.PimoroniI2C(**PINS_BREAKOUT_GARDEN, baudrate=2_000_000)
 
 print("Starting up sensor...")
 t_sta = time.ticks_ms()
-sensor = breakout_vl53l5cx.VL53L5CX(i2c, firmware=open("vl53l5cx_firmware.bin").read())
+sensor = breakout_vl53l5cx.VL53L5CX(i2c)
 t_end = time.ticks_ms()
 print("Done in {}ms...".format(t_end - t_sta))
 

--- a/micropython/examples/breakout_vl53l5cx/vl53l5cx_motion.py
+++ b/micropython/examples/breakout_vl53l5cx/vl53l5cx_motion.py
@@ -12,7 +12,7 @@ i2c = pimoroni_i2c.PimoroniI2C(**PINS_BREAKOUT_GARDEN, baudrate=2_000_000)
 
 print("Starting up sensor...")
 t_sta = time.ticks_ms()
-sensor = breakout_vl53l5cx.VL53L5CX(i2c)
+sensor = breakout_vl53l5cx.VL53L5CX(i2c, firmware=open("vl53l5cx_firmware.bin").read())
 t_end = time.ticks_ms()
 print("Done in {}ms...".format(t_end - t_sta))
 

--- a/micropython/examples/breakout_vl53l5cx/vl53l5cx_object_tracking.py
+++ b/micropython/examples/breakout_vl53l5cx/vl53l5cx_object_tracking.py
@@ -3,6 +3,10 @@ import breakout_vl53l5cx
 import time
 from ulab import numpy
 
+# The VL53L5CX requires a firmware blob to start up.
+# Make sure you upload "vl53l5cx_firmware.bin" via Thonny to the root of your filesystem
+# You can find it here: https://github.com/ST-mirror/VL53L5CX_ULD_driver/blob/no-fw/lite/en/vl53l5cx_firmware.bin
+
 # This example attempts to track a "bright" object (such as a white business card)
 # It uses reflectance to identify the target and compute the X/Y coordinates
 # of its "center of mass" in the sensors view.
@@ -24,7 +28,7 @@ i2c = pimoroni_i2c.PimoroniI2C(**PINS_BREAKOUT_GARDEN, baudrate=2_000_000)
 
 print("Starting up sensor...")
 t_sta = time.ticks_ms()
-sensor = breakout_vl53l5cx.VL53L5CX(i2c, firmware=open("vl53l5cx_firmware.bin").read())
+sensor = breakout_vl53l5cx.VL53L5CX(i2c)
 t_end = time.ticks_ms()
 print("Done in {}ms...".format(t_end - t_sta))
 

--- a/micropython/examples/breakout_vl53l5cx/vl53l5cx_object_tracking.py
+++ b/micropython/examples/breakout_vl53l5cx/vl53l5cx_object_tracking.py
@@ -24,7 +24,7 @@ i2c = pimoroni_i2c.PimoroniI2C(**PINS_BREAKOUT_GARDEN, baudrate=2_000_000)
 
 print("Starting up sensor...")
 t_sta = time.ticks_ms()
-sensor = breakout_vl53l5cx.VL53L5CX(i2c)
+sensor = breakout_vl53l5cx.VL53L5CX(i2c, firmware=open("vl53l5cx_firmware.bin").read())
 t_end = time.ticks_ms()
 print("Done in {}ms...".format(t_end - t_sta))
 

--- a/micropython/modules/micropython.cmake
+++ b/micropython/modules/micropython.cmake
@@ -29,7 +29,7 @@ include(breakout_bme280/micropython)
 include(breakout_bmp280/micropython)
 include(breakout_icp10125/micropython)
 include(breakout_scd41/micropython)
-# include(breakout_vl53l5cx/micropython)
+include(breakout_vl53l5cx/micropython)
 
 include(pico_scroll/micropython)
 include(pico_rgb_keypad/micropython)


### PR DESCRIPTION
Saves about 84k, albeit the VL53L5CX library still contains ~1.7k of default configuration values.

The binary must be supplied by the user, but is supplied as "vl53l5cx_firmware.bin". This can be uploaded via Thonny.

The library init becomes:

```python
sensor = breakout_vl53l5cx.VL53L5CX(i2c, firmware=open("vl53l5cx_firmware.bin").read())
```

~~We should probably find a way to hide the implementation detail of loading firmware, since we could better alloc and clean up the 84k of RAM used here rather than using an ephemeral file object and leaving it to GC.~~