### PR TITLE
Pico Display & Pico Display 2 Demos: Avoid passing buffer into bool parameter

### DIFF
--- a/examples/pico_display/demo.cpp
+++ b/examples/pico_display/demo.cpp
@@ -11,10 +11,8 @@ using namespace pimoroni;
 
 const bool ROTATE_180 = false;
 
-uint16_t buffer[PicoDisplay::WIDTH * PicoDisplay::HEIGHT];
-
 // Swap WIDTH and HEIGHT to rotate 90 degrees
-ST7789Generic pico_display(PicoDisplay::WIDTH, PicoDisplay::HEIGHT, buffer);
+ST7789Generic pico_display(PicoDisplay::WIDTH, PicoDisplay::HEIGHT);
 
 RGBLED led(PicoDisplay::LED_R, PicoDisplay::LED_G, PicoDisplay::LED_B);
 

--- a/examples/pico_display_2/demo.cpp
+++ b/examples/pico_display_2/demo.cpp
@@ -12,10 +12,8 @@ using namespace pimoroni;
 
 const bool ROTATE_180 = false;
 
-uint16_t buffer[PicoDisplay2::WIDTH * PicoDisplay2::HEIGHT];
-
 // Swap WIDTH and HEIGHT to rotate 90 degrees
-ST7789Generic pico_display(PicoDisplay2::WIDTH, PicoDisplay2::HEIGHT, buffer);
+ST7789Generic pico_display(240, 240);
 
 RGBLED led(PicoDisplay2::LED_R, PicoDisplay2::LED_G, PicoDisplay2::LED_B);
 


### PR DESCRIPTION
There's no real reason to pass in a buffer since it's allocated by the class, and since I missed the `round` parameter it was actually setting the displays to round rather than setting a buffer anyway... oof!

Luckily there's no such thing as a round Pico Display!