### PR TITLE
Inky Frame: Sensible limit on SDCard speed.

### DIFF
--- a/drivers/sdcard/sdcard.c
+++ b/drivers/sdcard/sdcard.c
@@ -51,7 +51,7 @@
 #define CT_BLOCK       0x08            /* Block addressing */
 
 #define CLK_SLOW	(100 * KHZ)
-#define CLK_FAST	(50 * MHZ)
+#define CLK_FAST	(30 * MHZ)
 
 static volatile
 DSTATUS Stat = STA_NOINIT;	/* Physical drive status */


### PR DESCRIPTION
Going any faster will result in corruption- this showed up as visible lines of distortion down decoded JPEG files.