### PR TITLE
Fetch pimoroni-pico SDK from git repository

### DIFF
--- a/pimoroni_pico_import.cmake
+++ b/pimoroni_pico_import.cmake
@@ -1,8 +1,35 @@
 # This file can be dropped into a project to help locate the Pimoroni Pico libraries
 # It will also set up the required include and module search paths.
 
+if (DEFINED ENV{PIMORONI_PICO_FETCH_FROM_GIT} AND (NOT PIMORONI_PICO_FETCH_FROM_GIT))
+    set(PIMORONI_PICO_FETCH_FROM_GIT $ENV{PIMORONI_PICO_FETCH_FROM_GIT})
+    message("Using PIMORONI_PICO_FETCH_FROM_GIT from environment ('${PIMORONI_PICO_FETCH_FROM_GIT}')")
+endif ()
+
+if (DEFINED ENV{PIMORONI_PICO_FETCH_FROM_GIT_PATH} AND (NOT PIMORONI_PICO_FETCH_FROM_GIT_PATH))
+    set(PIMORONI_PICO_FETCH_FROM_GIT_PATH $ENV{PIMORONI_PICO_FETCH_FROM_GIT_PATH})
+    message("Using PIMORONI_PICO_FETCH_FROM_GIT_PATH from environment ('${PIMORONI_PICO_FETCH_FROM_GIT_PATH}')")
+endif ()
+
 if (NOT PIMORONI_PICO_PATH)
-    if (PICO_SDK_PATH AND EXISTS "${PICO_SDK_PATH}/../pimoroni-pico")
+    if (PIMORONI_PICO_FETCH_FROM_GIT)
+        include(FetchContent)
+        set(FETCHCONTENT_BASE_DIR_SAVE ${FETCHCONTENT_BASE_DIR})
+        if (PIMORONI_PICO_FETCH_FROM_GIT_PATH)
+            get_filename_component(FETCHCONTENT_BASE_DIR "${PIMORONI_PICO_FETCH_FROM_GIT_PATH}" REALPATH BASE_DIR "${CMAKE_SOURCE_DIR}")
+        endif ()
+        FetchContent_Declare(
+                pimoroni_pico
+                GIT_REPOSITORY https://github.com/pimoroni/pimoroni-pico
+                GIT_TAG main
+        )
+        if (NOT pimoroni_pico)
+            message("Downloading PIMORONI_PICO SDK")
+            FetchContent_Populate(pimoroni_pico)
+            set(PIMORONI_PICO_PATH ${pimoroni_pico_SOURCE_DIR})
+        endif ()
+        set(FETCHCONTENT_BASE_DIR ${FETCHCONTENT_BASE_DIR_SAVE})
+    elseif(PICO_SDK_PATH AND EXISTS "${PICO_SDK_PATH}/../pimoroni-pico")
         set(PIMORONI_PICO_PATH ${PICO_SDK_PATH}/../pimoroni-pico)
         message("Defaulting PIMORONI_PICO_PATH as sibling of PICO_SDK_PATH: ${PIMORONI_PICO_PATH}")
     elseif(EXISTS "${CMAKE_CURRENT_BINARY_DIR}/../../pimoroni-pico/")


### PR DESCRIPTION
When `$PIMORONI_PICO_FETCH_FROM_GIT` environment variable is set
cmake script will fetch on the go git repository and use it to
build your project.

User can additionally use `$PIMORONI_PICO_FETCH_FROM_GIT_PATH` to
specify target directory for source code of fetched SDK.

This patch was inspired by [external/pico_sdk_import.cmake](https://github.com/raspberrypi/pico-sdk/blob/master/external/pico_sdk_import.cmake) from
official C/C++ [pico-sdk repository](https://github.com/raspberrypi/pico-sdk).