### PR TITLE
UC8159: Timeout compiler error fix.

### DIFF
--- a/drivers/uc8159/uc8159.cpp
+++ b/drivers/uc8159/uc8159.cpp
@@ -39,10 +39,9 @@ namespace pimoroni {
 
   bool UC8159::is_busy() {
     if(BUSY == PIN_UNUSED) {
-      if(timeout > 0 && absolute_time_diff_us(get_absolute_time(), timeout) > 0) {
+      if(absolute_time_diff_us(get_absolute_time(), timeout) > 0) {
         return true;
       } else {
-        timeout = 0;
         return false;
       }
     }

--- a/drivers/uc8159/uc8159.hpp
+++ b/drivers/uc8159/uc8159.hpp
@@ -26,13 +26,13 @@ namespace pimoroni {
 
     // interface pins with our standard defaults where appropriate
     uint CS     = SPI_BG_FRONT_CS;
-    uint DC     = 28;
+    uint DC     = 28; // 27;
     uint SCK    = SPI_DEFAULT_SCK;
     uint MOSI   = SPI_DEFAULT_MOSI;
     uint BUSY   = PIN_UNUSED;
-    uint RESET  = 27;
+    uint RESET  = 27; //25;
 
-    absolute_time_t timeout = 0;
+    absolute_time_t timeout;
 
   public:
     enum colour : uint8_t {


### PR DESCRIPTION
This fixes an issue with setting an `absolute_time_t` (which is a struct with a "private" uint64_t member) to `0`.