### PR TITLE
MicroPython: Add ShiftRegister class.

### DIFF
--- a/micropython/modules_py/pimoroni.py
+++ b/micropython/modules_py/pimoroni.py
@@ -196,3 +196,31 @@ class Buzzer:
         self.pwm.freq(freq)
         self.pwm.duty_u16(int(65535 * duty))
         return True
+
+
+class ShiftRegister:
+    def __init__(self, clk, lat, dat):
+        self.clk = Pin(clk, Pin.OUT)
+        self.lat = Pin(lat, Pin.OUT)
+        self.dat = Pin(dat, Pin.IN)
+
+    def __iter__(self):
+        self.lat.off()
+        self.lat.on()
+        for _ in range(8):
+            yield self.dat.value()
+            self.clk.on()
+            self.clk.off()
+
+    def __getitem__(self, k):
+        return list(self)[k]
+
+    def read(self):
+        out = 0
+        for bit in self:
+            out <<= 1
+            out += bit
+        return out
+
+    def is_set(self, mask):
+        return self.read() & mask == mask


### PR DESCRIPTION
Adds a new class to read the buttons on Inky Frame.

Can be read as an 8-bit integer and compared against a bitmask, or treated as an iterable or list to check a specific value.

Note: the bits are shifted out in MSB first (native) bit order so the *nth* bit (0-7) will be the `7-n`th list element.

Usage:

```python
import time
from pimoroni import ShiftRegister

# Shift register marks
BUTTON_A = 0b00000001
BUTTON_B = 0b00000010
BUTTON_C = 0b00000100
BUTTON_D = 0b00001000
BUTTON_E = 0b00010000

RTC_ALARM = 0b00100000
EXTR_TRIG = 0b01000000
EINK_BUSY = 0b10000000

SR_CLOCK = 8
SR_LATCH = 9
SR_OUT = 10

sr = ShiftRegister(SR_CLOCK, SR_LATCH, SR_OUT)

while True:
    result = sr.read()
    button_a = sr.is_set(BUTTON_A)
    button_b = sr[6]  # Bits come out in MSB-first order
    bits = list(sr)
    print(result, bits, button_a, button_b)
    time.sleep(1.0)
```