### PR TITLE
Update bme68x_demo.py

### DIFF
--- a/micropython/examples/breakout_bme68x/bme68x_demo.py
+++ b/micropython/examples/breakout_bme68x/bme68x_demo.py
@@ -10,7 +10,10 @@ PINS_BREAKOUT_GARDEN = {"sda": 4, "scl": 5}
 PINS_PICO_EXPLORER = {"sda": 20, "scl": 21}
 
 i2c = PimoroniI2C(**PINS_BREAKOUT_GARDEN)
+
 bmp = BreakoutBME68X(i2c)
+# If this gives an error, try the alternative address
+# bmp = BreakoutBME68X(i2c, 0x77)
 
 while True:
     temperature, pressure, humidity, gas, status, _, _ = bmp.read()


### PR DESCRIPTION
Some products such as the adafruit breakout and Pimoroni Enviro Indoor have the BME68x on the alternate address. This adds a prompt for users getting errors.