### PR TITLE
MicroPython: Use placement new to alloc classes on GC_HEAP

### DIFF
--- a/drivers/motor/motor_cluster.cpp
+++ b/drivers/motor/motor_cluster.cpp
@@ -9,22 +9,22 @@
 namespace motor {
   MotorCluster::MotorCluster(PIO pio, uint sm, uint pin_base, uint pin_pair_count, Direction direction,
                              float speed_scale, float zeropoint, float deadzone, float freq, DecayMode mode,
-                             bool auto_phase, PWMCluster::Sequence *seq_buffer, PWMCluster::TransitionData *dat_buffer)
-    : pwms(pio, sm, pin_base, (pin_pair_count * 2), seq_buffer, dat_buffer, false), pwm_frequency(freq) {
+                             bool auto_phase)
+    : pwms(pio, sm, pin_base, (pin_pair_count * 2), false), pwm_frequency(freq) {
     create_motor_states(direction, speed_scale, zeropoint, deadzone, mode, auto_phase);
   }
 
   MotorCluster::MotorCluster(PIO pio, uint sm, const pin_pair *pin_pairs, uint32_t length, Direction direction,
                              float speed_scale, float zeropoint, float deadzone, float freq, DecayMode mode,
-                             bool auto_phase, PWMCluster::Sequence *seq_buffer, PWMCluster::TransitionData *dat_buffer)
-    : pwms(pio, sm, pin_pairs, length, seq_buffer, dat_buffer, false), pwm_frequency(freq) {
+                             bool auto_phase)
+    : pwms(pio, sm, pin_pairs, length, false), pwm_frequency(freq) {
     create_motor_states(direction, speed_scale, zeropoint, deadzone, mode, auto_phase);
   }
 
   MotorCluster::MotorCluster(PIO pio, uint sm, std::initializer_list<pin_pair> pin_pairs, Direction direction,
                              float speed_scale, float zeropoint, float deadzone, float freq, DecayMode mode,
-                             bool auto_phase, PWMCluster::Sequence *seq_buffer, PWMCluster::TransitionData *dat_buffer)
-    : pwms(pio, sm, pin_pairs, seq_buffer, dat_buffer, false), pwm_frequency(freq) {
+                             bool auto_phase)
+    : pwms(pio, sm, pin_pairs, false), pwm_frequency(freq) {
     create_motor_states(direction, speed_scale, zeropoint, deadzone, mode, auto_phase);
   }
 

--- a/drivers/motor/motor_cluster.hpp
+++ b/drivers/motor/motor_cluster.hpp
@@ -36,13 +36,13 @@ namespace motor {
   public:
     MotorCluster(PIO pio, uint sm, uint pin_base, uint pin_pair_count, Direction direction = NORMAL_DIR, float speed_scale = MotorState::DEFAULT_SPEED_SCALE,
                  float zeropoint = MotorState::DEFAULT_ZEROPOINT, float deadzone = MotorState::DEFAULT_DEADZONE, float freq = MotorState::DEFAULT_FREQUENCY, DecayMode mode = MotorState::DEFAULT_DECAY_MODE,
-                 bool auto_phase = true, PWMCluster::Sequence *seq_buffer = nullptr, PWMCluster::TransitionData *dat_buffer = nullptr);
+                 bool auto_phase = true);
     MotorCluster(PIO pio, uint sm, const pin_pair *pin_pairs, uint32_t length, Direction direction = NORMAL_DIR, float speed_scale = MotorState::DEFAULT_SPEED_SCALE,
                  float zeropoint = MotorState::DEFAULT_ZEROPOINT, float deadzone = MotorState::DEFAULT_DEADZONE, float freq = MotorState::DEFAULT_FREQUENCY, DecayMode mode = MotorState::DEFAULT_DECAY_MODE,
-                 bool auto_phase = true, PWMCluster::Sequence *seq_buffer = nullptr, PWMCluster::TransitionData *dat_buffer = nullptr);
+                 bool auto_phase = true);
     MotorCluster(PIO pio, uint sm, std::initializer_list<pin_pair> pin_pairs, Direction direction = NORMAL_DIR, float speed_scale = MotorState::DEFAULT_SPEED_SCALE,
                  float zeropoint = MotorState::DEFAULT_ZEROPOINT, float deadzone = MotorState::DEFAULT_DEADZONE, float freq = MotorState::DEFAULT_FREQUENCY, DecayMode mode = MotorState::DEFAULT_DECAY_MODE,
-                 bool auto_phase = true, PWMCluster::Sequence *seq_buffer = nullptr, PWMCluster::TransitionData *dat_buffer = nullptr);
+                 bool auto_phase = true);
     ~MotorCluster();
 
 

--- a/drivers/pwm/pwm_cluster.hpp
+++ b/drivers/pwm/pwm_cluster.hpp
@@ -108,13 +108,11 @@ namespace pimoroni {
     uint8_t channel_to_pin_map[NUM_BANK0_GPIOS];
     uint wrap_level;
 
-    Sequence *sequences;
-    Sequence *loop_sequences;
-    bool managed_seq_buffer = false;
+    Sequence sequences[NUM_BUFFERS];
+    Sequence loop_sequences[NUM_BUFFERS];
 
-    TransitionData *transitions;
-    TransitionData *looping_transitions;
-    bool managed_dat_buffer = false;
+    TransitionData transitions[BUFFER_SIZE];
+    TransitionData looping_transitions[BUFFER_SIZE];
 
     volatile uint read_index = 0;
     volatile uint last_written_index = 0;
@@ -136,17 +134,17 @@ namespace pimoroni {
     // Constructors/Destructor
     //--------------------------------------------------
   public:
-    PWMCluster(PIO pio, uint sm, uint pin_mask, Sequence *seq_buffer = nullptr, TransitionData *dat_buffer = nullptr, bool loading_zone = DEFAULT_USE_LOADING_ZONE);
-    PWMCluster(PIO pio, uint sm, uint pin_base, uint pin_count, Sequence *seq_buffer = nullptr, TransitionData *dat_buffer = nullptr, bool loading_zone = DEFAULT_USE_LOADING_ZONE);
-    PWMCluster(PIO pio, uint sm, const uint8_t *pins, uint32_t length, Sequence *seq_buffer = nullptr, TransitionData *dat_buffer = nullptr, bool loading_zone = DEFAULT_USE_LOADING_ZONE);
-    PWMCluster(PIO pio, uint sm, std::initializer_list<uint8_t> pins, Sequence *seq_buffer = nullptr, TransitionData *dat_buffer = nullptr, bool loading_zone = DEFAULT_USE_LOADING_ZONE);
+    PWMCluster(PIO pio, uint sm, uint pin_mask, bool loading_zone = DEFAULT_USE_LOADING_ZONE);
+    PWMCluster(PIO pio, uint sm, uint pin_base, uint pin_count, bool loading_zone = DEFAULT_USE_LOADING_ZONE);
+    PWMCluster(PIO pio, uint sm, const uint8_t *pins, uint32_t length, bool loading_zone = DEFAULT_USE_LOADING_ZONE);
+    PWMCluster(PIO pio, uint sm, std::initializer_list<uint8_t> pins, bool loading_zone = DEFAULT_USE_LOADING_ZONE);
 
-    PWMCluster(PIO pio, uint sm, const pin_pair *pin_pairs, uint32_t length, Sequence *seq_buffer = nullptr, TransitionData *dat_buffer = nullptr, bool loading_zone = DEFAULT_USE_LOADING_ZONE);
-    PWMCluster(PIO pio, uint sm, std::initializer_list<pin_pair> pin_pairs, Sequence *seq_buffer = nullptr, TransitionData *dat_buffer = nullptr, bool loading_zone = DEFAULT_USE_LOADING_ZONE);
+    PWMCluster(PIO pio, uint sm, const pin_pair *pin_pairs, uint32_t length, bool loading_zone = DEFAULT_USE_LOADING_ZONE);
+    PWMCluster(PIO pio, uint sm, std::initializer_list<pin_pair> pin_pairs, bool loading_zone = DEFAULT_USE_LOADING_ZONE);
     ~PWMCluster();
 
   private:
-    void constructor_common(Sequence *seq_buffer, TransitionData *dat_buffer);
+    void constructor_common();
 
 
     //--------------------------------------------------

--- a/drivers/servo/servo_cluster.cpp
+++ b/drivers/servo/servo_cluster.cpp
@@ -3,43 +3,43 @@
 #include <cstdio>
 
 namespace servo {
-  ServoCluster::ServoCluster(PIO pio, uint sm, uint pin_mask, CalibrationType default_type, float freq, bool auto_phase, PWMCluster::Sequence *seq_buffer, PWMCluster::TransitionData *dat_buffer)
-    : pwms(pio, sm, pin_mask, seq_buffer, dat_buffer), pwm_frequency(freq) {
+  ServoCluster::ServoCluster(PIO pio, uint sm, uint pin_mask, CalibrationType default_type, float freq, bool auto_phase)
+    : pwms(pio, sm, pin_mask), pwm_frequency(freq) {
     create_servo_states(default_type, auto_phase);
   }
 
-  ServoCluster::ServoCluster(PIO pio, uint sm, uint pin_base, uint pin_count, CalibrationType default_type, float freq, bool auto_phase, PWMCluster::Sequence *seq_buffer, PWMCluster::TransitionData *dat_buffer)
-    : pwms(pio, sm, pin_base, pin_count, seq_buffer, dat_buffer), pwm_frequency(freq) {
+  ServoCluster::ServoCluster(PIO pio, uint sm, uint pin_base, uint pin_count, CalibrationType default_type, float freq, bool auto_phase)
+    : pwms(pio, sm, pin_base, pin_count), pwm_frequency(freq) {
     create_servo_states(default_type, auto_phase);
   }
 
-  ServoCluster::ServoCluster(PIO pio, uint sm, const uint8_t *pins, uint32_t length, CalibrationType default_type, float freq, bool auto_phase, PWMCluster::Sequence *seq_buffer, PWMCluster::TransitionData *dat_buffer)
-    : pwms(pio, sm, pins, length, seq_buffer, dat_buffer), pwm_frequency(freq) {
+  ServoCluster::ServoCluster(PIO pio, uint sm, const uint8_t *pins, uint32_t length, CalibrationType default_type, float freq, bool auto_phase)
+    : pwms(pio, sm, pins, length), pwm_frequency(freq) {
     create_servo_states(default_type, auto_phase);
   }
 
-  ServoCluster::ServoCluster(PIO pio, uint sm, std::initializer_list<uint8_t> pins, CalibrationType default_type, float freq, bool auto_phase, PWMCluster::Sequence *seq_buffer, PWMCluster::TransitionData *dat_buffer)
-    : pwms(pio, sm, pins, seq_buffer, dat_buffer), pwm_frequency(freq) {
+  ServoCluster::ServoCluster(PIO pio, uint sm, std::initializer_list<uint8_t> pins, CalibrationType default_type, float freq, bool auto_phase)
+    : pwms(pio, sm, pins), pwm_frequency(freq) {
     create_servo_states(default_type, auto_phase);
   }
 
-  ServoCluster::ServoCluster(PIO pio, uint sm, uint pin_mask, const Calibration& calibration, float freq, bool auto_phase, PWMCluster::Sequence *seq_buffer, PWMCluster::TransitionData *dat_buffer)
-    : pwms(pio, sm, pin_mask, seq_buffer, dat_buffer), pwm_frequency(freq) {
+  ServoCluster::ServoCluster(PIO pio, uint sm, uint pin_mask, const Calibration& calibration, float freq, bool auto_phase)
+    : pwms(pio, sm, pin_mask), pwm_frequency(freq) {
     create_servo_states(calibration, auto_phase);
   }
 
-  ServoCluster::ServoCluster(PIO pio, uint sm, uint pin_base, uint pin_count, const Calibration& calibration, float freq, bool auto_phase, PWMCluster::Sequence *seq_buffer, PWMCluster::TransitionData *dat_buffer)
-    : pwms(pio, sm, pin_base, pin_count, seq_buffer, dat_buffer), pwm_frequency(freq) {
+  ServoCluster::ServoCluster(PIO pio, uint sm, uint pin_base, uint pin_count, const Calibration& calibration, float freq, bool auto_phase)
+    : pwms(pio, sm, pin_base, pin_count), pwm_frequency(freq) {
     create_servo_states(calibration, auto_phase);
   }
 
-  ServoCluster::ServoCluster(PIO pio, uint sm, const uint8_t *pins, uint32_t length, const Calibration& calibration, float freq, bool auto_phase, PWMCluster::Sequence *seq_buffer, PWMCluster::TransitionData *dat_buffer)
-    : pwms(pio, sm, pins, length, seq_buffer, dat_buffer), pwm_frequency(freq) {
+  ServoCluster::ServoCluster(PIO pio, uint sm, const uint8_t *pins, uint32_t length, const Calibration& calibration, float freq, bool auto_phase)
+    : pwms(pio, sm, pins, length), pwm_frequency(freq) {
     create_servo_states(calibration, auto_phase);
   }
 
-  ServoCluster::ServoCluster(PIO pio, uint sm, std::initializer_list<uint8_t> pins, const Calibration& calibration, float freq, bool auto_phase, PWMCluster::Sequence *seq_buffer, PWMCluster::TransitionData *dat_buffer)
-    : pwms(pio, sm, pins, seq_buffer, dat_buffer), pwm_frequency(freq) {
+  ServoCluster::ServoCluster(PIO pio, uint sm, std::initializer_list<uint8_t> pins, const Calibration& calibration, float freq, bool auto_phase)
+    : pwms(pio, sm, pins), pwm_frequency(freq) {
     create_servo_states(calibration, auto_phase);
   }
 

--- a/drivers/servo/servo_cluster.hpp
+++ b/drivers/servo/servo_cluster.hpp
@@ -24,15 +24,15 @@ namespace servo {
     // Constructors/Destructor
     //--------------------------------------------------
   public:
-    ServoCluster(PIO pio, uint sm, uint pin_mask, CalibrationType default_type = ANGULAR, float freq = ServoState::DEFAULT_FREQUENCY, bool auto_phase = true, PWMCluster::Sequence *seq_buffer = nullptr, PWMCluster::TransitionData *dat_buffer = nullptr);
-    ServoCluster(PIO pio, uint sm, uint pin_base, uint pin_count, CalibrationType default_type = ANGULAR, float freq = ServoState::DEFAULT_FREQUENCY, bool auto_phase = true, PWMCluster::Sequence *seq_buffer = nullptr, PWMCluster::TransitionData *dat_buffer = nullptr);
-    ServoCluster(PIO pio, uint sm, const uint8_t *pins, uint32_t length, CalibrationType default_type = ANGULAR, float freq = ServoState::DEFAULT_FREQUENCY, bool auto_phase = true, PWMCluster::Sequence *seq_buffer = nullptr, PWMCluster::TransitionData *dat_buffer = nullptr);
-    ServoCluster(PIO pio, uint sm, std::initializer_list<uint8_t> pins, CalibrationType default_type = ANGULAR, float freq = ServoState::DEFAULT_FREQUENCY, bool auto_phase = true, PWMCluster::Sequence *seq_buffer = nullptr, PWMCluster::TransitionData *dat_buffer = nullptr);
+    ServoCluster(PIO pio, uint sm, uint pin_mask, CalibrationType default_type = ANGULAR, float freq = ServoState::DEFAULT_FREQUENCY, bool auto_phase = true);
+    ServoCluster(PIO pio, uint sm, uint pin_base, uint pin_count, CalibrationType default_type = ANGULAR, float freq = ServoState::DEFAULT_FREQUENCY, bool auto_phase = true);
+    ServoCluster(PIO pio, uint sm, const uint8_t *pins, uint32_t length, CalibrationType default_type = ANGULAR, float freq = ServoState::DEFAULT_FREQUENCY, bool auto_phase = true);
+    ServoCluster(PIO pio, uint sm, std::initializer_list<uint8_t> pins, CalibrationType default_type = ANGULAR, float freq = ServoState::DEFAULT_FREQUENCY, bool auto_phase = true);
 
-    ServoCluster(PIO pio, uint sm, uint pin_mask, const Calibration& calibration, float freq = ServoState::DEFAULT_FREQUENCY, bool auto_phase = true, PWMCluster::Sequence *seq_buffer = nullptr, PWMCluster::TransitionData *dat_buffer = nullptr);
-    ServoCluster(PIO pio, uint sm, uint pin_base, uint pin_count, const Calibration& calibration, float freq = ServoState::DEFAULT_FREQUENCY, bool auto_phase = true, PWMCluster::Sequence *seq_buffer = nullptr, PWMCluster::TransitionData *dat_buffer = nullptr);
-    ServoCluster(PIO pio, uint sm, const uint8_t *pins, uint32_t length, const Calibration& calibration, float freq = ServoState::DEFAULT_FREQUENCY, bool auto_phase = true, PWMCluster::Sequence *seq_buffer = nullptr, PWMCluster::TransitionData *dat_buffer = nullptr);
-    ServoCluster(PIO pio, uint sm, std::initializer_list<uint8_t> pins, const Calibration& calibration, float freq = ServoState::DEFAULT_FREQUENCY, bool auto_phase = true, PWMCluster::Sequence *seq_buffer = nullptr, PWMCluster::TransitionData *dat_buffer = nullptr);
+    ServoCluster(PIO pio, uint sm, uint pin_mask, const Calibration& calibration, float freq = ServoState::DEFAULT_FREQUENCY, bool auto_phase = true);
+    ServoCluster(PIO pio, uint sm, uint pin_base, uint pin_count, const Calibration& calibration, float freq = ServoState::DEFAULT_FREQUENCY, bool auto_phase = true);
+    ServoCluster(PIO pio, uint sm, const uint8_t *pins, uint32_t length, const Calibration& calibration, float freq = ServoState::DEFAULT_FREQUENCY, bool auto_phase = true);
+    ServoCluster(PIO pio, uint sm, std::initializer_list<uint8_t> pins, const Calibration& calibration, float freq = ServoState::DEFAULT_FREQUENCY, bool auto_phase = true);
     ~ServoCluster();
 
 

--- a/micropython/modules/badger2040/badger2040.cpp
+++ b/micropython/modules/badger2040/badger2040.cpp
@@ -2,7 +2,7 @@
 #include "hardware/watchdog.h"
 #include "badger2040.hpp"
 
-#define MP_OBJ_TO_PTR2(o, t) ((t *)(uintptr_t)(o))
+#include "micropython/modules/util.hpp"
 
 extern "C" {
 #include "badger2040.h"

--- a/micropython/modules/breakout_as7262/breakout_as7262.cpp
+++ b/micropython/modules/breakout_as7262/breakout_as7262.cpp
@@ -1,11 +1,6 @@
 #include "libraries/breakout_as7262/breakout_as7262.hpp"
 #include "common/pimoroni_i2c.hpp"
-
-#define MP_OBJ_TO_PTR2(o, t) ((t *)(uintptr_t)(o))
-
-// SDA/SCL on even/odd pins, I2C0/I2C1 on even/odd pairs of pins.
-#define IS_VALID_SCL(i2c, pin) (((pin) & 1) == 1 && (((pin) & 2) >> 1) == (i2c))
-#define IS_VALID_SDA(i2c, pin) (((pin) & 1) == 0 && (((pin) & 2) >> 1) == (i2c))
+#include "micropython/modules/util.hpp"
 
 
 using namespace pimoroni;
@@ -63,7 +58,7 @@ mp_obj_t BreakoutAS7262_make_new(const mp_obj_type_t *type, size_t n_args, size_
 
     self->i2c = PimoroniI2C_from_machine_i2c_or_native(args[ARG_i2c].u_obj);
 
-    self->breakout = new BreakoutAS7262((pimoroni::I2C *)(self->i2c->i2c), args[ARG_int].u_int);
+    self->breakout = m_new_class(BreakoutAS7262, (pimoroni::I2C *)(self->i2c->i2c), args[ARG_int].u_int);
 
     if(!self->breakout->init()) {
         mp_raise_msg(&mp_type_RuntimeError, "BreakoutAS7262: breakout not found when initialising");

--- a/micropython/modules/breakout_bh1745/breakout_bh1745.cpp
+++ b/micropython/modules/breakout_bh1745/breakout_bh1745.cpp
@@ -1,12 +1,6 @@
 #include "libraries/breakout_bh1745/breakout_bh1745.hpp"
+#include "micropython/modules/util.hpp"
 #include <cstdio>
-
-#define MP_OBJ_TO_PTR2(o, t) ((t *)(uintptr_t)(o))
-
-// SDA/SCL on even/odd pins, I2C0/I2C1 on even/odd pairs of pins.
-#define IS_VALID_SCL(i2c, pin) (((pin) & 1) == 1 && (((pin) & 2) >> 1) == (i2c))
-#define IS_VALID_SDA(i2c, pin) (((pin) & 1) == 0 && (((pin) & 2) >> 1) == (i2c))
-
 
 using namespace pimoroni;
 
@@ -64,7 +58,7 @@ mp_obj_t BreakoutBH1745_make_new(const mp_obj_type_t *type, size_t n_args, size_
 
     self->i2c = PimoroniI2C_from_machine_i2c_or_native(args[ARG_i2c].u_obj);
 
-    self->breakout = new BreakoutBH1745((pimoroni::I2C *)(self->i2c->i2c), args[ARG_address].u_int);
+    self->breakout = m_new_class(BreakoutBH1745, (pimoroni::I2C *)(self->i2c->i2c), args[ARG_address].u_int);
 
     if(!self->breakout->init()) {
         mp_raise_msg(&mp_type_RuntimeError, "BreakoutBH1745: breakout not found when initialising");

--- a/micropython/modules/breakout_bme280/breakout_bme280.cpp
+++ b/micropython/modules/breakout_bme280/breakout_bme280.cpp
@@ -1,11 +1,5 @@
 #include "drivers/bme280/bme280.hpp"
-
-#define MP_OBJ_TO_PTR2(o, t) ((t *)(uintptr_t)(o))
-
-// SDA/SCL on even/odd pins, I2C0/I2C1 on even/odd pairs of pins.
-#define IS_VALID_SCL(i2c, pin) (((pin) & 1) == 1 && (((pin) & 2) >> 1) == (i2c))
-#define IS_VALID_SDA(i2c, pin) (((pin) & 1) == 0 && (((pin) & 2) >> 1) == (i2c))
-
+#include "micropython/modules/util.hpp"
 
 using namespace pimoroni;
 
@@ -62,7 +56,7 @@ mp_obj_t BreakoutBME280_make_new(const mp_obj_type_t *type, size_t n_args, size_
 
     self->i2c = PimoroniI2C_from_machine_i2c_or_native(args[ARG_i2c].u_obj);
 
-    self->breakout = new BME280((pimoroni::I2C *)(self->i2c->i2c), args[ARG_address].u_int, args[ARG_int].u_int);
+    self->breakout = m_new_class(BME280, (pimoroni::I2C *)(self->i2c->i2c), args[ARG_address].u_int, args[ARG_int].u_int);
 
     if(!self->breakout->init()) {
         mp_raise_msg(&mp_type_RuntimeError, "BreakoutBME280: breakout not found when initialising");

--- a/micropython/modules/breakout_bme68x/breakout_bme68x.cpp
+++ b/micropython/modules/breakout_bme68x/breakout_bme68x.cpp
@@ -1,10 +1,5 @@
 #include "drivers/bme68x/bme68x.hpp"
-
-#define MP_OBJ_TO_PTR2(o, t) ((t *)(uintptr_t)(o))
-
-// SDA/SCL on even/odd pins, I2C0/I2C1 on even/odd pairs of pins.
-#define IS_VALID_SCL(i2c, pin) (((pin) & 1) == 1 && (((pin) & 2) >> 1) == (i2c))
-#define IS_VALID_SDA(i2c, pin) (((pin) & 1) == 0 && (((pin) & 2) >> 1) == (i2c))
+#include "micropython/modules/util.hpp"
 
 
 using namespace pimoroni;
@@ -63,7 +58,7 @@ mp_obj_t BreakoutBME68X_make_new(const mp_obj_type_t *type, size_t n_args, size_
 
     self->i2c = PimoroniI2C_from_machine_i2c_or_native(args[ARG_i2c].u_obj);
 
-    self->breakout = new BME68X((pimoroni::I2C *)(self->i2c->i2c), args[ARG_address].u_int, args[ARG_int].u_int);
+    self->breakout = m_new_class(BME68X, (pimoroni::I2C *)(self->i2c->i2c), args[ARG_address].u_int, args[ARG_int].u_int);
 
     if(!self->breakout->init()) {
         mp_raise_msg(&mp_type_RuntimeError, "BreakoutBME68X: breakout not found when initialising");

--- a/micropython/modules/breakout_bmp280/breakout_bmp280.cpp
+++ b/micropython/modules/breakout_bmp280/breakout_bmp280.cpp
@@ -1,10 +1,5 @@
 #include "drivers/bmp280/bmp280.hpp"
-
-#define MP_OBJ_TO_PTR2(o, t) ((t *)(uintptr_t)(o))
-
-// SDA/SCL on even/odd pins, I2C0/I2C1 on even/odd pairs of pins.
-#define IS_VALID_SCL(i2c, pin) (((pin) & 1) == 1 && (((pin) & 2) >> 1) == (i2c))
-#define IS_VALID_SDA(i2c, pin) (((pin) & 1) == 0 && (((pin) & 2) >> 1) == (i2c))
+#include "micropython/modules/util.hpp"
 
 
 using namespace pimoroni;
@@ -62,7 +57,7 @@ mp_obj_t BreakoutBMP280_make_new(const mp_obj_type_t *type, size_t n_args, size_
 
     self->i2c = PimoroniI2C_from_machine_i2c_or_native(args[ARG_i2c].u_obj);
 
-    self->breakout = new BMP280((pimoroni::I2C *)(self->i2c->i2c), args[ARG_address].u_int, args[ARG_int].u_int);
+    self->breakout = m_new_class(BMP280, (pimoroni::I2C *)(self->i2c->i2c), args[ARG_address].u_int, args[ARG_int].u_int);
 
     if(!self->breakout->init()) {
         mp_raise_msg(&mp_type_RuntimeError, "BreakoutBMP280: breakout not found when initialising");

--- a/micropython/modules/breakout_colourlcd160x80/breakout_colourlcd160x80.cpp
+++ b/micropython/modules/breakout_colourlcd160x80/breakout_colourlcd160x80.cpp
@@ -1,11 +1,5 @@
 #include "libraries/breakout_colourlcd160x80/breakout_colourlcd160x80.hpp"
-
-#define MP_OBJ_TO_PTR2(o, t) ((t *)(uintptr_t)(o))
-
-#define IS_VALID_PERIPH(spi, pin)   ((((pin) & 8) >> 3) == (spi))
-#define IS_VALID_SCK(spi, pin)      (((pin) & 3) == 2 && IS_VALID_PERIPH(spi, pin))
-#define IS_VALID_MOSI(spi, pin)     (((pin) & 3) == 3 && IS_VALID_PERIPH(spi, pin))
-#define IS_VALID_MISO(spi, pin)     (((pin) & 3) == 0 && IS_VALID_PERIPH(spi, pin))
+#include "micropython/modules/util.hpp"
 
 
 using namespace pimoroni;
@@ -70,7 +64,7 @@ mp_obj_t BreakoutColourLCD160x80_make_new(const mp_obj_type_t *type, size_t n_ar
             mp_buffer_info_t bufinfo;
             mp_get_buffer_raise(args[ARG_buffer].u_obj, &bufinfo, MP_BUFFER_RW);
 
-            self->breakout = new BreakoutColourLCD160x80((uint16_t *)bufinfo.buf, (BG_SPI_SLOT)slot);
+            self->breakout = m_new_class(BreakoutColourLCD160x80, (uint16_t *)bufinfo.buf, (BG_SPI_SLOT)slot);
         }
         else {
             mp_raise_ValueError("slot not a valid value. Expected 0 to 1");
@@ -119,7 +113,7 @@ mp_obj_t BreakoutColourLCD160x80_make_new(const mp_obj_type_t *type, size_t n_ar
         self->base.type = &breakout_colourlcd160x80_BreakoutColourLCD160x80_type;
 
         spi_inst_t *spi = (spi_id == 0) ? spi0 : spi1;
-        self->breakout = new BreakoutColourLCD160x80((uint16_t *)bufinfo.buf, spi,
+        self->breakout = m_new_class(BreakoutColourLCD160x80, (uint16_t *)bufinfo.buf, spi,
             args[ARG_cs].u_int, args[ARG_dc].u_int, sck, mosi, PIN_UNUSED, args[ARG_bl].u_int);
     }
 

--- a/micropython/modules/breakout_colourlcd240x240/breakout_colourlcd240x240.cpp
+++ b/micropython/modules/breakout_colourlcd240x240/breakout_colourlcd240x240.cpp
@@ -1,11 +1,7 @@
 #include "libraries/breakout_colourlcd240x240/breakout_colourlcd240x240.hpp"
 
-#define MP_OBJ_TO_PTR2(o, t) ((t *)(uintptr_t)(o))
+#include "micropython/modules/util.hpp"
 
-#define IS_VALID_PERIPH(spi, pin)   ((((pin) & 8) >> 3) == (spi))
-#define IS_VALID_SCK(spi, pin)      (((pin) & 3) == 2 && IS_VALID_PERIPH(spi, pin))
-#define IS_VALID_MOSI(spi, pin)     (((pin) & 3) == 3 && IS_VALID_PERIPH(spi, pin))
-#define IS_VALID_MISO(spi, pin)     (((pin) & 3) == 0 && IS_VALID_PERIPH(spi, pin))
 
 
 using namespace pimoroni;

--- a/micropython/modules/breakout_dotmatrix/breakout_dotmatrix.cpp
+++ b/micropython/modules/breakout_dotmatrix/breakout_dotmatrix.cpp
@@ -1,11 +1,7 @@
 #include "libraries/breakout_dotmatrix/breakout_dotmatrix.hpp"
+#include "micropython/modules/util.hpp"
 #include <cstdio>
 
-#define MP_OBJ_TO_PTR2(o, t) ((t *)(uintptr_t)(o))
-
-// SDA/SCL on even/odd pins, I2C0/I2C1 on even/odd pairs of pins.
-#define IS_VALID_SCL(i2c, pin) (((pin) & 1) == 1 && (((pin) & 2) >> 1) == (i2c))
-#define IS_VALID_SDA(i2c, pin) (((pin) & 1) == 0 && (((pin) & 2) >> 1) == (i2c))
 
 
 using namespace pimoroni;
@@ -64,7 +60,7 @@ mp_obj_t BreakoutDotMatrix_make_new(const mp_obj_type_t *type, size_t n_args, si
 
     self->i2c = PimoroniI2C_from_machine_i2c_or_native(args[ARG_i2c].u_obj);
 
-    self->breakout = new BreakoutDotMatrix((pimoroni::I2C *)(self->i2c->i2c), args[ARG_address].u_int);
+    self->breakout = m_new_class(BreakoutDotMatrix, (pimoroni::I2C *)(self->i2c->i2c), args[ARG_address].u_int);
 
     if(!self->breakout->init()) {
         mp_raise_msg(&mp_type_RuntimeError, "DotMatrix breakout not found when initialising");

--- a/micropython/modules/breakout_encoder/breakout_encoder.cpp
+++ b/micropython/modules/breakout_encoder/breakout_encoder.cpp
@@ -1,11 +1,6 @@
 #include "libraries/breakout_encoder/breakout_encoder.hpp"
+#include "micropython/modules/util.hpp"
 #include <cstdio>
-
-#define MP_OBJ_TO_PTR2(o, t) ((t *)(uintptr_t)(o))
-
-// SDA/SCL on even/odd pins, I2C0/I2C1 on even/odd pairs of pins.
-#define IS_VALID_SCL(i2c, pin) (((pin) & 1) == 1 && (((pin) & 2) >> 1) == (i2c))
-#define IS_VALID_SDA(i2c, pin) (((pin) & 1) == 0 && (((pin) & 2) >> 1) == (i2c))
 
 
 using namespace pimoroni;
@@ -68,7 +63,7 @@ mp_obj_t BreakoutEncoder_make_new(const mp_obj_type_t *type, size_t n_args, size
 
     self->i2c = PimoroniI2C_from_machine_i2c_or_native(args[ARG_i2c].u_obj);
 
-    self->breakout = new BreakoutEncoder((pimoroni::I2C *)(self->i2c->i2c), args[ARG_address].u_int, args[ARG_interrupt].u_int);
+    self->breakout = m_new_class(BreakoutEncoder, (pimoroni::I2C *)(self->i2c->i2c), args[ARG_address].u_int, args[ARG_interrupt].u_int);
 
     if(!self->breakout->init()) {
         mp_raise_msg(&mp_type_RuntimeError, "BreakoutEncoder: breakout not found when initialising");

--- a/micropython/modules/breakout_icp10125/breakout_icp10125.cpp
+++ b/micropython/modules/breakout_icp10125/breakout_icp10125.cpp
@@ -1,6 +1,6 @@
 #include "drivers/icp10125/icp10125.hpp"
+#include "micropython/modules/util.hpp"
 
-#define MP_OBJ_TO_PTR2(o, t) ((t *)(uintptr_t)(o))
 
 using namespace pimoroni;
 
@@ -43,7 +43,7 @@ mp_obj_t BreakoutICP10125_make_new(const mp_obj_type_t *type, size_t n_args, siz
 
     self->i2c = PimoroniI2C_from_machine_i2c_or_native(args[ARG_i2c].u_obj);
 
-    self->breakout = new ICP10125((pimoroni::I2C *)(self->i2c->i2c));
+    self->breakout = m_new_class(ICP10125, (pimoroni::I2C *)(self->i2c->i2c));
 
     if(!self->breakout->init()) {
         mp_raise_msg(&mp_type_RuntimeError, "BreakoutICP10125: breakout not found when initialising");

--- a/micropython/modules/breakout_ioexpander/breakout_ioexpander.cpp
+++ b/micropython/modules/breakout_ioexpander/breakout_ioexpander.cpp
@@ -1,11 +1,6 @@
 #include "libraries/breakout_ioexpander/breakout_ioexpander.hpp"
+#include "micropython/modules/util.hpp"
 #include <cstdio>
-
-#define MP_OBJ_TO_PTR2(o, t) ((t *)(uintptr_t)(o))
-
-// SDA/SCL on even/odd pins, I2C0/I2C1 on even/odd pairs of pins.
-#define IS_VALID_SCL(i2c, pin) (((pin) & 1) == 1 && (((pin) & 2) >> 1) == (i2c))
-#define IS_VALID_SDA(i2c, pin) (((pin) & 1) == 0 && (((pin) & 2) >> 1) == (i2c))
 
 
 using namespace pimoroni;
@@ -68,7 +63,7 @@ mp_obj_t BreakoutIOExpander_make_new(const mp_obj_type_t *type, size_t n_args, s
 
     self->i2c = PimoroniI2C_from_machine_i2c_or_native(args[ARG_i2c].u_obj);
 
-    self->breakout = new BreakoutIOExpander((pimoroni::I2C *)(self->i2c->i2c), args[ARG_address].u_int, args[ARG_interrupt].u_int);
+    self->breakout = m_new_class(BreakoutIOExpander, (pimoroni::I2C *)(self->i2c->i2c), args[ARG_address].u_int, args[ARG_interrupt].u_int);
 
     if(!self->breakout->init()) {
         mp_raise_msg(&mp_type_RuntimeError, "BreakoutIOExpander: breakout not found when initialising");

--- a/micropython/modules/breakout_ltr559/breakout_ltr559.cpp
+++ b/micropython/modules/breakout_ltr559/breakout_ltr559.cpp
@@ -1,11 +1,6 @@
 #include "libraries/breakout_ltr559/breakout_ltr559.hpp"
+#include "micropython/modules/util.hpp"
 #include <cstdio>
-
-#define MP_OBJ_TO_PTR2(o, t) ((t *)(uintptr_t)(o))
-
-// SDA/SCL on even/odd pins, I2C0/I2C1 on even/odd pairs of pins.
-#define IS_VALID_SCL(i2c, pin) (((pin) & 1) == 1 && (((pin) & 2) >> 1) == (i2c))
-#define IS_VALID_SDA(i2c, pin) (((pin) & 1) == 0 && (((pin) & 2) >> 1) == (i2c))
 
 
 using namespace pimoroni;
@@ -67,7 +62,7 @@ mp_obj_t BreakoutLTR559_make_new(const mp_obj_type_t *type, size_t n_args, size_
 
     self->i2c = PimoroniI2C_from_machine_i2c_or_native(args[ARG_i2c].u_obj);
 
-    self->breakout = new BreakoutLTR559((pimoroni::I2C *)(self->i2c->i2c), args[ARG_interrupt].u_int);
+    self->breakout = m_new_class(BreakoutLTR559, (pimoroni::I2C *)(self->i2c->i2c), args[ARG_interrupt].u_int);
 
     if(!self->breakout->init()) {
         mp_raise_msg(&mp_type_RuntimeError, "BreakoutLTR559: breakout not found when initialising");

--- a/micropython/modules/breakout_matrix11x7/breakout_matrix11x7.cpp
+++ b/micropython/modules/breakout_matrix11x7/breakout_matrix11x7.cpp
@@ -1,11 +1,6 @@
 #include "libraries/breakout_matrix11x7/breakout_matrix11x7.hpp"
+#include "micropython/modules/util.hpp"
 #include <cstdio>
-
-#define MP_OBJ_TO_PTR2(o, t) ((t *)(uintptr_t)(o))
-
-// SDA/SCL on even/odd pins, I2C0/I2C1 on even/odd pairs of pins.
-#define IS_VALID_SCL(i2c, pin) (((pin) & 1) == 1 && (((pin) & 2) >> 1) == (i2c))
-#define IS_VALID_SDA(i2c, pin) (((pin) & 1) == 0 && (((pin) & 2) >> 1) == (i2c))
 
 
 using namespace pimoroni;
@@ -64,7 +59,7 @@ mp_obj_t BreakoutMatrix11x7_make_new(const mp_obj_type_t *type, size_t n_args, s
 
     self->i2c = PimoroniI2C_from_machine_i2c_or_native(args[ARG_i2c].u_obj);
 
-    self->breakout = new BreakoutMatrix11x7((pimoroni::I2C *)(self->i2c->i2c), args[ARG_address].u_int);
+    self->breakout = m_new_class(BreakoutMatrix11x7, (pimoroni::I2C *)(self->i2c->i2c), args[ARG_address].u_int);
 
     if(!self->breakout->init()) {
         mp_raise_msg(&mp_type_RuntimeError, "BreakoutMatrix11x7: breakout not found when initialising");

--- a/micropython/modules/breakout_mics6814/breakout_mics6814.cpp
+++ b/micropython/modules/breakout_mics6814/breakout_mics6814.cpp
@@ -1,11 +1,6 @@
 #include "libraries/breakout_mics6814/breakout_mics6814.hpp"
+#include "micropython/modules/util.hpp"
 #include <cstdio>
-
-#define MP_OBJ_TO_PTR2(o, t) ((t *)(uintptr_t)(o))
-
-// SDA/SCL on even/odd pins, I2C0/I2C1 on even/odd pairs of pins.
-#define IS_VALID_SCL(i2c, pin) (((pin) & 1) == 1 && (((pin) & 2) >> 1) == (i2c))
-#define IS_VALID_SDA(i2c, pin) (((pin) & 1) == 0 && (((pin) & 2) >> 1) == (i2c))
 
 
 using namespace pimoroni;
@@ -68,7 +63,7 @@ mp_obj_t BreakoutMICS6814_make_new(const mp_obj_type_t *type, size_t n_args, siz
 
     self->i2c = PimoroniI2C_from_machine_i2c_or_native(args[ARG_i2c].u_obj);
 
-    self->breakout = new BreakoutMICS6814((pimoroni::I2C *)(self->i2c->i2c), args[ARG_address].u_int, args[ARG_interrupt].u_int);
+    self->breakout = m_new_class(BreakoutMICS6814, (pimoroni::I2C *)(self->i2c->i2c), args[ARG_address].u_int, args[ARG_interrupt].u_int);
 
     if(!self->breakout->init()) {
         mp_raise_msg(&mp_type_RuntimeError, "BreakoutMICS6814: breakout not found when initialising");

--- a/micropython/modules/breakout_msa301/breakout_msa301.cpp
+++ b/micropython/modules/breakout_msa301/breakout_msa301.cpp
@@ -1,10 +1,5 @@
 #include "libraries/breakout_msa301/breakout_msa301.hpp"
-
-#define MP_OBJ_TO_PTR2(o, t) ((t *)(uintptr_t)(o))
-
-// SDA/SCL on even/odd pins, I2C0/I2C1 on even/odd pairs of pins.
-#define IS_VALID_SCL(i2c, pin) (((pin) & 1) == 1 && (((pin) & 2) >> 1) == (i2c))
-#define IS_VALID_SDA(i2c, pin) (((pin) & 1) == 0 && (((pin) & 2) >> 1) == (i2c))
+#include "micropython/modules/util.hpp"
 
 
 using namespace pimoroni;
@@ -61,7 +56,7 @@ mp_obj_t BreakoutMSA301_make_new(const mp_obj_type_t *type, size_t n_args, size_
 
     self->i2c = PimoroniI2C_from_machine_i2c_or_native(args[ARG_i2c].u_obj);
 
-    self->breakout = new BreakoutMSA301((pimoroni::I2C *)(self->i2c->i2c), args[ARG_interrupt].u_int);
+    self->breakout = m_new_class(BreakoutMSA301, (pimoroni::I2C *)(self->i2c->i2c), args[ARG_interrupt].u_int);
 
     if(!self->breakout->init()) {
         mp_raise_msg(&mp_type_RuntimeError, "BreakoutMSA301: breakout not found when initialising");

--- a/micropython/modules/breakout_pmw3901/breakout_pmw3901.cpp
+++ b/micropython/modules/breakout_pmw3901/breakout_pmw3901.cpp
@@ -1,12 +1,6 @@
 #include "libraries/breakout_pmw3901/breakout_pmw3901.hpp"
 #include "libraries/breakout_paa5100/breakout_paa5100.hpp"
-
-#define MP_OBJ_TO_PTR2(o, t) ((t *)(uintptr_t)(o))
-
-#define IS_VALID_PERIPH(spi, pin)   ((((pin) & 8) >> 3) == (spi))
-#define IS_VALID_SCK(spi, pin)      (((pin) & 3) == 2 && IS_VALID_PERIPH(spi, pin))
-#define IS_VALID_MOSI(spi, pin)     (((pin) & 3) == 3 && IS_VALID_PERIPH(spi, pin))
-#define IS_VALID_MISO(spi, pin)     (((pin) & 3) == 0 && IS_VALID_PERIPH(spi, pin))
+#include "micropython/modules/util.hpp"
 
 
 using namespace pimoroni;
@@ -84,16 +78,16 @@ mp_obj_t make_new(enum ChipType chip, const mp_obj_type_t *type, size_t n_args, 
             self->base.type = &breakout_pmw3901_BreakoutPMW3901_type;
 
             if(chip == ChipType::PMW3901) {
-                BreakoutPMW3901 *breakout = new BreakoutPMW3901((BG_SPI_SLOT)slot);
+                BreakoutPMW3901 *breakout = m_new_class(BreakoutPMW3901, (BG_SPI_SLOT)slot);
                 if (!breakout->init()) {
-                    delete breakout;
+                    m_del_class(BreakoutPMW3901, breakout);
                     mp_raise_msg(&mp_type_RuntimeError, "BreakoutPMW3901: Init failed");
                 }
                 self->breakout = breakout;
             } else {
-                BreakoutPAA5100 *breakout = new BreakoutPAA5100((BG_SPI_SLOT)slot);
+                BreakoutPAA5100 *breakout = m_new_class(BreakoutPAA5100, (BG_SPI_SLOT)slot);
                 if (!breakout->init()) {
-                    delete breakout;
+                    m_del_class(BreakoutPAA5100, breakout);
                     mp_raise_msg(&mp_type_RuntimeError, "BreakoutPAA5100: Init failed");
                 }
                 self->breakout = breakout;
@@ -148,16 +142,16 @@ mp_obj_t make_new(enum ChipType chip, const mp_obj_type_t *type, size_t n_args, 
 
         spi_inst_t *spi = (spi_id == 0) ? spi0 : spi1;
         if(chip == ChipType::PMW3901) {
-            BreakoutPMW3901 *breakout = new BreakoutPMW3901(spi, args[ARG_cs].u_int, sck, mosi, miso, args[ARG_interrupt].u_int);
+            BreakoutPMW3901 *breakout = m_new_class(BreakoutPMW3901, spi, args[ARG_cs].u_int, sck, mosi, miso, args[ARG_interrupt].u_int);
             if (!breakout->init()) {
-                delete breakout;
+                m_del_class(BreakoutPMW3901, breakout);
                 mp_raise_msg(&mp_type_RuntimeError, "BreakoutPMW3901: Init failed");
             }
             self->breakout = breakout;
         } else {
-            BreakoutPAA5100 *breakout = new BreakoutPAA5100(spi, args[ARG_cs].u_int, sck, mosi, miso, args[ARG_interrupt].u_int);
+            BreakoutPAA5100 *breakout = m_new_class(BreakoutPAA5100, spi, args[ARG_cs].u_int, sck, mosi, miso, args[ARG_interrupt].u_int);
             if (!breakout->init()) {
-                delete breakout;
+                m_del_class(BreakoutPAA5100, breakout);
                 mp_raise_msg(&mp_type_RuntimeError, "BreakoutPAA5100: Init failed");
             }
             self->breakout = breakout;
@@ -172,7 +166,7 @@ mp_obj_t make_new(enum ChipType chip, const mp_obj_type_t *type, size_t n_args, 
 /***** Destructor ******/
 mp_obj_t BreakoutPMW3901___del__(mp_obj_t self_in) {
     breakout_pmw3901_BreakoutPMW3901_obj_t *self = MP_OBJ_TO_PTR2(self_in, breakout_pmw3901_BreakoutPMW3901_obj_t);
-    delete self->breakout;
+    m_del_class(BreakoutPMW3901, self->breakout);
     return mp_const_none;
 }
 

--- a/micropython/modules/breakout_potentiometer/breakout_potentiometer.cpp
+++ b/micropython/modules/breakout_potentiometer/breakout_potentiometer.cpp
@@ -1,11 +1,6 @@
 #include "libraries/breakout_potentiometer/breakout_potentiometer.hpp"
+#include "micropython/modules/util.hpp"
 #include <cstdio>
-
-#define MP_OBJ_TO_PTR2(o, t) ((t *)(uintptr_t)(o))
-
-// SDA/SCL on even/odd pins, I2C0/I2C1 on even/odd pairs of pins.
-#define IS_VALID_SCL(i2c, pin) (((pin) & 1) == 1 && (((pin) & 2) >> 1) == (i2c))
-#define IS_VALID_SDA(i2c, pin) (((pin) & 1) == 0 && (((pin) & 2) >> 1) == (i2c))
 
 
 using namespace pimoroni;
@@ -68,7 +63,7 @@ mp_obj_t BreakoutPotentiometer_make_new(const mp_obj_type_t *type, size_t n_args
 
     self->i2c = PimoroniI2C_from_machine_i2c_or_native(args[ARG_i2c].u_obj);
 
-    self->breakout = new BreakoutPotentiometer((pimoroni::I2C *)(self->i2c->i2c), args[ARG_interrupt].u_int);
+    self->breakout = m_new_class(BreakoutPotentiometer, (pimoroni::I2C *)(self->i2c->i2c), args[ARG_interrupt].u_int);
 
     if(!self->breakout->init()) {
         mp_raise_msg(&mp_type_RuntimeError, "BreakoutPotentiometer: breakout not found when initialising");

--- a/micropython/modules/breakout_rgbmatrix5x5/breakout_rgbmatrix5x5.cpp
+++ b/micropython/modules/breakout_rgbmatrix5x5/breakout_rgbmatrix5x5.cpp
@@ -1,11 +1,6 @@
 #include "libraries/breakout_rgbmatrix5x5/breakout_rgbmatrix5x5.hpp"
+#include "micropython/modules/util.hpp"
 #include <cstdio>
-
-#define MP_OBJ_TO_PTR2(o, t) ((t *)(uintptr_t)(o))
-
-// SDA/SCL on even/odd pins, I2C0/I2C1 on even/odd pairs of pins.
-#define IS_VALID_SCL(i2c, pin) (((pin) & 1) == 1 && (((pin) & 2) >> 1) == (i2c))
-#define IS_VALID_SDA(i2c, pin) (((pin) & 1) == 0 && (((pin) & 2) >> 1) == (i2c))
 
 
 using namespace pimoroni;
@@ -64,7 +59,7 @@ mp_obj_t BreakoutRGBMatrix5x5_make_new(const mp_obj_type_t *type, size_t n_args,
 
     self->i2c = PimoroniI2C_from_machine_i2c_or_native(args[ARG_i2c].u_obj);
 
-    self->breakout = new BreakoutRGBMatrix5x5((pimoroni::I2C *)(self->i2c->i2c), args[ARG_address].u_int);
+    self->breakout = m_new_class(BreakoutRGBMatrix5x5, (pimoroni::I2C *)(self->i2c->i2c), args[ARG_address].u_int);
 
     if(!self->breakout->init()) {
         mp_raise_msg(&mp_type_RuntimeError, "BreakoutRGBMatrix5x5: breakout not found when initialising");

--- a/micropython/modules/breakout_roundlcd/breakout_roundlcd.cpp
+++ b/micropython/modules/breakout_roundlcd/breakout_roundlcd.cpp
@@ -1,11 +1,7 @@
 #include "libraries/breakout_roundlcd/breakout_roundlcd.hpp"
 
-#define MP_OBJ_TO_PTR2(o, t) ((t *)(uintptr_t)(o))
+#include "micropython/modules/util.hpp"
 
-#define IS_VALID_PERIPH(spi, pin)   ((((pin) & 8) >> 3) == (spi))
-#define IS_VALID_SCK(spi, pin)      (((pin) & 3) == 2 && IS_VALID_PERIPH(spi, pin))
-#define IS_VALID_MOSI(spi, pin)     (((pin) & 3) == 3 && IS_VALID_PERIPH(spi, pin))
-#define IS_VALID_MISO(spi, pin)     (((pin) & 3) == 0 && IS_VALID_PERIPH(spi, pin))
 
 
 using namespace pimoroni;

--- a/micropython/modules/breakout_rtc/breakout_rtc.cpp
+++ b/micropython/modules/breakout_rtc/breakout_rtc.cpp
@@ -1,12 +1,7 @@
-#include "../../../libraries/breakout_rtc/breakout_rtc.hpp"
+#include "libraries/breakout_rtc/breakout_rtc.hpp"
+#include "micropython/modules/util.hpp"
 #include <string>
 #include <cstring>
-
-#define MP_OBJ_TO_PTR2(o, t) ((t *)(uintptr_t)(o))
-
-// SDA/SCL on even/odd pins, I2C0/I2C1 on even/odd pairs of pins.
-#define IS_VALID_SCL(i2c, pin) (((pin) & 1) == 1 && (((pin) & 2) >> 1) == (i2c))
-#define IS_VALID_SDA(i2c, pin) (((pin) & 1) == 0 && (((pin) & 2) >> 1) == (i2c))
 
 
 using namespace pimoroni;
@@ -64,7 +59,7 @@ mp_obj_t BreakoutRTC_make_new(const mp_obj_type_t *type, size_t n_args, size_t n
 
     self->i2c = PimoroniI2C_from_machine_i2c_or_native(args[ARG_i2c].u_obj);
 
-    self->breakout = new BreakoutRTC((pimoroni::I2C *)(self->i2c->i2c), args[ARG_interrupt].u_int);
+    self->breakout = m_new_class(BreakoutRTC, (pimoroni::I2C *)(self->i2c->i2c), args[ARG_interrupt].u_int);
 
     if(!self->breakout->init()) {
         mp_raise_msg(&mp_type_RuntimeError, "BreakoutRTC: breakout not found when initialising");

--- a/micropython/modules/breakout_sgp30/breakout_sgp30.cpp
+++ b/micropython/modules/breakout_sgp30/breakout_sgp30.cpp
@@ -1,10 +1,5 @@
 #include "libraries/breakout_sgp30/breakout_sgp30.hpp"
-
-#define MP_OBJ_TO_PTR2(o, t) ((t *)(uintptr_t)(o))
-
-// SDA/SCL on even/odd pins, I2C0/I2C1 on even/odd pairs of pins.
-#define IS_VALID_SCL(i2c, pin) (((pin) & 1) == 1 && (((pin) & 2) >> 1) == (i2c))
-#define IS_VALID_SDA(i2c, pin) (((pin) & 1) == 0 && (((pin) & 2) >> 1) == (i2c))
+#include "micropython/modules/util.hpp"
 
 
 using namespace pimoroni;
@@ -57,7 +52,7 @@ mp_obj_t BreakoutSGP30_make_new(const mp_obj_type_t *type, size_t n_args, size_t
 
     self->i2c = PimoroniI2C_from_machine_i2c_or_native(args[ARG_i2c].u_obj);
 
-    self->breakout = new BreakoutSGP30((pimoroni::I2C *)(self->i2c->i2c));
+    self->breakout = m_new_class(BreakoutSGP30, (pimoroni::I2C *)(self->i2c->i2c));
 
     if(!self->breakout->init()) {
         mp_raise_msg(&mp_type_RuntimeError, "BreakoutSGP30: breakout not found when initialising");

--- a/micropython/modules/breakout_trackball/breakout_trackball.cpp
+++ b/micropython/modules/breakout_trackball/breakout_trackball.cpp
@@ -1,11 +1,6 @@
 #include "libraries/breakout_trackball/breakout_trackball.hpp"
+#include "micropython/modules/util.hpp"
 #include <cstdio>
-
-#define MP_OBJ_TO_PTR2(o, t) ((t *)(uintptr_t)(o))
-
-// SDA/SCL on even/odd pins, I2C0/I2C1 on even/odd pairs of pins.
-#define IS_VALID_SCL(i2c, pin) (((pin) & 1) == 1 && (((pin) & 2) >> 1) == (i2c))
-#define IS_VALID_SDA(i2c, pin) (((pin) & 1) == 0 && (((pin) & 2) >> 1) == (i2c))
 
 
 using namespace pimoroni;
@@ -68,7 +63,7 @@ mp_obj_t BreakoutTrackball_make_new(const mp_obj_type_t *type, size_t n_args, si
 
     self->i2c = PimoroniI2C_from_machine_i2c_or_native(args[ARG_i2c].u_obj);
 
-    self->breakout = new BreakoutTrackball((pimoroni::I2C *)(self->i2c->i2c), args[ARG_address].u_int, args[ARG_interrupt].u_int);
+    self->breakout = m_new_class(BreakoutTrackball, (pimoroni::I2C *)(self->i2c->i2c), args[ARG_address].u_int, args[ARG_interrupt].u_int);
 
     if(!self->breakout->init()) {
         mp_raise_msg(&mp_type_RuntimeError, "Trackball breakout not found when initialising");

--- a/micropython/modules/encoder/encoder.cpp
+++ b/micropython/modules/encoder/encoder.cpp
@@ -1,8 +1,8 @@
 #include "drivers/encoder/encoder.hpp"
+#include "micropython/modules/util.hpp"
 #include <cstdio>
 #include <cfloat>
 
-#define MP_OBJ_TO_PTR2(o, t) ((t *)(uintptr_t)(o))
 
 using namespace pimoroni;
 using namespace encoder;
@@ -138,9 +138,9 @@ mp_obj_t Encoder_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw,
         freq_divider = mp_obj_get_float(args[ARG_freq_divider].u_obj);
     }
 
-    Encoder *encoder = new Encoder(pio, sm, pins, args[ARG_common_pin].u_int, (Direction)direction, counts_per_rev, count_microsteps, freq_divider);
+    Encoder *encoder = m_new_class(Encoder, pio, sm, pins, args[ARG_common_pin].u_int, (Direction)direction, counts_per_rev, count_microsteps, freq_divider);
     if(!encoder->init()) {
-        delete encoder;
+        m_del_class(Encoder, encoder);
         mp_raise_msg(&mp_type_RuntimeError, "unable to allocate the hardware resources needed to initialise this Encoder. Try running `import gc` followed by `gc.collect()` before creating it");
     }
 
@@ -155,7 +155,7 @@ mp_obj_t Encoder_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw,
 /***** Destructor ******/
 mp_obj_t Encoder___del__(mp_obj_t self_in) {
     _Encoder_obj_t *self = MP_OBJ_TO_PTR2(self_in, _Encoder_obj_t);
-    delete self->encoder;
+    m_del_class(Encoder, self->encoder);
     return mp_const_none;
 }
 

--- a/micropython/modules/hub75/hub75.cpp
+++ b/micropython/modules/hub75/hub75.cpp
@@ -2,7 +2,7 @@
 #include "hub75.hpp"
 #include "pico/multicore.h"
 
-#define MP_OBJ_TO_PTR2(o, t) ((t *)(uintptr_t)(o))
+#include "micropython/modules/util.hpp"
 
 
 extern "C" {
@@ -65,7 +65,7 @@ void Hub75_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind
 mp_obj_t Hub75___del__(mp_obj_t self_in) {
     _Hub75_obj_t *self = MP_OBJ_TO_PTR2(self_in, _Hub75_obj_t);
     self->hub75->stop(dma_complete);
-    delete self->hub75;
+    m_del_class(Hub75, self->hub75);
     return mp_const_none;
 }
 
@@ -111,7 +111,7 @@ mp_obj_t Hub75_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, c
     hub75_obj = m_new_obj_with_finaliser(_Hub75_obj_t);
     hub75_obj->base.type = &Hub75_type;
     hub75_obj->buf = buffer;
-    hub75_obj->hub75 = new Hub75(width, height, buffer, paneltype, stb_invert);
+    hub75_obj->hub75 = m_new_class(Hub75, width, height, buffer, paneltype, stb_invert);
 
     return MP_OBJ_FROM_PTR(hub75_obj);
 }

--- a/micropython/modules/pico_display/pico_display.cpp
+++ b/micropython/modules/pico_display/pico_display.cpp
@@ -2,7 +2,7 @@
 #include "hardware/sync.h"
 #include "pico/binary_info.h"
 
-#include "libraries/pico_display/pico_display.hpp"
+#include "libraries/pico_display/pico_display.hpp"zzz
 
 using namespace pimoroni;
 

--- a/micropython/modules/pimoroni_i2c/pimoroni_i2c.cpp
+++ b/micropython/modules/pimoroni_i2c/pimoroni_i2c.cpp
@@ -1,11 +1,6 @@
 #include "common/pimoroni_i2c.hpp"
+#include "micropython/modules/util.hpp"
 #include <cstdio>
-
-#define MP_OBJ_TO_PTR2(o, t) ((t *)(uintptr_t)(o))
-
-// SDA/SCL on even/odd pins, I2C0/I2C1 on even/odd pairs of pins.
-#define IS_VALID_SCL(i2c, pin) (((pin) & 1) == 1 && (((pin) & 2) >> 1) == (i2c))
-#define IS_VALID_SDA(i2c, pin) (((pin) & 1) == 0 && (((pin) & 2) >> 1) == (i2c))
 
 
 using namespace pimoroni;
@@ -24,7 +19,8 @@ _PimoroniI2C_obj_t*  PimoroniI2C_from_machine_i2c_or_native(mp_obj_t i2c_obj) {
         machine_i2c_obj_t *machine_i2c = (machine_i2c_obj_t *)MP_OBJ_TO_PTR(i2c_obj);
         pimoroni_i2c = m_new_obj(_PimoroniI2C_obj_t);
         pimoroni_i2c->base.type = &PimoroniI2C_type;
-        pimoroni_i2c->i2c = new I2C(machine_i2c->sda, machine_i2c->scl, machine_i2c->freq);
+
+        pimoroni_i2c->i2c = m_new_class(I2C, machine_i2c->sda, machine_i2c->scl, machine_i2c->freq);
         return pimoroni_i2c;
     } else {
         mp_raise_ValueError(MP_ERROR_TEXT("Bad I2C object"));
@@ -81,7 +77,7 @@ mp_obj_t PimoroniI2C_make_new(const mp_obj_type_t *type, size_t n_args, size_t n
     self = m_new_obj(_PimoroniI2C_obj_t);
     self->base.type = &PimoroniI2C_type;
 
-    self->i2c = new I2C(sda, scl, baud);
+    self->i2c = m_new_class(I2C, sda, scl, baud);
 
     return MP_OBJ_FROM_PTR(self);
 }

--- a/micropython/modules/plasma/plasma.cpp
+++ b/micropython/modules/plasma/plasma.cpp
@@ -1,12 +1,7 @@
 #include "drivers/plasma/ws2812.hpp"
 #include "drivers/plasma/apa102.hpp"
+#include "micropython/modules/util.hpp"
 #include <cstdio>
-
-#define MP_OBJ_TO_PTR2(o, t) ((t *)(uintptr_t)(o))
-
-// SDA/SCL on even/odd pins, I2C0/I2C1 on even/odd pairs of pins.
-#define IS_VALID_SCL(i2c, pin) (((pin) & 1) == 1 && (((pin) & 2) >> 1) == (i2c))
-#define IS_VALID_SDA(i2c, pin) (((pin) & 1) == 0 && (((pin) & 2) >> 1) == (i2c))
 
 
 using namespace plasma;
@@ -47,7 +42,7 @@ void PlasmaWS2812_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind
 /***** Destructor ******/
 mp_obj_t PlasmaWS2812___del__(mp_obj_t self_in) {
     _PlasmaWS2812_obj_t *self = MP_OBJ_TO_PTR2(self_in, _PlasmaWS2812_obj_t);
-    delete self->ws2812;
+    m_del_class(WS2812, self->ws2812);
     return mp_const_none;
 }
 
@@ -103,7 +98,7 @@ mp_obj_t PlasmaWS2812_make_new(const mp_obj_type_t *type, size_t n_args, size_t 
     self->base.type = &PlasmaWS2812_type;
     self->buf = buffer;
 
-    self->ws2812 = new WS2812(num_leds, pio, sm, dat, freq, rgbw, color_order, (WS2812::RGB *)buffer);
+    self->ws2812 = m_new_class(WS2812, num_leds, pio, sm, dat, freq, rgbw, color_order, (WS2812::RGB *)buffer);
 
     return MP_OBJ_FROM_PTR(self);
 }
@@ -252,7 +247,7 @@ void PlasmaAPA102_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind
 /***** Destructor ******/
 mp_obj_t PlasmaAPA102___del__(mp_obj_t self_in) {
     _PlasmaAPA102_obj_t *self = MP_OBJ_TO_PTR2(self_in, _PlasmaAPA102_obj_t);
-    delete self->apa102;
+    m_del_class(APA102, self->apa102);
     return mp_const_none;
 }
 
@@ -312,7 +307,7 @@ mp_obj_t PlasmaAPA102_make_new(const mp_obj_type_t *type, size_t n_args, size_t 
     self->base.type = &PlasmaAPA102_type;
     self->buf = buffer;
 
-    self->apa102 = new APA102(num_leds, pio, sm, dat, clk, freq, buffer);
+    self->apa102 = m_new_class(APA102, num_leds, pio, sm, dat, clk, freq, buffer);
 
     return MP_OBJ_FROM_PTR(self);
 }

--- a/micropython/modules/st7789/st7789.cpp
+++ b/micropython/modules/st7789/st7789.cpp
@@ -1,11 +1,7 @@
 #include "libraries/generic_st7789/generic_st7789.hpp"
 
-#define MP_OBJ_TO_PTR2(o, t) ((t *)(uintptr_t)(o))
+#include "micropython/modules/util.hpp"
 
-#define IS_VALID_PERIPH(spi, pin)   ((((pin) & 8) >> 3) == (spi))
-#define IS_VALID_SCK(spi, pin)      (((pin) & 3) == 2 && IS_VALID_PERIPH(spi, pin))
-#define IS_VALID_MOSI(spi, pin)     (((pin) & 3) == 3 && IS_VALID_PERIPH(spi, pin))
-#define IS_VALID_MISO(spi, pin)     (((pin) & 3) == 0 && IS_VALID_PERIPH(spi, pin))
 
 
 using namespace pimoroni;
@@ -93,7 +89,7 @@ mp_obj_t GenericST7789_make_new(const mp_obj_type_t *type, size_t n_args, size_t
 
     if(args[ARG_slot].u_int != -1) {
         BG_SPI_SLOT slot = (BG_SPI_SLOT)args[ARG_slot].u_int;
-        self->st7789 = new ST7789Generic(width, height, round, self->buffer, slot);
+        self->st7789 = m_new_class(ST7789Generic, width, height, round, self->buffer, slot);
         if (rotate180) {
             self->st7789->configure_display(true);
         }
@@ -121,7 +117,7 @@ mp_obj_t GenericST7789_make_new(const mp_obj_type_t *type, size_t n_args, size_t
             mp_raise_ValueError(MP_ERROR_TEXT("bad MOSI pin"));
         }
         spi_inst_t *spi = (spi_id == 0) ? spi0 : spi1;
-        self->st7789 = new ST7789Generic(width, height, round, self->buffer,
+        self->st7789 = m_new_class(ST7789Generic, width, height, round, self->buffer,
             spi, cs, dc, sck, mosi, bl);
         if (rotate180) {
             self->st7789->configure_display(true);

--- a/micropython/modules/util.hpp
+++ b/micropython/modules/util.hpp
@@ -1,0 +1,16 @@
+#include <new>
+
+#define MP_OBJ_TO_PTR2(o, t) ((t *)(uintptr_t)(o))
+
+// SDA/SCL on even/odd pins, I2C0/I2C1 on even/odd pairs of pins.
+#define IS_VALID_SCL(i2c, pin) (((pin) & 1) == 1 && (((pin) & 2) >> 1) == (i2c))
+#define IS_VALID_SDA(i2c, pin) (((pin) & 1) == 0 && (((pin) & 2) >> 1) == (i2c))
+
+#define IS_VALID_PERIPH(spi, pin)   ((((pin) & 8) >> 3) == (spi))
+#define IS_VALID_SCK(spi, pin)      (((pin) & 3) == 2 && IS_VALID_PERIPH(spi, pin))
+#define IS_VALID_MOSI(spi, pin)     (((pin) & 3) == 3 && IS_VALID_PERIPH(spi, pin))
+#define IS_VALID_MISO(spi, pin)     (((pin) & 3) == 0 && IS_VALID_PERIPH(spi, pin))
+
+
+#define m_new_class(cls, ...) new(m_new(cls, 1)) cls(__VA_ARGS__)
+#define m_del_class(cls, ptr) ptr->~cls();m_del(cls, ptr, 1)


### PR DESCRIPTION
This change should hopefully allow us to write more generic classes that do not need special treatment under MicroPython.

I have updated Servo/PWM to remove the dynamic buffers in place of constant-sized buffers defined in the class. Using `m_new` to allocate some memory in the GC_HEAP and `placement new` to construct a class within that memory, we can push the *entire* class into MicroPython's memory region and avoid running out of memory.

I have also updated Pimoroni I2C to make this change both in the `machine.I2C` to `PimoroniI2C` promotion and in the regular I2C object.