### PR TITLE
Pico Graphics: Double buffer scanline conversion

### DIFF
--- a/drivers/st7735/st7735.cpp
+++ b/drivers/st7735/st7735.cpp
@@ -172,8 +172,10 @@ namespace pimoroni {
       gpio_put(dc, 1); // data mode
       gpio_put(cs, 0);
 
-      graphics->scanline_convert(PicoGraphics::PEN_RGB565, [this](void *data, size_t length) {
-        spi_write_blocking(spi, (const uint8_t*)data, length);
+      graphics->frame_convert(PicoGraphics::PEN_RGB565, [this](void *data, size_t length) {
+        if (length > 0) {
+          spi_write_blocking(spi, (const uint8_t*)data, length);
+        }
       });
 
       gpio_put(cs, 1);

--- a/drivers/st7789/st7789.cpp
+++ b/drivers/st7789/st7789.cpp
@@ -110,11 +110,11 @@ namespace pimoroni {
   }
 
   void ST7789::cleanup() {
-    if(spi) return; // SPI mode needs no tear down
-    if(dma_channel_is_claimed(parallel_dma)) {
-      dma_channel_abort(parallel_dma);
-      dma_channel_unclaim(parallel_dma);
+    if(dma_channel_is_claimed(st_dma)) {
+      dma_channel_abort(st_dma);
+      dma_channel_unclaim(st_dma);
     }
+    if(spi) return; // SPI mode needs no further tear down
 
     if(pio_sm_is_claimed(parallel_pio, parallel_sm)) {
       pio_sm_set_enabled(parallel_pio, parallel_sm, false);
@@ -223,11 +223,11 @@ namespace pimoroni {
     command(reg::MADCTL, 1, (char *)&madctl);
   }
 
-  void ST7789::write_blocking_parallel_dma(const uint8_t *src, size_t len) {
-    while (dma_channel_is_busy(parallel_dma))
+  void ST7789::write_blocking_dma(const uint8_t *src, size_t len) {
+    while (dma_channel_is_busy(st_dma))
       ;
-    dma_channel_set_trans_count(parallel_dma, len, false);
-    dma_channel_set_read_addr(parallel_dma, src, true);
+    dma_channel_set_trans_count(st_dma, len, false);
+    dma_channel_set_read_addr(st_dma, src, true);
   }
 
   void ST7789::write_blocking_parallel(const uint8_t *src, size_t len) {
@@ -284,31 +284,23 @@ namespace pimoroni {
 
     if(graphics->pen_type == PicoGraphics::PEN_RGB565) { // Display buffer is screen native
       command(cmd, width * height * sizeof(uint16_t), (const char*)graphics->frame_buffer);
-    } else if(spi) { // SPI Bus
+    } else {
       gpio_put(dc, 0); // command mode
       gpio_put(cs, 0);
-      spi_write_blocking(spi, &cmd, 1);
+      if(spi) { // SPI Bus
+        spi_write_blocking(spi, &cmd, 1);
+      } else { // Parallel Bus
+        write_blocking_parallel(&cmd, 1);
+      }
+
       gpio_put(dc, 1); // data mode
 
       graphics->frame_convert(PicoGraphics::PEN_RGB565, [this](void *data, size_t length) {
         if (length > 0) {
-          spi_write_blocking(spi, (const uint8_t*)data, length);
-        }
-      });
-  
-      gpio_put(cs, 1);
-    } else { // Parallel Bus
-      gpio_put(dc, 0); // command mode
-      gpio_put(cs, 0);
-      write_blocking_parallel(&cmd, 1);
-      gpio_put(dc, 1); // data mode
-
-      graphics->frame_convert(PicoGraphics::PEN_RGB565, [this](void *data, size_t length) {
-        if (length > 0) {
-          write_blocking_parallel_dma((const uint8_t*)data, length);
+          write_blocking_dma((const uint8_t*)data, length);
         }
         else {
-          dma_channel_wait_for_finish_blocking(parallel_dma);
+          dma_channel_wait_for_finish_blocking(st_dma);
         }
       });
 

--- a/drivers/st7789/st7789.hpp
+++ b/drivers/st7789/st7789.hpp
@@ -40,7 +40,7 @@ namespace pimoroni {
     uint parallel_sm;
     PIO parallel_pio;
     uint parallel_offset;
-    uint parallel_dma;
+    uint st_dma;
 
 
     // The ST7789 requires 16 ns between SPI rising edges.
@@ -94,12 +94,12 @@ namespace pimoroni {
       pio_sm_set_enabled(parallel_pio, parallel_sm, true);
 
 
-      parallel_dma = dma_claim_unused_channel(true);
-      dma_channel_config config = dma_channel_get_default_config(parallel_dma);
+      st_dma = dma_claim_unused_channel(true);
+      dma_channel_config config = dma_channel_get_default_config(st_dma);
       channel_config_set_transfer_data_size(&config, DMA_SIZE_8);
       channel_config_set_bswap(&config, false);
       channel_config_set_dreq(&config, pio_get_dreq(parallel_pio, parallel_sm, true));
-      dma_channel_configure(parallel_dma, &config, &parallel_pio->txf[parallel_sm], NULL, 0, false);
+      dma_channel_configure(st_dma, &config, &parallel_pio->txf[parallel_sm], NULL, 0, false);
   
       gpio_put(rd_sck, 1);
 
@@ -118,6 +118,13 @@ namespace pimoroni {
       gpio_set_function(wr_sck, GPIO_FUNC_SPI);
       gpio_set_function(d0, GPIO_FUNC_SPI);
 
+      st_dma = dma_claim_unused_channel(true);
+      dma_channel_config config = dma_channel_get_default_config(st_dma);
+      channel_config_set_transfer_data_size(&config, DMA_SIZE_8);
+      channel_config_set_bswap(&config, false);
+      channel_config_set_dreq(&config, spi_get_dreq(spi, true));
+      dma_channel_configure(st_dma, &config, &spi_get_hw(spi)->dr, NULL, 0, false);
+  
       common_init();
     }
 
@@ -128,7 +135,7 @@ namespace pimoroni {
   private:
     void common_init();
     void configure_display(Rotation rotate);
-    void write_blocking_parallel_dma(const uint8_t *src, size_t len);
+    void write_blocking_dma(const uint8_t *src, size_t len);
     void write_blocking_parallel(const uint8_t *src, size_t len);
     void command(uint8_t command, size_t len = 0, const char *data = NULL);
   };

--- a/drivers/uc8159/uc8159.cpp
+++ b/drivers/uc8159/uc8159.cpp
@@ -154,8 +154,10 @@ namespace pimoroni {
     spi_write_blocking(spi, &reg, 1);
 
     gpio_put(DC, 1); // data mode
-    graphics->scanline_convert(PicoGraphics::PEN_P4, [this](void *buf, size_t length) {
-      spi_write_blocking(spi, (const uint8_t*)buf, length);
+    graphics->frame_convert(PicoGraphics::PEN_P4, [this](void *buf, size_t length) {
+      if (length > 0) {
+        spi_write_blocking(spi, (const uint8_t*)buf, length);
+      }
     });
 
     gpio_put(CS, 1);

--- a/libraries/pico_graphics/pico_graphics.hpp
+++ b/libraries/pico_graphics/pico_graphics.hpp
@@ -172,6 +172,7 @@ namespace pimoroni {
     Rect clip;
 
     typedef std::function<void(void *data, size_t length)> conversion_callback_func;
+    typedef std::function<RGB565()> next_pixel_func;
     //typedef std::function<void(int y)> scanline_interrupt_func;
 
     //scanline_interrupt_func scanline_interrupt = nullptr;
@@ -225,7 +226,7 @@ namespace pimoroni {
     virtual void set_pixel_dither(const Point &p, const RGB &c);
     virtual void set_pixel_dither(const Point &p, const RGB565 &c);
     virtual void set_pixel_dither(const Point &p, const uint8_t &c);
-    virtual void scanline_convert(PenType type, conversion_callback_func callback);
+    virtual void frame_convert(PenType type, conversion_callback_func callback);
     virtual void sprite(void* data, const Point &sprite, const Point &dest, const int scale, const int transparent);
 
     void set_font(const bitmap::font_t *font);
@@ -252,6 +253,9 @@ namespace pimoroni {
     void polygon(const std::vector<Point> &points);
     void triangle(Point p1, Point p2, Point p3);
     void line(Point p1, Point p2);
+
+  protected:
+    void frame_convert_rgb565(conversion_callback_func callback, next_pixel_func get_next_pixel);
   };
 
   class PicoGraphics_Pen1Bit : public PicoGraphics {
@@ -325,7 +329,7 @@ namespace pimoroni {
       void get_dither_candidates(const RGB &col, const RGB *palette, size_t len, std::array<uint8_t, 16> &candidates);
       void set_pixel_dither(const Point &p, const RGB &c) override;
 
-      void scanline_convert(PenType type, conversion_callback_func callback) override;
+      void frame_convert(PenType type, conversion_callback_func callback) override;
       static size_t buffer_size(uint w, uint h) {
           return (w * h / 8) * 3;
       }
@@ -354,7 +358,7 @@ namespace pimoroni {
       void get_dither_candidates(const RGB &col, const RGB *palette, size_t len, std::array<uint8_t, 16> &candidates);
       void set_pixel_dither(const Point &p, const RGB &c) override;
 
-      void scanline_convert(PenType type, conversion_callback_func callback) override;
+      void frame_convert(PenType type, conversion_callback_func callback) override;
       static size_t buffer_size(uint w, uint h) {
           return w * h / 2;
       }
@@ -383,7 +387,7 @@ namespace pimoroni {
       void get_dither_candidates(const RGB &col, const RGB *palette, size_t len, std::array<uint8_t, 16> &candidates);
       void set_pixel_dither(const Point &p, const RGB &c) override;
 
-      void scanline_convert(PenType type, conversion_callback_func callback) override;
+      void frame_convert(PenType type, conversion_callback_func callback) override;
       static size_t buffer_size(uint w, uint h) {
         return w * h;
       }
@@ -404,7 +408,7 @@ namespace pimoroni {
 
       void sprite(void* data, const Point &sprite, const Point &dest, const int scale, const int transparent) override;
 
-      void scanline_convert(PenType type, conversion_callback_func callback) override;
+      void frame_convert(PenType type, conversion_callback_func callback) override;
       static size_t buffer_size(uint w, uint h) {
         return w * h;
       }

--- a/libraries/pico_graphics/pico_graphics_pen_3bit.cpp
+++ b/libraries/pico_graphics/pico_graphics_pen_3bit.cpp
@@ -90,7 +90,7 @@ namespace pimoroni {
         color = candidate_cache[cache_key][dither16_pattern[pattern_index]];
         set_pixel(p);
     }
-    void PicoGraphics_Pen3Bit::scanline_convert(PenType type, conversion_callback_func callback) {
+    void PicoGraphics_Pen3Bit::frame_convert(PenType type, conversion_callback_func callback) {
         if(type == PEN_P4) {
             uint8_t row_buf[bounds.w / 2];
             uint offset = (bounds.w * bounds.h) / 8;

--- a/libraries/pico_graphics/pico_graphics_pen_p4.cpp
+++ b/libraries/pico_graphics/pico_graphics_pen_p4.cpp
@@ -135,8 +135,9 @@ namespace pimoroni {
             // Treat our void* frame_buffer as uint8_t
             uint8_t *src = (uint8_t *)frame_buffer;
 
-            // Allocate a per-row temporary buffer
-            uint16_t row_buf[bounds.w];
+            // Allocate two per-row temporary buffers, as the callback may transfer by DMA
+            // while we're preparing the next row
+            uint16_t row_buf[2][bounds.w];
             for(auto y = 0; y < bounds.h; y++) {
                 /*if(scanline_interrupt != nullptr) {
                     scanline_interrupt(y);
@@ -150,10 +151,10 @@ namespace pimoroni {
                     uint8_t c = src[(bounds.w * y / 2) + (x / 2)];
                     uint8_t  o = (~x & 0b1) * 4; // bit offset within byte
                     uint8_t  b = (c >> o) & 0xf; // bit value shifted to position
-                    row_buf[x] = cache[b];
+                    row_buf[y & 1][x] = cache[b];
                 }
                 // Callback to the driver with the row data
-                callback(row_buf, bounds.w * sizeof(RGB565));
+                callback(row_buf[y & 1], bounds.w * sizeof(RGB565));
             }
         }
     }

--- a/libraries/pico_graphics/pico_graphics_pen_p8.cpp
+++ b/libraries/pico_graphics/pico_graphics_pen_p8.cpp
@@ -109,14 +109,15 @@ namespace pimoroni {
             // Treat our void* frame_buffer as uint8_t
             uint8_t *src = (uint8_t *)frame_buffer;
 
-            // Allocate a per-row temporary buffer
-            uint16_t row_buf[bounds.w];
+            // Allocate two per-row temporary buffers, as the callback may transfer by DMA
+            // while we're preparing the next row
+            uint16_t row_buf[2][bounds.w];
             for(auto y = 0; y < bounds.h; y++) {
                 for(auto x = 0; x < bounds.w; x++) {
-                    row_buf[x] = cache[src[bounds.w * y + x]];
+                    row_buf[y & 1][x] = cache[src[bounds.w * y + x]];
                 }
                 // Callback to the driver with the row data
-                callback(row_buf, bounds.w * sizeof(RGB565));
+                callback(row_buf[y & 1], bounds.w * sizeof(RGB565));
             }
         }
     }

--- a/libraries/pico_graphics/pico_graphics_pen_p8.cpp
+++ b/libraries/pico_graphics/pico_graphics_pen_p8.cpp
@@ -98,7 +98,7 @@ namespace pimoroni {
         set_pixel(p);
     }
 
-    void PicoGraphics_PenP8::scanline_convert(PenType type, conversion_callback_func callback) {
+    void PicoGraphics_PenP8::frame_convert(PenType type, conversion_callback_func callback) {
         if(type == PEN_RGB565) {
             // Cache the RGB888 palette as RGB565
             RGB565 cache[palette_size];
@@ -109,16 +109,9 @@ namespace pimoroni {
             // Treat our void* frame_buffer as uint8_t
             uint8_t *src = (uint8_t *)frame_buffer;
 
-            // Allocate two per-row temporary buffers, as the callback may transfer by DMA
-            // while we're preparing the next row
-            uint16_t row_buf[2][bounds.w];
-            for(auto y = 0; y < bounds.h; y++) {
-                for(auto x = 0; x < bounds.w; x++) {
-                    row_buf[y & 1][x] = cache[src[bounds.w * y + x]];
-                }
-                // Callback to the driver with the row data
-                callback(row_buf[y & 1], bounds.w * sizeof(RGB565));
-            }
+            frame_convert_rgb565(callback, [&]() {
+                return cache[*src++];
+            });
         }
     }
 }

--- a/libraries/pico_graphics/pico_graphics_pen_rgb332.cpp
+++ b/libraries/pico_graphics/pico_graphics_pen_rgb332.cpp
@@ -84,16 +84,17 @@ namespace pimoroni {
             // Treat our void* frame_buffer as uint8_t
             uint8_t *src = (uint8_t *)frame_buffer;
 
-            // Allocate a per-row temporary buffer
-            uint16_t row_buf[bounds.w];
+            // Allocate two per-row temporary buffers, as the callback may transfer by DMA
+            // while we're preparing the next row
+            uint16_t row_buf[2][bounds.w];
             for(auto y = 0; y < bounds.h; y++) {
                 for(auto x = 0; x < bounds.w; x++) {
-                    row_buf[x] = rgb332_to_rgb565_lut[*src];
+                    row_buf[y & 1][x] = rgb332_to_rgb565_lut[*src];
 
                     src++;
                 }
                 // Callback to the driver with the row data
-                callback(row_buf, bounds.w * sizeof(RGB565));
+                callback(row_buf[y & 1], bounds.w * sizeof(RGB565));
             }
         }
     }

--- a/libraries/pico_graphics/pico_graphics_pen_rgb332.cpp
+++ b/libraries/pico_graphics/pico_graphics_pen_rgb332.cpp
@@ -78,24 +78,15 @@ namespace pimoroni {
 
         set_pixel(p);
     }
-    void PicoGraphics_PenRGB332::scanline_convert(PenType type, conversion_callback_func callback) {
+    void PicoGraphics_PenRGB332::frame_convert(PenType type, conversion_callback_func callback) {
         if(type == PEN_RGB565) {
 
             // Treat our void* frame_buffer as uint8_t
             uint8_t *src = (uint8_t *)frame_buffer;
 
-            // Allocate two per-row temporary buffers, as the callback may transfer by DMA
-            // while we're preparing the next row
-            uint16_t row_buf[2][bounds.w];
-            for(auto y = 0; y < bounds.h; y++) {
-                for(auto x = 0; x < bounds.w; x++) {
-                    row_buf[y & 1][x] = rgb332_to_rgb565_lut[*src];
-
-                    src++;
-                }
-                // Callback to the driver with the row data
-                callback(row_buf[y & 1], bounds.w * sizeof(RGB565));
-            }
+            frame_convert_rgb565(callback, [&]() {
+                return rgb332_to_rgb565_lut[*src++];
+            });
         }
     }
     void PicoGraphics_PenRGB332::sprite(void* data, const Point &sprite, const Point &dest, const int scale, const int transparent) {


### PR DESCRIPTION
This fixes an issue where the Tufty display was mildly corrupted when using Pico Graphics modes other than RGB565.

The problem was the DMA transfer in ST7789 would read from the same buffer that the scanline conversion was setting up for the next line.  This meant that the first few pixels of each row would have the values from the next row, and could possibly cause further corruption if the RP2040 was otherwise busy (e.g. when USB is enabled).