### PR TITLE
Drop obsolete MicroPython binding compat constructors.

### DIFF
--- a/drivers/as7262/as7262.hpp
+++ b/drivers/as7262/as7262.hpp
@@ -83,9 +83,6 @@ namespace pimoroni {
 
     AS7262(I2C *i2c, uint interrupt = PIN_UNUSED) : i2c(i2c), interrupt(interrupt) {}
 
-    // TODO remove MicroPython-binding compatibility constructors
-    AS7262(uint sda, uint scl, uint interrupt = PIN_UNUSED) : AS7262(new I2C(), interrupt) {}
-
 
     //--------------------------------------------------
     // Methods

--- a/drivers/ioexpander/ioexpander.hpp
+++ b/drivers/ioexpander/ioexpander.hpp
@@ -164,10 +164,6 @@ namespace pimoroni {
     IOExpander(uint8_t address, uint32_t timeout = 1, bool debug = false) :
         IOExpander(new I2C(), address, PIN_UNUSED, timeout, debug) {};
 
-    IOExpander(uint8_t address, uint sda, uint scl, uint interrupt = PIN_UNUSED, uint32_t timeout = 1, bool debug = false) :
-        IOExpander(new I2C(sda, scl), address, interrupt, timeout, debug) {};
-
-    // TODO remove MicroPython-binding compatibility constructors
     IOExpander(I2C *i2c, uint8_t address=DEFAULT_I2C_ADDRESS, uint interrupt = PIN_UNUSED, uint32_t timeout = 1, bool debug = false);
 
 

--- a/drivers/ltr559/ltr559.hpp
+++ b/drivers/ltr559/ltr559.hpp
@@ -148,8 +148,6 @@ namespace pimoroni {
 
     LTR559(I2C *i2c, uint interrupt = PIN_UNUSED) : i2c(i2c), interrupt(interrupt) {}
 
-    // TODO remove MicroPython-binding compatibility constructors
-    LTR559(uint sda, uint scl, uint interrupt = PIN_UNUSED) : LTR559(new I2C(), interrupt) {}
 
     //--------------------------------------------------
     // Methods

--- a/drivers/msa301/msa301.hpp
+++ b/drivers/msa301/msa301.hpp
@@ -116,9 +116,6 @@ namespace pimoroni {
 
     MSA301(I2C *i2c, uint interrupt = PIN_UNUSED) : i2c(i2c), interrupt(interrupt) {}
 
-    // TODO remove MicroPython-binding compatibility constructors
-    MSA301(i2c_inst_t *i2c_inst, uint sda, uint scl, uint interrupt = PIN_UNUSED) : MSA301(new I2C(sda, scl), interrupt) {}
-
 
     //--------------------------------------------------
     // Methods

--- a/drivers/rv3028/rv3028.hpp
+++ b/drivers/rv3028/rv3028.hpp
@@ -224,9 +224,6 @@ namespace pimoroni {
     RV3028(I2C *i2c, uint interrupt = DEFAULT_INT_PIN) :
       i2c(i2c), interrupt(interrupt) {}
 
-    // TODO remove MicroPython-binding compatibility constructors
-    RV3028(i2c_inst_t *i2c, uint sda, uint scl, uint interrupt = DEFAULT_INT_PIN) : RV3028(new I2C(sda, scl), interrupt) {}
-
 
     //--------------------------------------------------
     // Methods

--- a/drivers/sgp30/sgp30.hpp
+++ b/drivers/sgp30/sgp30.hpp
@@ -50,9 +50,6 @@ namespace pimoroni {
 
     SGP30(I2C *i2c) : i2c(i2c) {}
 
-    // TODO remove MicroPython-binding compatibility constructors
-    SGP30(i2c_inst_t *i2c_inst, uint sda, uint scl) : i2c(new I2C(sda, scl)) { }
-
     //--------------------------------------------------
     // Methods
     //--------------------------------------------------

--- a/drivers/trackball/trackball.hpp
+++ b/drivers/trackball/trackball.hpp
@@ -52,9 +52,6 @@ namespace pimoroni {
 
     Trackball(I2C *i2c, uint8_t address = DEFAULT_I2C_ADDRESS, uint interrupt = PIN_UNUSED, uint32_t timeout = DEFAULT_TIMEOUT) : i2c(i2c), address(address), interrupt(interrupt) {}
 
-    // TODO remove MicroPython-binding compatibility constructors
-    Trackball(i2c_inst_t *i2c_inst, uint8_t address, uint sda, uint scl, uint interrupt = PIN_UNUSED, uint32_t timeout = DEFAULT_TIMEOUT) : Trackball(new I2C(sda, scl), address, interrupt) {}
-
     //--------------------------------------------------
     // Methods
     //--------------------------------------------------

--- a/libraries/breakout_encoder/breakout_encoder.hpp
+++ b/libraries/breakout_encoder/breakout_encoder.hpp
@@ -58,9 +58,6 @@ namespace pimoroni {
     BreakoutEncoder(I2C *i2c, uint8_t address = DEFAULT_I2C_ADDRESS, uint interrupt = PIN_UNUSED, uint32_t timeout = DEFAULT_TIMEOUT, bool debug = false) :
       ioe(i2c, address, interrupt, timeout, debug) {}
 
-    // TODO remove MicroPython-binding compatibility constructors
-    BreakoutEncoder(uint8_t address, uint sda, uint scl, uint interrupt = PIN_UNUSED, uint32_t timeout = DEFAULT_TIMEOUT) : BreakoutEncoder(new I2C(sda, scl), address, interrupt, timeout) {};
-
 
     //--------------------------------------------------
     // Methods

--- a/libraries/breakout_mics6814/breakout_mics6814.hpp
+++ b/libraries/breakout_mics6814/breakout_mics6814.hpp
@@ -57,9 +57,6 @@ namespace pimoroni {
     BreakoutMICS6814(I2C *i2c, uint8_t address = DEFAULT_I2C_ADDRESS, uint interrupt = PIN_UNUSED, uint32_t timeout = DEFAULT_TIMEOUT, bool debug = false) :
       ioe(i2c, address, interrupt, timeout, debug) {}
 
-    // TODO remove MicroPython-binding compatibility constructors
-    BreakoutMICS6814(uint8_t address, uint sda, uint scl, uint interrupt = PIN_UNUSED, uint32_t timeout = DEFAULT_TIMEOUT) : BreakoutMICS6814(new I2C(sda, scl), address, interrupt, timeout) {};
-
     //--------------------------------------------------
     // Methods
     //--------------------------------------------------

--- a/libraries/breakout_potentiometer/breakout_potentiometer.hpp
+++ b/libraries/breakout_potentiometer/breakout_potentiometer.hpp
@@ -55,9 +55,6 @@ namespace pimoroni {
     BreakoutPotentiometer(I2C *i2c, uint8_t address = DEFAULT_I2C_ADDRESS, uint interrupt = PIN_UNUSED, uint32_t timeout = DEFAULT_TIMEOUT, bool debug = false) :
       ioe(i2c, address, interrupt, timeout, debug) {}
 
-    // TODO remove MicroPython-binding compatibility constructors
-    BreakoutPotentiometer(uint8_t address, uint sda, uint scl, uint interrupt = PIN_UNUSED, uint32_t timeout = DEFAULT_TIMEOUT) : BreakoutPotentiometer(new I2C(sda, scl), address, interrupt, timeout) {};
-
 
     //--------------------------------------------------
     // Methods


### PR DESCRIPTION
These constructors should never be used. Specifying I2C pins should be done by providing an "I2C" instance.