### PR TITLE
Feature/pen888

### DIFF
--- a/libraries/pico_graphics/pico_graphics.cmake
+++ b/libraries/pico_graphics/pico_graphics.cmake
@@ -8,6 +8,7 @@ add_library(pico_graphics
     ${CMAKE_CURRENT_LIST_DIR}/pico_graphics_pen_p8.cpp
     ${CMAKE_CURRENT_LIST_DIR}/pico_graphics_pen_rgb332.cpp
     ${CMAKE_CURRENT_LIST_DIR}/pico_graphics_pen_rgb565.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/pico_graphics_pen_rgb888.cpp
 )
 
 target_include_directories(pico_graphics INTERFACE ${CMAKE_CURRENT_LIST_DIR})

--- a/libraries/pico_graphics/pico_graphics.hpp
+++ b/libraries/pico_graphics/pico_graphics.hpp
@@ -24,6 +24,7 @@
 namespace pimoroni {
   typedef uint8_t RGB332;
   typedef uint16_t RGB565;
+  typedef uint32_t RGB888;
   struct RGB {
     int16_t r, g, b;
 
@@ -82,6 +83,10 @@ namespace pimoroni {
 
     constexpr RGB565 to_rgb332() {
       return (r & 0b11100000) | ((g & 0b11100000) >> 3) | ((b & 0b11000000) >> 6);
+    }
+
+    constexpr RGB888 to_rgb888() {
+      return (r << 16) | (g << 8) | (b << 0);
     }
   };
 
@@ -418,6 +423,23 @@ namespace pimoroni {
         return w * h * sizeof(RGB565);
       }
   };
+
+  
+  class PicoGraphics_PenRGB888 : public PicoGraphics {
+    public:
+      RGB src_color;
+      RGB888 color;
+      PicoGraphics_PenRGB888(uint16_t width, uint16_t height, void *frame_buffer);
+      void set_pen(uint c) override;
+      void set_pen(uint8_t r, uint8_t g, uint8_t b) override;
+      int create_pen(uint8_t r, uint8_t g, uint8_t b) override;
+      void set_pixel(const Point &p) override;
+      void set_pixel_span(const Point &p, uint l) override;
+      static size_t buffer_size(uint w, uint h) {
+        return w * h * sizeof(uint32_t);
+      }
+  };
+
 
   class DisplayDriver {
     public:

--- a/libraries/pico_graphics/pico_graphics.hpp
+++ b/libraries/pico_graphics/pico_graphics.hpp
@@ -161,7 +161,8 @@ namespace pimoroni {
       PEN_P4,
       PEN_P8,
       PEN_RGB332,
-      PEN_RGB565
+      PEN_RGB565,
+      PEN_RGB888,
     };
 
     void *frame_buffer;

--- a/libraries/pico_graphics/pico_graphics_pen_rgb888.cpp
+++ b/libraries/pico_graphics/pico_graphics_pen_rgb888.cpp
@@ -1,0 +1,33 @@
+#include "pico_graphics.hpp"
+
+namespace pimoroni {
+    PicoGraphics_PenRGB888::PicoGraphics_PenRGB888(uint16_t width, uint16_t height, void *frame_buffer)
+    : PicoGraphics(width, height, frame_buffer) {
+        this->pen_type = PEN_RGB888;
+        if(this->frame_buffer == nullptr) {
+            this->frame_buffer = (void *)(new uint8_t[buffer_size(width, height)]);
+        }
+    }
+    void PicoGraphics_PenRGB888::set_pen(uint c) {
+        color = {c, c, c};
+    }
+    void PicoGraphics_PenRGB888::set_pen(uint8_t r, uint8_t g, uint8_t b) {
+        color = {r, g, b};
+    }
+    int PicoGraphics_PenRGB888::create_pen(uint8_t r, uint8_t g, uint8_t b) {
+        return RGB(r, g, b).to_rgb888();
+    }
+    void PicoGraphics_PenRGB888::set_pixel(const Point &p) {
+        uint32_t *buf = (uint32_t *)frame_buffer;
+        buf[p.y * bounds.w + p.x] = color;
+    }
+    void PicoGraphics_PenRGB888::set_pixel_span(const Point &p, uint l) {
+        // pointer to byte in framebuffer that contains this pixel
+        uint32_t *buf = (uint32_t *)frame_buffer;
+        buf = &buf[p.y * bounds.w + p.x];
+
+        while(l--) {
+            *buf++ = color;
+        }
+    }
+}

--- a/libraries/pico_graphics/pico_graphics_pen_rgb888.cpp
+++ b/libraries/pico_graphics/pico_graphics_pen_rgb888.cpp
@@ -9,10 +9,10 @@ namespace pimoroni {
         }
     }
     void PicoGraphics_PenRGB888::set_pen(uint c) {
-        color = {c, c, c};
+        color = RGB(c, c, c).to_rgb888();
     }
     void PicoGraphics_PenRGB888::set_pen(uint8_t r, uint8_t g, uint8_t b) {
-        color = {r, g, b};
+        color = RGB(r, g, b).to_rgb888();
     }
     int PicoGraphics_PenRGB888::create_pen(uint8_t r, uint8_t g, uint8_t b) {
         return RGB(r, g, b).to_rgb888();

--- a/micropython/modules/jpegdec/jpegdec.cpp
+++ b/micropython/modules/jpegdec/jpegdec.cpp
@@ -238,6 +238,7 @@ mp_obj_t _JPEG_decode(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args
     switch(self->graphics->graphics->pen_type) {
         case PicoGraphics::PEN_RGB332:
         case PicoGraphics::PEN_RGB565:
+        case PicoGraphics::PEN_RGB888:
         case PicoGraphics::PEN_P8:
         case PicoGraphics::PEN_P4:
         case PicoGraphics::PEN_3BIT:


### PR DESCRIPTION
Add new RGB888 pen type. While probably too memory hungry for use with LCDs this is a nice feature to have for driving our LED matrix products (uuuuuuuniiiiicoooooorn!).