### PR TITLE
Exposed byte access for PCF RTC

### DIFF
--- a/micropython/modules/pcf85063a/pcf85063a.c
+++ b/micropython/modules/pcf85063a/pcf85063a.c
@@ -22,6 +22,8 @@ MP_DEFINE_CONST_FUN_OBJ_1(PCF85063A_clear_timer_flag_obj, PCF85063A_clear_timer_
 MP_DEFINE_CONST_FUN_OBJ_1(PCF85063A_unset_timer_obj, PCF85063A_unset_timer);
 
 MP_DEFINE_CONST_FUN_OBJ_2(PCF85063A_set_clock_output_obj, PCF85063A_set_clock_output);
+MP_DEFINE_CONST_FUN_OBJ_2(PCF85063A_set_byte_obj, PCF85063A_set_byte);
+MP_DEFINE_CONST_FUN_OBJ_1(PCF85063A_get_byte_obj, PCF85063A_get_byte);
 
 /***** Binding of Methods *****/
 STATIC const mp_rom_map_elem_t PCF85063A_locals_dict_table[] = {
@@ -42,6 +44,8 @@ STATIC const mp_rom_map_elem_t PCF85063A_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_unset_timer), MP_ROM_PTR(&PCF85063A_unset_timer_obj) },
 
     { MP_ROM_QSTR(MP_QSTR_set_clock_output), MP_ROM_PTR(&PCF85063A_set_clock_output_obj) },
+    { MP_ROM_QSTR(MP_QSTR_set_byte), MP_ROM_PTR(&PCF85063A_set_byte_obj) },
+    { MP_ROM_QSTR(MP_QSTR_get_byte), MP_ROM_PTR(&PCF85063A_get_byte_obj) },
 
     { MP_ROM_QSTR(MP_QSTR_CLOCK_OUT_32768HZ), MP_ROM_INT(0) },
     { MP_ROM_QSTR(MP_QSTR_CLOCK_OUT_16384HZ), MP_ROM_INT(1) },

--- a/micropython/modules/pcf85063a/pcf85063a.cpp
+++ b/micropython/modules/pcf85063a/pcf85063a.cpp
@@ -286,4 +286,21 @@ mp_obj_t PCF85063A_set_clock_output(mp_obj_t self_in, mp_obj_t co_in) {
 
     return mp_const_none;
 }
+
+mp_obj_t PCF85063A_set_byte(mp_obj_t self_in, mp_obj_t v) {
+    pcf85063a_PCF85063A_obj_t *self = MP_OBJ_TO_PTR2(self_in, pcf85063a_PCF85063A_obj_t);
+
+    int val = mp_obj_get_int(v);
+    if(val < 0 || val > 255) mp_raise_ValueError("out of range. Expected 0 to 255");
+
+    self->breakout->set_byte((uint8_t)val);
+
+    return mp_const_none;
+}
+
+mp_obj_t PCF85063A_get_byte(mp_obj_t self_in) {
+    pcf85063a_PCF85063A_obj_t *self = MP_OBJ_TO_PTR2(self_in, pcf85063a_PCF85063A_obj_t);
+
+    return mp_obj_new_int(self->breakout->get_byte());
+}
 }

--- a/micropython/modules/pcf85063a/pcf85063a.h
+++ b/micropython/modules/pcf85063a/pcf85063a.h
@@ -24,3 +24,6 @@ extern mp_obj_t PCF85063A_read_timer_flag(mp_obj_t self_in);
 extern mp_obj_t PCF85063A_unset_timer(mp_obj_t self_in);
 
 extern mp_obj_t PCF85063A_set_clock_output(mp_obj_t self_in, mp_obj_t co_in);
+
+extern mp_obj_t PCF85063A_set_byte(mp_obj_t self_in, mp_obj_t v);
+extern mp_obj_t PCF85063A_get_byte(mp_obj_t self_in);


### PR DESCRIPTION
PCF has a free byte that can be written to and read from. Useful for storing state information separate from the main processor.