### PR TITLE
Improve PIMORONI_PICO_PATH fallback

### DIFF
--- a/pimoroni_pico_import.cmake
+++ b/pimoroni_pico_import.cmake
@@ -2,16 +2,17 @@
 # It will also set up the required include and module search paths.
 
 if (NOT PIMORONI_PICO_PATH)
-    set(PIMORONI_PICO_PATH "../../pimoroni-pico/")
+    if (PICO_SDK_PATH AND EXISTS "${PICO_SDK_PATH}/../pimoroni-pico")
+        set(PIMORONI_PICO_PATH ${PICO_SDK_PATH}/../pimoroni-pico)
+        message("Defaulting PIMORONI_PICO_PATH as sibling of PICO_SDK_PATH: ${PIMORONI_PICO_PATH}")
+    elseif(EXISTS "${CMAKE_CURRENT_BINARY_DIR}/../../pimoroni-pico/")
+        set(PIMORONI_PICO_PATH ${CMAKE_CURRENT_BINARY_DIR}/../../pimoroni-pico/)
+    else()
+        message(FATAL_ERROR "Pimoroni Pico location was not specified. Please set PIMORONI_PICO_PATH.")
+    endif()
 endif()
 
-if(NOT IS_ABSOLUTE ${PIMORONI_PICO_PATH})
-    get_filename_component(
-        PIMORONI_PICO_PATH
-        "${CMAKE_CURRENT_BINARY_DIR}/${PIMORONI_PICO_PATH}"
-        ABSOLUTE)
-endif()
-
+get_filename_component(PIMORONI_PICO_PATH "${PIMORONI_PICO_PATH}" REALPATH BASE_DIR "${CMAKE_BINARY_DIR}")
 if (NOT EXISTS ${PIMORONI_PICO_PATH})
     message(FATAL_ERROR "Directory '${PIMORONI_PICO_PATH}' not found")
 endif ()


### PR DESCRIPTION
Check for pimoroni-pico next to the pico sdk, then next to the project. If neither exist, fail with an error that tells the user to set `PIMORONI_PICO_PATH`.

This is mostly a copy from pico-extras. [Did this while ago... and forgot about it](https://github.com/Daft-Freak/i75-snow-demo/blob/main/pimoroni_pico_import.cmake)