### PR TITLE
MicroPython: Drop redundant Print. Saves 4K.

### DIFF
--- a/micropython/modules/adcfft/adcfft.c
+++ b/micropython/modules/adcfft/adcfft.c
@@ -16,7 +16,6 @@ STATIC MP_DEFINE_CONST_DICT(adcfft_locals_dict, adcfft_locals_dict_table);
 const mp_obj_type_t adcfft_type = {
     { &mp_type_type },
     .name = MP_QSTR_ADCFFT,
-    .print = adcfft_print,
     .make_new = adcfft_make_new,
     .locals_dict = (mp_obj_dict_t*)&adcfft_locals_dict,
 };

--- a/micropython/modules/adcfft/adcfft.cpp
+++ b/micropython/modules/adcfft/adcfft.cpp
@@ -9,13 +9,6 @@ typedef struct _adcfft_obj_t {
     ADCFFT *adcfft;
 } adcfft_obj_t;
 
-void adcfft_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
-    (void)kind; //Unused input parameter    
-    adcfft_obj_t *self = MP_OBJ_TO_PTR2(self_in, adcfft_obj_t);
-    (void)self;
-    mp_print_str(print, "ADCFFT()");
-}
-
 mp_obj_t adcfft_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     enum { ARG_adc_channel, ARG_adc_gpio, ARG_sample_rate };
     static const mp_arg_t allowed_args[] = {

--- a/micropython/modules/adcfft/adcfft.h
+++ b/micropython/modules/adcfft/adcfft.h
@@ -7,7 +7,6 @@
 extern const mp_obj_type_t adcfft_type;
 
 /***** Extern of Class Methods *****/
-extern void adcfft_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind);
 extern mp_obj_t adcfft_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args);
 extern mp_obj_t adcfft__del__(mp_obj_t self_in);
 

--- a/micropython/modules/badger2040/badger2040.c
+++ b/micropython/modules/badger2040/badger2040.c
@@ -78,7 +78,6 @@ STATIC MP_DEFINE_CONST_DICT(Badger2040_locals_dict, Badger2040_locals_dict_table
 const mp_obj_type_t Badger2040_type = {
     { &mp_type_type },
     .name = MP_QSTR_badger2040,
-    .print = Badger2040_print,
     .make_new = Badger2040_make_new,
     .locals_dict = (mp_obj_dict_t*)&Badger2040_locals_dict,
 };

--- a/micropython/modules/badger2040/badger2040.cpp
+++ b/micropython/modules/badger2040/badger2040.cpp
@@ -60,14 +60,6 @@ typedef struct _Badger2040_obj_t {
 
 _Badger2040_obj_t *badger2040_obj;
 
-/***** Print *****/
-void Badger2040_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
-    (void)kind; // Unused input parameter
-    (void)self_in;
-    //_Badger2040_obj_t *self = MP_OBJ_TO_PTR2(self_in, _Badger2040_obj_t);
-    mp_print_str(print, "Badger2040( ");
-    mp_print_str(print, " )");
-}
 
 /***** Destructor ******/
 mp_obj_t Badger2040___del__(mp_obj_t self_in) {

--- a/micropython/modules/badger2040/badger2040.h
+++ b/micropython/modules/badger2040/badger2040.h
@@ -6,7 +6,6 @@
 extern const mp_obj_type_t Badger2040_type;
 
 /***** Extern of Class Methods *****/
-extern void Badger2040_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind);
 extern mp_obj_t Badger2040___del__(mp_obj_t self_in);
 extern mp_obj_t Badger2040_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args);
 

--- a/micropython/modules/breakout_as7262/breakout_as7262.c
+++ b/micropython/modules/breakout_as7262/breakout_as7262.c
@@ -55,7 +55,6 @@ STATIC MP_DEFINE_CONST_DICT(BreakoutAS7262_locals_dict, BreakoutAS7262_locals_di
 const mp_obj_type_t breakout_as7262_BreakoutAS7262_type = {
     { &mp_type_type },
     .name = MP_QSTR_breakout_as7262,
-    .print = BreakoutAS7262_print,
     .make_new = BreakoutAS7262_make_new,
     .locals_dict = (mp_obj_dict_t*)&BreakoutAS7262_locals_dict,
 };

--- a/micropython/modules/breakout_as7262/breakout_as7262.cpp
+++ b/micropython/modules/breakout_as7262/breakout_as7262.cpp
@@ -17,27 +17,6 @@ typedef struct _breakout_as7262_BreakoutAS7262_obj_t {
 } breakout_as7262_BreakoutAS7262_obj_t;
 
 
-/***** Print *****/
-void BreakoutAS7262_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
-    (void)kind; //Unused input parameter    
-    breakout_as7262_BreakoutAS7262_obj_t *self = MP_OBJ_TO_PTR2(self_in, breakout_as7262_BreakoutAS7262_obj_t);
-    BreakoutAS7262* breakout = self->breakout;
-    mp_print_str(print, "BreakoutAS7262(");
-
-    mp_print_str(print, "i2c = ");
-    mp_obj_print_helper(print, mp_obj_new_int((breakout->get_i2c() == i2c0) ? 0 : 1), PRINT_REPR);
-
-    mp_print_str(print, ", sda = ");
-    mp_obj_print_helper(print, mp_obj_new_int(breakout->get_sda()), PRINT_REPR);
-
-    mp_print_str(print, ", scl = ");
-    mp_obj_print_helper(print, mp_obj_new_int(breakout->get_scl()), PRINT_REPR);
-
-    mp_print_str(print, ", int = ");
-    mp_obj_print_helper(print, mp_obj_new_int(breakout->get_int()), PRINT_REPR);
-
-    mp_print_str(print, ")");
-}
 
 /***** Constructor *****/
 mp_obj_t BreakoutAS7262_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {

--- a/micropython/modules/breakout_as7262/breakout_as7262.h
+++ b/micropython/modules/breakout_as7262/breakout_as7262.h
@@ -34,7 +34,6 @@ enum {
 extern const mp_obj_type_t breakout_as7262_BreakoutAS7262_type;
 
 /***** Extern of Class Methods *****/
-extern void BreakoutAS7262_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind);
 extern mp_obj_t BreakoutAS7262_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args);
 extern mp_obj_t BreakoutAS7262_reset(mp_obj_t self_in);
 extern mp_obj_t BreakoutAS7262_device_type(mp_obj_t self_in);

--- a/micropython/modules/breakout_bh1745/breakout_bh1745.c
+++ b/micropython/modules/breakout_bh1745/breakout_bh1745.c
@@ -31,7 +31,6 @@ STATIC MP_DEFINE_CONST_DICT(BreakoutBH1745_locals_dict, BreakoutBH1745_locals_di
 const mp_obj_type_t breakout_bh1745_BreakoutBH1745_type = {
     { &mp_type_type },
     .name = MP_QSTR_breakout_bh1745,
-    .print = BreakoutBH1745_print,
     .make_new = BreakoutBH1745_make_new,
     .locals_dict = (mp_obj_dict_t*)&BreakoutBH1745_locals_dict,
 };

--- a/micropython/modules/breakout_bh1745/breakout_bh1745.cpp
+++ b/micropython/modules/breakout_bh1745/breakout_bh1745.cpp
@@ -15,29 +15,6 @@ typedef struct _breakout_bh1745_BreakoutBH1745_obj_t {
     _PimoroniI2C_obj_t *i2c;
 } breakout_bh1745_BreakoutBH1745_obj_t;
 
-/***** Print *****/
-void BreakoutBH1745_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
-    (void)kind; //Unused input parameter
-    breakout_bh1745_BreakoutBH1745_obj_t *self = MP_OBJ_TO_PTR2(self_in, breakout_bh1745_BreakoutBH1745_obj_t);
-    BreakoutBH1745* breakout = self->breakout;
-    mp_print_str(print, "BreakoutBH1745(");
-
-    mp_print_str(print, "i2c = ");
-    mp_obj_print_helper(print, mp_obj_new_int((breakout->get_i2c()->get_i2c() == i2c0) ? 0 : 1), PRINT_REPR);
-
-    mp_print_str(print, ", address = 0x");
-    char buf[3];
-    sprintf(buf, "%02X", breakout->get_address());
-    mp_print_str(print, buf);
-
-    mp_print_str(print, ", sda = ");
-    mp_obj_print_helper(print, mp_obj_new_int(breakout->get_i2c()->get_sda()), PRINT_REPR);
-
-    mp_print_str(print, ", scl = ");
-    mp_obj_print_helper(print, mp_obj_new_int(breakout->get_i2c()->get_scl()), PRINT_REPR);
-
-    mp_print_str(print, ")");
-}
 
 /***** Constructor *****/
 mp_obj_t BreakoutBH1745_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {

--- a/micropython/modules/breakout_bh1745/breakout_bh1745.h
+++ b/micropython/modules/breakout_bh1745/breakout_bh1745.h
@@ -17,7 +17,6 @@ static const uint8_t BH1745_I2C_ADDRESS_ALTERNATE = 0x39;
 extern const mp_obj_type_t breakout_bh1745_BreakoutBH1745_type;
 
 /***** Extern of Class Methods *****/
-extern void BreakoutBH1745_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind);
 extern mp_obj_t BreakoutBH1745_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args);
 extern mp_obj_t BreakoutBH1745_chip_id(mp_obj_t self_in);
 extern mp_obj_t BreakoutBH1745_manufacturer_id(mp_obj_t self_in);

--- a/micropython/modules/breakout_bme280/breakout_bme280.c
+++ b/micropython/modules/breakout_bme280/breakout_bme280.c
@@ -19,7 +19,6 @@ STATIC MP_DEFINE_CONST_DICT(BreakoutBME280_locals_dict, BreakoutBME280_locals_di
 const mp_obj_type_t breakout_bme280_BreakoutBME280_type = {
     { &mp_type_type },
     .name = MP_QSTR_breakout_bme280,
-    .print = BreakoutBME280_print,
     .make_new = BreakoutBME280_make_new,
     .locals_dict = (mp_obj_dict_t*)&BreakoutBME280_locals_dict,
 };

--- a/micropython/modules/breakout_bme280/breakout_bme280.cpp
+++ b/micropython/modules/breakout_bme280/breakout_bme280.cpp
@@ -14,27 +14,6 @@ typedef struct _breakout_bme280_BreakoutBME280_obj_t {
     _PimoroniI2C_obj_t *i2c;
 } breakout_bme280_BreakoutBME280_obj_t;
 
-/***** Print *****/
-void BreakoutBME280_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
-    (void)kind; //Unused input parameter    
-    breakout_bme280_BreakoutBME280_obj_t *self = MP_OBJ_TO_PTR2(self_in, breakout_bme280_BreakoutBME280_obj_t);
-    BME280* breakout = self->breakout;
-    mp_print_str(print, "BreakoutBME280(");
-
-    mp_print_str(print, "i2c = ");
-    mp_obj_print_helper(print, mp_obj_new_int((breakout->get_i2c()->get_i2c() == i2c0) ? 0 : 1), PRINT_REPR);
-
-    mp_print_str(print, ", sda = ");
-    mp_obj_print_helper(print, mp_obj_new_int(breakout->get_i2c()->get_sda()), PRINT_REPR);
-
-    mp_print_str(print, ", scl = ");
-    mp_obj_print_helper(print, mp_obj_new_int(breakout->get_i2c()->get_scl()), PRINT_REPR);
-
-    mp_print_str(print, ", int = ");
-    mp_obj_print_helper(print, mp_obj_new_int(breakout->get_int()), PRINT_REPR);
-
-    mp_print_str(print, ")");
-}
 
 /***** Constructor *****/
 mp_obj_t BreakoutBME280_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {

--- a/micropython/modules/breakout_bme280/breakout_bme280.h
+++ b/micropython/modules/breakout_bme280/breakout_bme280.h
@@ -8,7 +8,6 @@
 extern const mp_obj_type_t breakout_bme280_BreakoutBME280_type;
 
 /***** Extern of Class Methods *****/
-extern void BreakoutBME280_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind);
 extern mp_obj_t BreakoutBME280_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args);
 extern mp_obj_t BreakoutBME280_read(mp_obj_t self_in);
 extern mp_obj_t BreakoutBME280_configure(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args);

--- a/micropython/modules/breakout_bme68x/breakout_bme68x.c
+++ b/micropython/modules/breakout_bme68x/breakout_bme68x.c
@@ -18,7 +18,6 @@ STATIC MP_DEFINE_CONST_DICT(BreakoutBME68X_locals_dict, BreakoutBME68X_locals_di
 const mp_obj_type_t breakout_bme68x_BreakoutBME68X_type = {
     { &mp_type_type },
     .name = MP_QSTR_breakout_bme68x,
-    .print = BreakoutBME68X_print,
     .make_new = BreakoutBME68X_make_new,
     .locals_dict = (mp_obj_dict_t*)&BreakoutBME68X_locals_dict,
 };

--- a/micropython/modules/breakout_bme68x/breakout_bme68x.cpp
+++ b/micropython/modules/breakout_bme68x/breakout_bme68x.cpp
@@ -16,28 +16,6 @@ typedef struct _breakout_bme68x_BreakoutBME68X_obj_t {
     _PimoroniI2C_obj_t *i2c;
 } breakout_bme68x_BreakoutBME68X_obj_t;
 
-/***** Print *****/
-void BreakoutBME68X_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
-    (void)kind; //Unused input parameter    
-    breakout_bme68x_BreakoutBME68X_obj_t *self = MP_OBJ_TO_PTR2(self_in, breakout_bme68x_BreakoutBME68X_obj_t);
-    BME68X* breakout = self->breakout;
-    mp_print_str(print, "BreakoutBME68X(");
-
-    mp_print_str(print, "i2c = ");
-    mp_obj_print_helper(print, mp_obj_new_int((breakout->get_i2c()->get_i2c() == i2c0) ? 0 : 1), PRINT_REPR);
-
-    mp_print_str(print, ", sda = ");
-    mp_obj_print_helper(print, mp_obj_new_int(breakout->get_i2c()->get_sda()), PRINT_REPR);
-
-    mp_print_str(print, ", scl = ");
-    mp_obj_print_helper(print, mp_obj_new_int(breakout->get_i2c()->get_scl()), PRINT_REPR);
-
-    mp_print_str(print, ", int = ");
-    mp_obj_print_helper(print, mp_obj_new_int(breakout->get_int()), PRINT_REPR);
-
-    mp_print_str(print, ")");
-}
-
 /***** Constructor *****/
 mp_obj_t BreakoutBME68X_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     breakout_bme68x_BreakoutBME68X_obj_t *self = nullptr;

--- a/micropython/modules/breakout_bme68x/breakout_bme68x.h
+++ b/micropython/modules/breakout_bme68x/breakout_bme68x.h
@@ -8,7 +8,6 @@
 extern const mp_obj_type_t breakout_bme68x_BreakoutBME68X_type;
 
 /***** Extern of Class Methods *****/
-extern void BreakoutBME68X_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind);
 extern mp_obj_t BreakoutBME68X_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args);
 extern mp_obj_t BreakoutBME68X_read(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args);
 extern mp_obj_t BreakoutBME68X_configure(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args);

--- a/micropython/modules/breakout_bmp280/breakout_bmp280.c
+++ b/micropython/modules/breakout_bmp280/breakout_bmp280.c
@@ -19,7 +19,6 @@ STATIC MP_DEFINE_CONST_DICT(BreakoutBMP280_locals_dict, BreakoutBMP280_locals_di
 const mp_obj_type_t breakout_bmp280_BreakoutBMP280_type = {
     { &mp_type_type },
     .name = MP_QSTR_breakout_bmp280,
-    .print = BreakoutBMP280_print,
     .make_new = BreakoutBMP280_make_new,
     .locals_dict = (mp_obj_dict_t*)&BreakoutBMP280_locals_dict,
 };

--- a/micropython/modules/breakout_bmp280/breakout_bmp280.cpp
+++ b/micropython/modules/breakout_bmp280/breakout_bmp280.cpp
@@ -15,27 +15,6 @@ typedef struct _breakout_bmp280_BreakoutBMP280_obj_t {
     _PimoroniI2C_obj_t *i2c;
 } breakout_bmp280_BreakoutBMP280_obj_t;
 
-/***** Print *****/
-void BreakoutBMP280_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
-    (void)kind; //Unused input parameter    
-    breakout_bmp280_BreakoutBMP280_obj_t *self = MP_OBJ_TO_PTR2(self_in, breakout_bmp280_BreakoutBMP280_obj_t);
-    BMP280* breakout = self->breakout;
-    mp_print_str(print, "BreakoutBMP280(");
-
-    mp_print_str(print, "i2c = ");
-    mp_obj_print_helper(print, mp_obj_new_int((breakout->get_i2c()->get_i2c() == i2c0) ? 0 : 1), PRINT_REPR);
-
-    mp_print_str(print, ", sda = ");
-    mp_obj_print_helper(print, mp_obj_new_int(breakout->get_i2c()->get_sda()), PRINT_REPR);
-
-    mp_print_str(print, ", scl = ");
-    mp_obj_print_helper(print, mp_obj_new_int(breakout->get_i2c()->get_scl()), PRINT_REPR);
-
-    mp_print_str(print, ", int = ");
-    mp_obj_print_helper(print, mp_obj_new_int(breakout->get_int()), PRINT_REPR);
-
-    mp_print_str(print, ")");
-}
 
 /***** Constructor *****/
 mp_obj_t BreakoutBMP280_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {

--- a/micropython/modules/breakout_bmp280/breakout_bmp280.h
+++ b/micropython/modules/breakout_bmp280/breakout_bmp280.h
@@ -8,7 +8,6 @@
 extern const mp_obj_type_t breakout_bmp280_BreakoutBMP280_type;
 
 /***** Extern of Class Methods *****/
-extern void BreakoutBMP280_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind);
 extern mp_obj_t BreakoutBMP280_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args);
 extern mp_obj_t BreakoutBMP280_read(mp_obj_t self_in);
 extern mp_obj_t BreakoutBMP280_configure(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args);

--- a/micropython/modules/breakout_dotmatrix/breakout_dotmatrix.c
+++ b/micropython/modules/breakout_dotmatrix/breakout_dotmatrix.c
@@ -31,7 +31,6 @@ STATIC MP_DEFINE_CONST_DICT(BreakoutDotMatrix_locals_dict, BreakoutDotMatrix_loc
 const mp_obj_type_t breakout_dotmatrix_BreakoutDotMatrix_type = {
     { &mp_type_type },
     .name = MP_QSTR_breakout_dotmatrix,
-    .print = BreakoutDotMatrix_print,
     .make_new = BreakoutDotMatrix_make_new,
     .locals_dict = (mp_obj_dict_t*)&BreakoutDotMatrix_locals_dict,
 };

--- a/micropython/modules/breakout_dotmatrix/breakout_dotmatrix.cpp
+++ b/micropython/modules/breakout_dotmatrix/breakout_dotmatrix.cpp
@@ -17,29 +17,6 @@ typedef struct _breakout_dotmatrix_BreakoutDotMatrix_obj_t {
     _PimoroniI2C_obj_t *i2c;
 } breakout_dotmatrix_BreakoutDotMatrix_obj_t;
 
-/***** Print *****/
-void BreakoutDotMatrix_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
-    (void)kind; //Unused input parameter
-    breakout_dotmatrix_BreakoutDotMatrix_obj_t *self = MP_OBJ_TO_PTR2(self_in, breakout_dotmatrix_BreakoutDotMatrix_obj_t);
-    BreakoutDotMatrix* breakout = self->breakout;
-    mp_print_str(print, "BreakoutDotMatrix(");
-
-    mp_print_str(print, "i2c = ");
-    mp_obj_print_helper(print, mp_obj_new_int((breakout->get_i2c() == i2c0) ? 0 : 1), PRINT_REPR);
-
-    mp_print_str(print, ", address = 0x");
-    char buf[3];
-    sprintf(buf, "%02X", breakout->get_address());
-    mp_print_str(print, buf);
-
-    mp_print_str(print, ", sda = ");
-    mp_obj_print_helper(print, mp_obj_new_int(breakout->get_sda()), PRINT_REPR);
-
-    mp_print_str(print, ", scl = ");
-    mp_obj_print_helper(print, mp_obj_new_int(breakout->get_scl()), PRINT_REPR);
-
-    mp_print_str(print, ")");
-}
 
 /***** Constructor *****/
 mp_obj_t BreakoutDotMatrix_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {

--- a/micropython/modules/breakout_dotmatrix/breakout_dotmatrix.h
+++ b/micropython/modules/breakout_dotmatrix/breakout_dotmatrix.h
@@ -10,7 +10,6 @@ static const int HEIGHT     = 7;
 extern const mp_obj_type_t breakout_dotmatrix_BreakoutDotMatrix_type;
 
 /***** Extern of Class Methods *****/
-extern void BreakoutDotMatrix_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind);
 extern mp_obj_t BreakoutDotMatrix_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args);
 extern mp_obj_t BreakoutDotMatrix_set_brightness(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args);
 extern mp_obj_t BreakoutDotMatrix_set_decimal(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args);

--- a/micropython/modules/breakout_encoder/breakout_encoder.c
+++ b/micropython/modules/breakout_encoder/breakout_encoder.c
@@ -37,7 +37,6 @@ STATIC MP_DEFINE_CONST_DICT(BreakoutEncoder_locals_dict, BreakoutEncoder_locals_
 const mp_obj_type_t breakout_encoder_BreakoutEncoder_type = {
     { &mp_type_type },
     .name = MP_QSTR_breakout_encoder,
-    .print = BreakoutEncoder_print,
     .make_new = BreakoutEncoder_make_new,
     .locals_dict = (mp_obj_dict_t*)&BreakoutEncoder_locals_dict,
 };

--- a/micropython/modules/breakout_encoder/breakout_encoder.cpp
+++ b/micropython/modules/breakout_encoder/breakout_encoder.cpp
@@ -16,32 +16,6 @@ typedef struct _breakout_encoder_BreakoutEncoder_obj_t {
     _PimoroniI2C_obj_t *i2c;
 } breakout_encoder_BreakoutEncoder_obj_t;
 
-/***** Print *****/
-void BreakoutEncoder_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
-    (void)kind; //Unused input parameter
-    breakout_encoder_BreakoutEncoder_obj_t *self = MP_OBJ_TO_PTR2(self_in, breakout_encoder_BreakoutEncoder_obj_t);
-    BreakoutEncoder* breakout = self->breakout;
-    mp_print_str(print, "BreakoutEncoder(");
-
-    mp_print_str(print, "i2c = ");
-    mp_obj_print_helper(print, mp_obj_new_int((breakout->get_i2c() == i2c0) ? 0 : 1), PRINT_REPR);
-
-    mp_print_str(print, ", address = 0x");
-    char buf[3];
-    sprintf(buf, "%02X", breakout->get_address());
-    mp_print_str(print, buf);
-
-    mp_print_str(print, ", sda = ");
-    mp_obj_print_helper(print, mp_obj_new_int(breakout->get_sda()), PRINT_REPR);
-
-    mp_print_str(print, ", scl = ");
-    mp_obj_print_helper(print, mp_obj_new_int(breakout->get_scl()), PRINT_REPR);
-
-    mp_print_str(print, ", int = ");
-    mp_obj_print_helper(print, mp_obj_new_int(breakout->get_int()), PRINT_REPR);
-
-    mp_print_str(print, ")");
-}
 
 /***** Constructor *****/
 mp_obj_t BreakoutEncoder_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {

--- a/micropython/modules/breakout_encoder/breakout_encoder.h
+++ b/micropython/modules/breakout_encoder/breakout_encoder.h
@@ -5,7 +5,6 @@
 extern const mp_obj_type_t breakout_encoder_BreakoutEncoder_type;
 
 /***** Extern of Class Methods *****/
-extern void BreakoutEncoder_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind);
 extern mp_obj_t BreakoutEncoder_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args);
 extern mp_obj_t BreakoutEncoder_set_address(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args);
 extern mp_obj_t BreakoutEncoder_get_interrupt_flag(mp_obj_t self_in);

--- a/micropython/modules/breakout_icp10125/breakout_icp10125.c
+++ b/micropython/modules/breakout_icp10125/breakout_icp10125.c
@@ -25,7 +25,6 @@ STATIC MP_DEFINE_CONST_DICT(BreakoutICP10125_locals_dict, BreakoutICP10125_local
 const mp_obj_type_t breakout_icp10125_BreakoutICP10125_type = {
     { &mp_type_type },
     .name = MP_QSTR_breakout_matrix11x7,
-    .print = BreakoutICP10125_print,
     .make_new = BreakoutICP10125_make_new,
     .locals_dict = (mp_obj_dict_t*)&BreakoutICP10125_locals_dict,
 };

--- a/micropython/modules/breakout_icp10125/breakout_icp10125.cpp
+++ b/micropython/modules/breakout_icp10125/breakout_icp10125.cpp
@@ -15,15 +15,6 @@ typedef struct _breakout_icp10125_BreakoutICP10125_obj_t {
     _PimoroniI2C_obj_t *i2c;
 } breakout_icp10125_BreakoutICP10125_obj_t;
 
-/***** Print *****/
-void BreakoutICP10125_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
-    (void)kind; //Unused input parameter
-    (void)self_in;
-    // breakout_icp10125_BreakoutICP10125_obj_t *self = MP_OBJ_TO_PTR2(self_in, breakout_icp10125_BreakoutICP10125_obj_t);
-    // ICP10125* breakout = self->breakout;
-    // TODO put something useful here? There's no point printing I2C info since that's handled by the I2C object now
-    mp_print_str(print, "BreakoutICP10125()");
-}
 
 /***** Constructor *****/
 mp_obj_t BreakoutICP10125_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {

--- a/micropython/modules/breakout_icp10125/breakout_icp10125.h
+++ b/micropython/modules/breakout_icp10125/breakout_icp10125.h
@@ -17,7 +17,6 @@ enum reading_status {
 };
 
 /***** Extern of Class Methods *****/
-extern void BreakoutICP10125_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind);
 extern mp_obj_t BreakoutICP10125_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args);
 extern mp_obj_t BreakoutICP10125_soft_reset(mp_obj_t self_in);
 extern mp_obj_t BreakoutICP10125_measure(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args);

--- a/micropython/modules/breakout_ioexpander/breakout_ioexpander.c
+++ b/micropython/modules/breakout_ioexpander/breakout_ioexpander.c
@@ -66,7 +66,6 @@ STATIC MP_DEFINE_CONST_DICT(BreakoutIOExpander_locals_dict, BreakoutIOExpander_l
 const mp_obj_type_t breakout_ioexpander_BreakoutIOExpander_type = {
     { &mp_type_type },
     .name = MP_QSTR_breakout_ioexpander,
-    .print = BreakoutIOExpander_print,
     .make_new = BreakoutIOExpander_make_new,
     .locals_dict = (mp_obj_dict_t*)&BreakoutIOExpander_locals_dict,
 };

--- a/micropython/modules/breakout_ioexpander/breakout_ioexpander.cpp
+++ b/micropython/modules/breakout_ioexpander/breakout_ioexpander.cpp
@@ -16,32 +16,6 @@ typedef struct _breakout_ioexpander_BreakoutIOExpander_obj_t {
     _PimoroniI2C_obj_t *i2c;
 } breakout_ioexpander_BreakoutIOExpander_obj_t;
 
-/***** Print *****/
-void BreakoutIOExpander_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
-    (void)kind; //Unused input parameter
-    breakout_ioexpander_BreakoutIOExpander_obj_t *self = MP_OBJ_TO_PTR2(self_in, breakout_ioexpander_BreakoutIOExpander_obj_t);
-    BreakoutIOExpander* breakout = self->breakout;
-    mp_print_str(print, "BreakoutIOExpander(");
-
-    mp_print_str(print, "i2c = ");
-    mp_obj_print_helper(print, mp_obj_new_int((breakout->get_i2c() == i2c0) ? 0 : 1), PRINT_REPR);
-
-    mp_print_str(print, ", address = 0x");
-    char buf[3];
-    sprintf(buf, "%02X", breakout->get_address());
-    mp_print_str(print, buf);
-
-    mp_print_str(print, ", sda = ");
-    mp_obj_print_helper(print, mp_obj_new_int(breakout->get_sda()), PRINT_REPR);
-
-    mp_print_str(print, ", scl = ");
-    mp_obj_print_helper(print, mp_obj_new_int(breakout->get_scl()), PRINT_REPR);
-
-    mp_print_str(print, ", int = ");
-    mp_obj_print_helper(print, mp_obj_new_int(breakout->get_int()), PRINT_REPR);
-
-    mp_print_str(print, ")");
-}
 
 /***** Constructor *****/
 mp_obj_t BreakoutIOExpander_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {

--- a/micropython/modules/breakout_ioexpander/breakout_ioexpander.h
+++ b/micropython/modules/breakout_ioexpander/breakout_ioexpander.h
@@ -19,7 +19,6 @@ enum {
 extern const mp_obj_type_t breakout_ioexpander_BreakoutIOExpander_type;
 
 /***** Extern of Class Methods *****/
-extern void BreakoutIOExpander_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind);
 extern mp_obj_t BreakoutIOExpander_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args);
 extern mp_obj_t BreakoutIOExpander_get_chip_id(mp_obj_t self_in);
 extern mp_obj_t BreakoutIOExpander_set_address(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args);

--- a/micropython/modules/breakout_ltr559/breakout_ltr559.c
+++ b/micropython/modules/breakout_ltr559/breakout_ltr559.c
@@ -48,7 +48,6 @@ STATIC MP_DEFINE_CONST_DICT(BreakoutLTR559_locals_dict, BreakoutLTR559_locals_di
 const mp_obj_type_t breakout_ltr559_BreakoutLTR559_type = {
     { &mp_type_type },
     .name = MP_QSTR_breakout_ltr559,
-    .print = BreakoutLTR559_print,
     .make_new = BreakoutLTR559_make_new,
     .locals_dict = (mp_obj_dict_t*)&BreakoutLTR559_locals_dict,
 };

--- a/micropython/modules/breakout_ltr559/breakout_ltr559.cpp
+++ b/micropython/modules/breakout_ltr559/breakout_ltr559.cpp
@@ -16,32 +16,6 @@ typedef struct _breakout_ltr559_BreakoutLTR559_obj_t {
     _PimoroniI2C_obj_t *i2c;
 } breakout_ltr559_BreakoutLTR559_obj_t;
 
-/***** Print *****/
-void BreakoutLTR559_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
-    (void)kind; //Unused input parameter
-    breakout_ltr559_BreakoutLTR559_obj_t *self = MP_OBJ_TO_PTR2(self_in, breakout_ltr559_BreakoutLTR559_obj_t);
-    BreakoutLTR559* breakout = self->breakout;
-    mp_print_str(print, "BreakoutLTR559(");
-
-    mp_print_str(print, "i2c = ");
-    mp_obj_print_helper(print, mp_obj_new_int((breakout->get_i2c() == i2c0) ? 0 : 1), PRINT_REPR);
-
-    mp_print_str(print, ", address = 0x");
-    char buf[3];
-    sprintf(buf, "%02X", breakout->get_address());
-    mp_print_str(print, buf);
-
-    mp_print_str(print, ", sda = ");
-    mp_obj_print_helper(print, mp_obj_new_int(breakout->get_sda()), PRINT_REPR);
-
-    mp_print_str(print, ", scl = ");
-    mp_obj_print_helper(print, mp_obj_new_int(breakout->get_scl()), PRINT_REPR);
-
-    mp_print_str(print, ", int = ");
-    mp_obj_print_helper(print, mp_obj_new_int(breakout->get_int()), PRINT_REPR);
-
-    mp_print_str(print, ")");
-}
 
 /***** Constructor *****/
 mp_obj_t BreakoutLTR559_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {

--- a/micropython/modules/breakout_ltr559/breakout_ltr559.h
+++ b/micropython/modules/breakout_ltr559/breakout_ltr559.h
@@ -17,7 +17,6 @@ enum {
 extern const mp_obj_type_t breakout_ltr559_BreakoutLTR559_type;
 
 /***** Extern of Class Methods *****/
-extern void BreakoutLTR559_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind);
 extern mp_obj_t BreakoutLTR559_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args);
 extern mp_obj_t BreakoutLTR559_part_id(mp_obj_t self_in);
 extern mp_obj_t BreakoutLTR559_revision_id(mp_obj_t self_in);

--- a/micropython/modules/breakout_matrix11x7/breakout_matrix11x7.c
+++ b/micropython/modules/breakout_matrix11x7/breakout_matrix11x7.c
@@ -23,7 +23,6 @@ STATIC MP_DEFINE_CONST_DICT(BreakoutMatrix11x7_locals_dict, BreakoutMatrix11x7_l
 const mp_obj_type_t breakout_matrix11x7_BreakoutMatrix11x7_type = {
     { &mp_type_type },
     .name = MP_QSTR_breakout_matrix11x7,
-    .print = BreakoutMatrix11x7_print,
     .make_new = BreakoutMatrix11x7_make_new,
     .locals_dict = (mp_obj_dict_t*)&BreakoutMatrix11x7_locals_dict,
 };

--- a/micropython/modules/breakout_matrix11x7/breakout_matrix11x7.cpp
+++ b/micropython/modules/breakout_matrix11x7/breakout_matrix11x7.cpp
@@ -16,30 +16,6 @@ typedef struct _breakout_matrix11x7_BreakoutMatrix11x7_obj_t {
     _PimoroniI2C_obj_t *i2c;
 } breakout_matrix11x7_BreakoutMatrix11x7_obj_t;
 
-/***** Print *****/
-void BreakoutMatrix11x7_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
-    (void)kind; //Unused input parameter    
-    breakout_matrix11x7_BreakoutMatrix11x7_obj_t *self = MP_OBJ_TO_PTR2(self_in, breakout_matrix11x7_BreakoutMatrix11x7_obj_t);
-    BreakoutMatrix11x7* breakout = self->breakout;
-    mp_print_str(print, "BreakoutMatrix11x7(");
-
-    mp_print_str(print, "i2c = ");
-    mp_obj_print_helper(print, mp_obj_new_int((breakout->get_i2c() == i2c0) ? 0 : 1), PRINT_REPR);
-
-    mp_print_str(print, ", address = 0x");
-    char buf[3];
-    sprintf(buf, "%02X", breakout->get_address());
-    mp_print_str(print, buf);
-
-    mp_print_str(print, ", sda = ");
-    mp_obj_print_helper(print, mp_obj_new_int(breakout->get_sda()), PRINT_REPR);
-
-    mp_print_str(print, ", scl = ");
-    mp_obj_print_helper(print, mp_obj_new_int(breakout->get_scl()), PRINT_REPR);
-
-    mp_print_str(print, ")");
-}
-
 /***** Constructor *****/
 mp_obj_t BreakoutMatrix11x7_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     breakout_matrix11x7_BreakoutMatrix11x7_obj_t *self = nullptr;

--- a/micropython/modules/breakout_matrix11x7/breakout_matrix11x7.h
+++ b/micropython/modules/breakout_matrix11x7/breakout_matrix11x7.h
@@ -9,7 +9,6 @@ static const int HEIGHT     = 7;
 extern const mp_obj_type_t breakout_matrix11x7_BreakoutMatrix11x7_type;
 
 /***** Extern of Class Methods *****/
-extern void BreakoutMatrix11x7_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind);
 extern mp_obj_t BreakoutMatrix11x7_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args);
 extern mp_obj_t BreakoutMatrix11x7_set_pixel(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args);
 extern mp_obj_t BreakoutMatrix11x7_update(mp_obj_t self_in);

--- a/micropython/modules/breakout_mics6814/breakout_mics6814.c
+++ b/micropython/modules/breakout_mics6814/breakout_mics6814.c
@@ -51,7 +51,6 @@ STATIC MP_DEFINE_CONST_DICT(BreakoutMICS6814_locals_dict, BreakoutMICS6814_local
 const mp_obj_type_t breakout_mics6814_BreakoutMICS6814_type = {
     { &mp_type_type },
     .name = MP_QSTR_breakout_mics6814,
-    .print = BreakoutMICS6814_print,
     .make_new = BreakoutMICS6814_make_new,
     .locals_dict = (mp_obj_dict_t*)&BreakoutMICS6814_locals_dict,
 };

--- a/micropython/modules/breakout_mics6814/breakout_mics6814.cpp
+++ b/micropython/modules/breakout_mics6814/breakout_mics6814.cpp
@@ -16,32 +16,6 @@ typedef struct _breakout_mics6814_BreakoutMICS6814_obj_t {
     _PimoroniI2C_obj_t *i2c;
 } breakout_mics6814_BreakoutMICS6814_obj_t;
 
-/***** Print *****/
-void BreakoutMICS6814_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
-    (void)kind; //Unused input parameter
-    breakout_mics6814_BreakoutMICS6814_obj_t *self = MP_OBJ_TO_PTR2(self_in, breakout_mics6814_BreakoutMICS6814_obj_t);
-    BreakoutMICS6814* breakout = self->breakout;
-    mp_print_str(print, "BreakoutMICS6814(");
-
-    mp_print_str(print, "i2c = ");
-    mp_obj_print_helper(print, mp_obj_new_int((breakout->get_i2c() == i2c0) ? 0 : 1), PRINT_REPR);
-
-    mp_print_str(print, ", address = 0x");
-    char buf[3];
-    sprintf(buf, "%02X", breakout->get_address());
-    mp_print_str(print, buf);
-
-    mp_print_str(print, ", sda = ");
-    mp_obj_print_helper(print, mp_obj_new_int(breakout->get_sda()), PRINT_REPR);
-
-    mp_print_str(print, ", scl = ");
-    mp_obj_print_helper(print, mp_obj_new_int(breakout->get_scl()), PRINT_REPR);
-
-    mp_print_str(print, ", int = ");
-    mp_obj_print_helper(print, mp_obj_new_int(breakout->get_int()), PRINT_REPR);
-
-    mp_print_str(print, ")");
-}
 
 /***** Constructor *****/
 mp_obj_t BreakoutMICS6814_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {

--- a/micropython/modules/breakout_mics6814/breakout_mics6814.h
+++ b/micropython/modules/breakout_mics6814/breakout_mics6814.h
@@ -12,7 +12,6 @@ enum {
 extern const mp_obj_type_t breakout_mics6814_BreakoutMICS6814_type;
 
 /***** Extern of Class Methods *****/
-extern void BreakoutMICS6814_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind);
 extern mp_obj_t BreakoutMICS6814_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args);
 extern mp_obj_t BreakoutMICS6814_set_address(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args);
 extern mp_obj_t BreakoutMICS6814_get_adc_vref(mp_obj_t self_in);

--- a/micropython/modules/breakout_msa301/breakout_msa301.c
+++ b/micropython/modules/breakout_msa301/breakout_msa301.c
@@ -84,7 +84,6 @@ STATIC MP_DEFINE_CONST_DICT(BreakoutMSA301_locals_dict, BreakoutMSA301_locals_di
 const mp_obj_type_t breakout_msa301_BreakoutMSA301_type = {
     { &mp_type_type },
     .name = MP_QSTR_breakout_msa301,
-    .print = BreakoutMSA301_print,
     .make_new = BreakoutMSA301_make_new,
     .locals_dict = (mp_obj_dict_t*)&BreakoutMSA301_locals_dict,
 };

--- a/micropython/modules/breakout_msa301/breakout_msa301.cpp
+++ b/micropython/modules/breakout_msa301/breakout_msa301.cpp
@@ -15,28 +15,6 @@ typedef struct _breakout_msa301_BreakoutMSA301_obj_t {
     _PimoroniI2C_obj_t *i2c;
 } breakout_msa301_BreakoutMSA301_obj_t;
 
-/***** Print *****/
-void BreakoutMSA301_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
-    (void)kind; //Unused input parameter
-    breakout_msa301_BreakoutMSA301_obj_t *self = MP_OBJ_TO_PTR2(self_in, breakout_msa301_BreakoutMSA301_obj_t);
-    BreakoutMSA301* breakout = self->breakout;
-    mp_print_str(print, "BreakoutMSA301(");
-
-    mp_print_str(print, "i2c = ");
-    mp_obj_print_helper(print, mp_obj_new_int((breakout->get_i2c() == i2c0) ? 0 : 1), PRINT_REPR);
-
-    mp_print_str(print, ", sda = ");
-    mp_obj_print_helper(print, mp_obj_new_int(breakout->get_sda()), PRINT_REPR);
-
-    mp_print_str(print, ", scl = ");
-    mp_obj_print_helper(print, mp_obj_new_int(breakout->get_scl()), PRINT_REPR);
-
-    mp_print_str(print, ", int = ");
-    mp_obj_print_helper(print, mp_obj_new_int(breakout->get_int()), PRINT_REPR);
-
-    mp_print_str(print, ")");
-}
-
 /***** Constructor *****/
 mp_obj_t BreakoutMSA301_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     breakout_msa301_BreakoutMSA301_obj_t *self = nullptr;

--- a/micropython/modules/breakout_msa301/breakout_msa301.h
+++ b/micropython/modules/breakout_msa301/breakout_msa301.h
@@ -77,7 +77,6 @@ enum {
 extern const mp_obj_type_t breakout_msa301_BreakoutMSA301_type;
 
 /***** Extern of Class Methods *****/
-extern void BreakoutMSA301_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind);
 extern mp_obj_t BreakoutMSA301_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args);
 extern mp_obj_t BreakoutMSA301_part_id(mp_obj_t self_in);
 extern mp_obj_t BreakoutMSA301_get_axis(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args);

--- a/micropython/modules/breakout_potentiometer/breakout_potentiometer.c
+++ b/micropython/modules/breakout_potentiometer/breakout_potentiometer.c
@@ -35,7 +35,6 @@ STATIC MP_DEFINE_CONST_DICT(BreakoutPotentiometer_locals_dict, BreakoutPotentiom
 const mp_obj_type_t breakout_potentiometer_BreakoutPotentiometer_type = {
     { &mp_type_type },
     .name = MP_QSTR_breakout_potentiometer,
-    .print = BreakoutPotentiometer_print,
     .make_new = BreakoutPotentiometer_make_new,
     .locals_dict = (mp_obj_dict_t*)&BreakoutPotentiometer_locals_dict,
 };

--- a/micropython/modules/breakout_potentiometer/breakout_potentiometer.cpp
+++ b/micropython/modules/breakout_potentiometer/breakout_potentiometer.cpp
@@ -16,32 +16,6 @@ typedef struct _breakout_potentiometer_BreakoutPotentiometer_obj_t {
     _PimoroniI2C_obj_t *i2c;
 } breakout_potentiometer_BreakoutPotentiometer_obj_t;
 
-/***** Print *****/
-void BreakoutPotentiometer_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
-    (void)kind; //Unused input parameter
-    breakout_potentiometer_BreakoutPotentiometer_obj_t *self = MP_OBJ_TO_PTR2(self_in, breakout_potentiometer_BreakoutPotentiometer_obj_t);
-    BreakoutPotentiometer* breakout = self->breakout;
-    mp_print_str(print, "BreakoutPotentiometer(");
-
-    mp_print_str(print, "i2c = ");
-    mp_obj_print_helper(print, mp_obj_new_int((breakout->get_i2c() == i2c0) ? 0 : 1), PRINT_REPR);
-
-    mp_print_str(print, ", address = 0x");
-    char buf[3];
-    sprintf(buf, "%02X", breakout->get_address());
-    mp_print_str(print, buf);
-
-    mp_print_str(print, ", sda = ");
-    mp_obj_print_helper(print, mp_obj_new_int(breakout->get_sda()), PRINT_REPR);
-
-    mp_print_str(print, ", scl = ");
-    mp_obj_print_helper(print, mp_obj_new_int(breakout->get_scl()), PRINT_REPR);
-
-    mp_print_str(print, ", int = ");
-    mp_obj_print_helper(print, mp_obj_new_int(breakout->get_int()), PRINT_REPR);
-
-    mp_print_str(print, ")");
-}
 
 /***** Constructor *****/
 mp_obj_t BreakoutPotentiometer_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {

--- a/micropython/modules/breakout_potentiometer/breakout_potentiometer.h
+++ b/micropython/modules/breakout_potentiometer/breakout_potentiometer.h
@@ -5,7 +5,6 @@
 extern const mp_obj_type_t breakout_potentiometer_BreakoutPotentiometer_type;
 
 /***** Extern of Class Methods *****/
-extern void BreakoutPotentiometer_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind);
 extern mp_obj_t BreakoutPotentiometer_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args);
 extern mp_obj_t BreakoutPotentiometer_set_address(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args);
 extern mp_obj_t BreakoutPotentiometer_get_adc_vref(mp_obj_t self_in);

--- a/micropython/modules/breakout_rgbmatrix5x5/breakout_rgbmatrix5x5.c
+++ b/micropython/modules/breakout_rgbmatrix5x5/breakout_rgbmatrix5x5.c
@@ -23,7 +23,6 @@ STATIC MP_DEFINE_CONST_DICT(BreakoutRGBMatrix5x5_locals_dict, BreakoutRGBMatrix5
 const mp_obj_type_t breakout_rgbmatrix5x5_BreakoutRGBMatrix5x5_type = {
     { &mp_type_type },
     .name = MP_QSTR_breakout_rgbmatrix5x5,
-    .print = BreakoutRGBMatrix5x5_print,
     .make_new = BreakoutRGBMatrix5x5_make_new,
     .locals_dict = (mp_obj_dict_t*)&BreakoutRGBMatrix5x5_locals_dict,
 };

--- a/micropython/modules/breakout_rgbmatrix5x5/breakout_rgbmatrix5x5.cpp
+++ b/micropython/modules/breakout_rgbmatrix5x5/breakout_rgbmatrix5x5.cpp
@@ -16,29 +16,6 @@ typedef struct _breakout_rgbmatrix5x5_BreakoutRGBMatrix5x5_obj_t {
     _PimoroniI2C_obj_t *i2c;
 } breakout_rgbmatrix5x5_BreakoutRGBMatrix5x5_obj_t;
 
-/***** Print *****/
-void BreakoutRGBMatrix5x5_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
-    (void)kind; //Unused input parameter    
-    breakout_rgbmatrix5x5_BreakoutRGBMatrix5x5_obj_t *self = MP_OBJ_TO_PTR2(self_in, breakout_rgbmatrix5x5_BreakoutRGBMatrix5x5_obj_t);
-    BreakoutRGBMatrix5x5* breakout = self->breakout;
-    mp_print_str(print, "BreakoutRGBMatrix5x5(");
-
-    mp_print_str(print, "i2c = ");
-    mp_obj_print_helper(print, mp_obj_new_int((breakout->get_i2c() == i2c0) ? 0 : 1), PRINT_REPR);
-
-    mp_print_str(print, ", address = 0x");
-    char buf[3];
-    sprintf(buf, "%02X", breakout->get_address());
-    mp_print_str(print, buf);
-
-    mp_print_str(print, ", sda = ");
-    mp_obj_print_helper(print, mp_obj_new_int(breakout->get_sda()), PRINT_REPR);
-
-    mp_print_str(print, ", scl = ");
-    mp_obj_print_helper(print, mp_obj_new_int(breakout->get_scl()), PRINT_REPR);
-
-    mp_print_str(print, ")");
-}
 
 /***** Constructor *****/
 mp_obj_t BreakoutRGBMatrix5x5_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {

--- a/micropython/modules/breakout_rgbmatrix5x5/breakout_rgbmatrix5x5.h
+++ b/micropython/modules/breakout_rgbmatrix5x5/breakout_rgbmatrix5x5.h
@@ -9,7 +9,6 @@ static const int HEIGHT     = 5;
 extern const mp_obj_type_t breakout_rgbmatrix5x5_BreakoutRGBMatrix5x5_type;
 
 /***** Extern of Class Methods *****/
-extern void BreakoutRGBMatrix5x5_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind);
 extern mp_obj_t BreakoutRGBMatrix5x5_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args);
 extern mp_obj_t BreakoutRGBMatrix5x5_set_pixel(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args);
 extern mp_obj_t BreakoutRGBMatrix5x5_update(mp_obj_t self_in);

--- a/micropython/modules/breakout_rtc/breakout_rtc.c
+++ b/micropython/modules/breakout_rtc/breakout_rtc.c
@@ -139,7 +139,6 @@ STATIC MP_DEFINE_CONST_DICT(BreakoutRTC_locals_dict, BreakoutRTC_locals_dict_tab
 const mp_obj_type_t breakout_rtc_BreakoutRTC_type = {
     { &mp_type_type },
     .name = MP_QSTR_breakout_rtc,
-    .print = BreakoutRTC_print,
     .make_new = BreakoutRTC_make_new,
     .locals_dict = (mp_obj_dict_t*)&BreakoutRTC_locals_dict,
 };

--- a/micropython/modules/breakout_rtc/breakout_rtc.cpp
+++ b/micropython/modules/breakout_rtc/breakout_rtc.cpp
@@ -18,27 +18,6 @@ typedef struct _breakout_rtc_BreakoutRTC_obj_t {
     _PimoroniI2C_obj_t *i2c;
 } breakout_rtc_BreakoutRTC_obj_t;
 
-/***** Print *****/
-void BreakoutRTC_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
-    (void)kind; //Unused input parameter
-    breakout_rtc_BreakoutRTC_obj_t *self = MP_OBJ_TO_PTR2(self_in, breakout_rtc_BreakoutRTC_obj_t);
-    BreakoutRTC* breakout = self->breakout;
-    mp_print_str(print, "BreakoutRTC(");
-
-    mp_print_str(print, "i2c = ");
-    mp_obj_print_helper(print, mp_obj_new_int((breakout->get_i2c() == i2c0) ? 0 : 1), PRINT_REPR);
-
-    mp_print_str(print, ", sda = ");
-    mp_obj_print_helper(print, mp_obj_new_int(breakout->get_sda()), PRINT_REPR);
-
-    mp_print_str(print, ", scl = ");
-    mp_obj_print_helper(print, mp_obj_new_int(breakout->get_scl()), PRINT_REPR);
-
-    mp_print_str(print, ", int = ");
-    mp_obj_print_helper(print, mp_obj_new_int(breakout->get_int()), PRINT_REPR);
-
-    mp_print_str(print, ")");
-}
 
 /***** Constructor *****/
 mp_obj_t BreakoutRTC_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {

--- a/micropython/modules/breakout_rtc/breakout_rtc.h
+++ b/micropython/modules/breakout_rtc/breakout_rtc.h
@@ -14,7 +14,6 @@ enum TCR {
 extern const mp_obj_type_t breakout_rtc_BreakoutRTC_type;
 
 /***** Extern of Class Methods *****/
-extern void BreakoutRTC_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind);
 extern mp_obj_t BreakoutRTC_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args);
 
 extern mp_obj_t BreakoutRTC_reset(mp_obj_t self_in);

--- a/micropython/modules/breakout_sgp30/breakout_sgp30.c
+++ b/micropython/modules/breakout_sgp30/breakout_sgp30.c
@@ -37,7 +37,6 @@ STATIC MP_DEFINE_CONST_DICT(BreakoutSGP30_locals_dict, BreakoutSGP30_locals_dict
 const mp_obj_type_t breakout_sgp30_BreakoutSGP30_type = {
     { &mp_type_type },
     .name = MP_QSTR_breakout_matrix11x7,
-    .print = BreakoutSGP30_print,
     .make_new = BreakoutSGP30_make_new,
     .locals_dict = (mp_obj_dict_t*)&BreakoutSGP30_locals_dict,
 };

--- a/micropython/modules/breakout_sgp30/breakout_sgp30.cpp
+++ b/micropython/modules/breakout_sgp30/breakout_sgp30.cpp
@@ -15,24 +15,6 @@ typedef struct _breakout_sgp30_BreakoutSGP30_obj_t {
     _PimoroniI2C_obj_t *i2c;
 } breakout_sgp30_BreakoutSGP30_obj_t;
 
-/***** Print *****/
-void BreakoutSGP30_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
-    (void)kind; //Unused input parameter    
-    breakout_sgp30_BreakoutSGP30_obj_t *self = MP_OBJ_TO_PTR2(self_in, breakout_sgp30_BreakoutSGP30_obj_t);
-    BreakoutSGP30* breakout = self->breakout;
-    mp_print_str(print, "BreakoutSGP30(");
-
-    mp_print_str(print, "i2c = ");
-    mp_obj_print_helper(print, mp_obj_new_int((breakout->get_i2c() == i2c0) ? 0 : 1), PRINT_REPR);
-
-    mp_print_str(print, ", sda = ");
-    mp_obj_print_helper(print, mp_obj_new_int(breakout->get_sda()), PRINT_REPR);
-
-    mp_print_str(print, ", scl = ");
-    mp_obj_print_helper(print, mp_obj_new_int(breakout->get_scl()), PRINT_REPR);
-
-    mp_print_str(print, ")");
-}
 
 /***** Constructor *****/
 mp_obj_t BreakoutSGP30_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {

--- a/micropython/modules/breakout_sgp30/breakout_sgp30.h
+++ b/micropython/modules/breakout_sgp30/breakout_sgp30.h
@@ -16,7 +16,6 @@ enum {
 extern const mp_obj_type_t breakout_sgp30_BreakoutSGP30_type;
 
 /***** Extern of Class Methods *****/
-extern void BreakoutSGP30_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind);
 extern mp_obj_t BreakoutSGP30_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args);
 extern mp_obj_t BreakoutSGP30_retrieve_unique_id(mp_obj_t self_in);
 extern mp_obj_t BreakoutSGP30_get_unique_id(mp_obj_t self_in);

--- a/micropython/modules/breakout_trackball/breakout_trackball.c
+++ b/micropython/modules/breakout_trackball/breakout_trackball.c
@@ -39,7 +39,6 @@ STATIC MP_DEFINE_CONST_DICT(BreakoutTrackball_locals_dict, BreakoutTrackball_loc
 const mp_obj_type_t breakout_trackball_BreakoutTrackball_type = {
     { &mp_type_type },
     .name = MP_QSTR_breakout_trackball,
-    .print = BreakoutTrackball_print,
     .make_new = BreakoutTrackball_make_new,
     .locals_dict = (mp_obj_dict_t*)&BreakoutTrackball_locals_dict,
 };

--- a/micropython/modules/breakout_trackball/breakout_trackball.cpp
+++ b/micropython/modules/breakout_trackball/breakout_trackball.cpp
@@ -16,32 +16,6 @@ typedef struct _breakout_trackball_BreakoutTrackball_obj_t {
     _PimoroniI2C_obj_t *i2c;
 } breakout_trackball_BreakoutTrackball_obj_t;
 
-/***** Print *****/
-void BreakoutTrackball_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
-    (void)kind; //Unused input parameter    
-    breakout_trackball_BreakoutTrackball_obj_t *self = MP_OBJ_TO_PTR2(self_in, breakout_trackball_BreakoutTrackball_obj_t);
-    BreakoutTrackball* breakout = self->breakout;
-    mp_print_str(print, "BreakoutTrackball(");
-
-    mp_print_str(print, "i2c = ");
-    mp_obj_print_helper(print, mp_obj_new_int((breakout->get_i2c() == i2c0) ? 0 : 1), PRINT_REPR);
-
-    mp_print_str(print, ", address = 0x");
-    char buf[3];
-    sprintf(buf, "%02X", breakout->get_address());
-    mp_print_str(print, buf);
-
-    mp_print_str(print, ", sda = ");
-    mp_obj_print_helper(print, mp_obj_new_int(breakout->get_sda()), PRINT_REPR);
-
-    mp_print_str(print, ", scl = ");
-    mp_obj_print_helper(print, mp_obj_new_int(breakout->get_scl()), PRINT_REPR);
-
-    mp_print_str(print, ", int = ");
-    mp_obj_print_helper(print, mp_obj_new_int(breakout->get_int()), PRINT_REPR);
-
-    mp_print_str(print, ")");
-}
 
 /***** Constructor *****/
 mp_obj_t BreakoutTrackball_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {

--- a/micropython/modules/breakout_trackball/breakout_trackball.h
+++ b/micropython/modules/breakout_trackball/breakout_trackball.h
@@ -15,7 +15,6 @@ enum {
 extern const mp_obj_type_t breakout_trackball_BreakoutTrackball_type;
 
 /***** Extern of Class Methods *****/
-extern void BreakoutTrackball_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind);
 extern mp_obj_t BreakoutTrackball_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args);
 extern mp_obj_t  BreakoutTrackball_change_address(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args);
 extern mp_obj_t  BreakoutTrackball_enable_interrupt(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args);

--- a/micropython/modules/breakout_vl53l5cx/vl53l5cx.c
+++ b/micropython/modules/breakout_vl53l5cx/vl53l5cx.c
@@ -50,7 +50,6 @@ STATIC MP_DEFINE_CONST_DICT(VL53L5CX_locals_dict, VL53L5CX_locals_dict_table);
 const mp_obj_type_t VL53L5CX_type = {
     { &mp_type_type },
     .name = MP_QSTR_breakout_vl53l5cx,
-    .print = VL53L5CX_print,
     .make_new = VL53L5CX_make_new,
     .locals_dict = (mp_obj_dict_t*)&VL53L5CX_locals_dict,
 };

--- a/micropython/modules/breakout_vl53l5cx/vl53l5cx.cpp
+++ b/micropython/modules/breakout_vl53l5cx/vl53l5cx.cpp
@@ -27,22 +27,6 @@ typedef struct _VL53L5CX_obj_t {
 } _VL53L5CX_obj_t;
 
 
-/***** Print *****/
-void VL53L5CX_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
-    (void)kind; // Unused input parameter
-    _VL53L5CX_obj_t *self = MP_OBJ_TO_PTR2(self_in, _VL53L5CX_obj_t);
-    mp_print_str(print, "VL53L5CX( ");
-
-
-    mp_print_str(print, "i2c = ");
-    mp_obj_print_helper(print, mp_obj_new_int((self->breakout->get_configuration()->platform.i2c == i2c0) ? 0 : 1), PRINT_REPR);
-
-    mp_print_str(print, " addr = ");
-    mp_obj_print_helper(print, mp_obj_new_int(self->breakout->get_configuration()->platform.address), PRINT_REPR);
-
-    mp_print_str(print, " )");
-}
-
 /***** Destructor ******/
 mp_obj_t VL53L5CX___del__(mp_obj_t self_in) {
     _VL53L5CX_obj_t *self = MP_OBJ_TO_PTR2(self_in, _VL53L5CX_obj_t);

--- a/micropython/modules/breakout_vl53l5cx/vl53l5cx.h
+++ b/micropython/modules/breakout_vl53l5cx/vl53l5cx.h
@@ -3,7 +3,6 @@
 
 extern const mp_obj_type_t VL53L5CX_type;
 
-extern void VL53L5CX_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind);
 
 extern mp_obj_t VL53L5CX___del__(mp_obj_t self_in);
 extern mp_obj_t VL53L5CX_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args);


### PR DESCRIPTION
Measured as saving 4048 bytes.

These functions serve basically no purpose, since they just reiterate the pins passed in from Pimoroni I2C. They are useful during development sometimes, but we can just do printf style debugging in the module constructors for this, eg:

```c++
mp_printf(&mp_plat_print, "Some debug text.");
```