### PR TITLE
MicroPython: Ported PicoSleep module.

### DIFF
--- a/micropython/modules/micropython-common.cmake
+++ b/micropython/modules/micropython-common.cmake
@@ -45,6 +45,8 @@ include(pcf85063a/micropython)
 include(picographics/micropython)
 include(jpegdec/micropython)
 
+include(picosleep/micropython)
+
 include(modules_py/modules_py)
 
 function(enable_ulab)

--- a/micropython/modules/picosleep/README.md
+++ b/micropython/modules/picosleep/README.md
@@ -1,0 +1,3 @@
+# PicoSleep
+
+Ported to an external module from https://github.com/ghubcoder/micropython-pico-deepsleep/

--- a/micropython/modules/picosleep/micropython.cmake
+++ b/micropython/modules/picosleep/micropython.cmake
@@ -1,0 +1,18 @@
+set(MOD_NAME picosleep)
+string(TOUPPER ${MOD_NAME} MOD_NAME_UPPER)
+add_library(usermod_${MOD_NAME} INTERFACE)
+
+target_sources(usermod_${MOD_NAME} INTERFACE
+    ${CMAKE_CURRENT_LIST_DIR}/${MOD_NAME}.c
+    ${CMAKE_CURRENT_LIST_DIR}/sleep.c
+    ${CMAKE_CURRENT_LIST_DIR}/rosc.c
+)
+target_include_directories(usermod_${MOD_NAME} INTERFACE
+    ${CMAKE_CURRENT_LIST_DIR}
+)
+
+target_compile_definitions(usermod_${MOD_NAME} INTERFACE
+    -DMODULE_${MOD_NAME_UPPER}_ENABLED=1
+)
+
+target_link_libraries(usermod INTERFACE usermod_${MOD_NAME})

--- a/micropython/modules/picosleep/picosleep.c
+++ b/micropython/modules/picosleep/picosleep.c
@@ -1,0 +1,112 @@
+#include "py/runtime.h"
+#include "sleep.h"
+#include "pico/stdlib.h"
+#include <stdint.h>
+#include <string.h>
+#include <stdio.h>
+#include <time.h>
+#include <stdlib.h>
+#include "hardware/clocks.h"
+#include "rosc.h"
+#include "hardware/structs/scb.h"
+
+static void sleep_callback(void)
+{
+    return;
+}
+
+static void rtc_sleep_seconds(uint32_t seconds_to_sleep)
+{
+
+    // Hangs if we attempt to sleep for 1 second....
+    // Guard against this and perform a normal sleep
+    if (seconds_to_sleep == 1)
+    {
+        sleep_ms(1000);
+        return;
+    }
+
+    int y = 2020, m = 6, d = 5, hour = 15, mins = 45, secs = 0;
+    struct tm t = {.tm_year = y - 1900,
+                   .tm_mon = m - 1,
+                   .tm_mday = d,
+                   .tm_hour = hour,
+                   .tm_min = mins,
+                   .tm_sec = secs};
+
+    t.tm_sec += seconds_to_sleep;
+    mktime(&t);
+
+    datetime_t t_alarm = {
+        .year = t.tm_year + 1900,
+        .month = t.tm_mon + 1,
+        .day = t.tm_mday,
+        .dotw = t.tm_wday, // 0 is Sunday, so 5 is Friday
+        .hour = t.tm_hour,
+        .min = t.tm_min,
+        .sec = t.tm_sec};
+
+    sleep_goto_sleep_until(&t_alarm, &sleep_callback);
+}
+
+void recover_from_sleep(uint scb_orig, uint clock0_orig, uint clock1_orig)
+{
+
+    // Re-enable ring Oscillator control
+    rosc_write(&rosc_hw->ctrl, ROSC_CTRL_ENABLE_BITS);
+
+    // reset procs back to default
+    scb_hw->scr = scb_orig;
+    clocks_hw->sleep_en0 = clock0_orig;
+    clocks_hw->sleep_en1 = clock1_orig;
+
+    // reset clocks
+    clocks_init();
+    stdio_init_all();
+
+    return;
+}
+
+STATIC mp_obj_t picosleep_seconds(mp_obj_t seconds_obj)
+{
+    mp_int_t seconds = mp_obj_get_int(seconds_obj);
+    stdio_init_all();
+    // save values for later
+    uint scb_orig = scb_hw->scr;
+    uint clock0_orig = clocks_hw->sleep_en0;
+    uint clock1_orig = clocks_hw->sleep_en1;
+
+    // crudely reset the clock each time
+    // to the value below
+    datetime_t t = {
+        .year = 2020,
+        .month = 06,
+        .day = 05,
+        .dotw = 5, // 0 is Sunday, so 5 is Friday
+        .hour = 15,
+        .min = 45,
+        .sec = 00};
+
+    // Start the Real time clock
+    rtc_init();
+    sleep_run_from_xosc();
+    rtc_set_datetime(&t);
+    rtc_sleep_seconds(seconds);
+    recover_from_sleep(scb_orig, clock0_orig, clock1_orig);
+
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_1(picosleep_seconds_obj, picosleep_seconds);
+
+STATIC const mp_rom_map_elem_t picosleep_module_globals_table[] = {
+    {MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_picosleep)},
+    {MP_ROM_QSTR(MP_QSTR_seconds), MP_ROM_PTR(&picosleep_seconds_obj)},
+};
+STATIC MP_DEFINE_CONST_DICT(picosleep_module_globals, picosleep_module_globals_table);
+
+const mp_obj_module_t mp_module_picosleep = {
+    .base = {&mp_type_module},
+    .globals = (mp_obj_dict_t *)&picosleep_module_globals,
+};
+
+MP_REGISTER_MODULE(MP_QSTR_picosleep, mp_module_picosleep);

--- a/micropython/modules/picosleep/pll.h
+++ b/micropython/modules/picosleep/pll.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2020 Raspberry Pi (Trading) Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef _HARDWARE_PLL_H_
+#define _HARDWARE_PLL_H_
+
+#include "pico.h"
+#include "hardware/structs/pll.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** \file hardware/pll.h
+ *  \defgroup hardware_pll hardware_pll
+ *
+ * Phase Locked Loop control APIs
+ *
+ * There are two PLLs in RP2040. They are:
+ *   - pll_sys - Used to generate up to a 133MHz system clock
+ *   - pll_usb - Used to generate a 48MHz USB reference clock
+ *
+ * For details on how the PLL's are calculated, please refer to the RP2040 datasheet.
+ */
+
+typedef pll_hw_t *PLL;
+
+#define pll_sys pll_sys_hw
+#define pll_usb pll_usb_hw
+
+#ifndef PICO_PLL_VCO_MIN_FREQ_MHZ
+#define PICO_PLL_VCO_MIN_FREQ_MHZ 750
+#endif
+
+#ifndef PICO_PLL_VCO_MAX_FREQ_MHZ
+#define PICO_PLL_VCO_MAX_FREQ_MHZ 1600
+#endif
+
+/*! \brief Initialise specified PLL.
+ *  \ingroup hardware_pll
+ * \param pll pll_sys or pll_usb
+ * \param ref_div Input clock divider.
+ * \param vco_freq  Requested output from the VCO (voltage controlled oscillator)
+ * \param post_div1 Post Divider 1 - range 1-7. Must be >= post_div2
+ * \param post_div2 Post Divider 2 - range 1-7
+ */
+void pll_init(PLL pll, uint ref_div, uint vco_freq, uint post_div1, uint post_div2);
+
+/*! \brief Release/uninitialise specified PLL.
+ *  \ingroup hardware_pll
+ *
+ * This will turn off the power to the specified PLL. Note this function does not currently check if
+ * the PLL is in use before powering it off so should be used with care.
+ *
+ * \param pll pll_sys or pll_usb
+ */
+void pll_deinit(PLL pll);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/micropython/modules/picosleep/rosc.c
+++ b/micropython/modules/picosleep/rosc.c
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2020 Raspberry Pi (Trading) Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "pico.h"
+
+// For MHZ definitions etc
+#include "hardware/clocks.h"
+#include "rosc.h"
+
+// Given a ROSC delay stage code, return the next-numerically-higher code.
+// Top result bit is set when called on maximum ROSC code.
+uint32_t next_rosc_code(uint32_t code) {
+    return ((code | 0x08888888u) + 1u) & 0xf7777777u;
+}
+
+uint rosc_find_freq(uint32_t low_mhz, uint32_t high_mhz) {
+    // TODO: This could be a lot better
+    rosc_set_div(1);
+    for (uint32_t code = 0; code <= 0x77777777u; code = next_rosc_code(code)) {
+        rosc_set_freq(code);
+        uint rosc_mhz = frequency_count_khz(CLOCKS_FC0_SRC_VALUE_ROSC_CLKSRC) / 1000;
+        if ((rosc_mhz >= low_mhz) && (rosc_mhz <= high_mhz)) {
+            return rosc_mhz;
+        }
+    }
+    return 0;
+}
+
+void rosc_set_div(uint32_t div) {
+    assert(div <= 31 && div >= 1);
+    rosc_write(&rosc_hw->div, ROSC_DIV_VALUE_PASS + div);
+}
+
+void rosc_set_freq(uint32_t code) {
+    rosc_write(&rosc_hw->freqa, (ROSC_FREQA_PASSWD_VALUE_PASS << ROSC_FREQA_PASSWD_LSB) | (code & 0xffffu));
+    rosc_write(&rosc_hw->freqb, (ROSC_FREQA_PASSWD_VALUE_PASS << ROSC_FREQA_PASSWD_LSB) | (code >> 16u));
+}
+
+void rosc_set_range(uint range) {
+    // Range should use enumvals from the headers and thus have the password correct
+    rosc_write(&rosc_hw->ctrl, (ROSC_CTRL_ENABLE_VALUE_ENABLE << ROSC_CTRL_ENABLE_LSB) | range);
+}
+
+void rosc_disable(void) {
+    uint32_t tmp = rosc_hw->ctrl;
+    tmp &= (~ROSC_CTRL_ENABLE_BITS);
+    tmp |= (ROSC_CTRL_ENABLE_VALUE_DISABLE << ROSC_CTRL_ENABLE_LSB);
+    rosc_write(&rosc_hw->ctrl, tmp);
+    // Wait for stable to go away
+    while(rosc_hw->status & ROSC_STATUS_STABLE_BITS);
+}
+
+void rosc_set_dormant(void) {
+    // WARNING: This stops the rosc until woken up by an irq
+    rosc_write(&rosc_hw->dormant, ROSC_DORMANT_VALUE_DORMANT);
+    // Wait for it to become stable once woken up
+    while(!(rosc_hw->status & ROSC_STATUS_STABLE_BITS));
+}

--- a/micropython/modules/picosleep/rosc.h
+++ b/micropython/modules/picosleep/rosc.h
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2020 Raspberry Pi (Trading) Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef _HARDWARE_ROSC_H_
+#define _HARDWARE_ROSC_H_
+
+#include "pico.h"
+#include "hardware/structs/rosc.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** \file rosc.h
+ *  \defgroup hardware_rosc hardware_rosc
+ *
+ * Ring Oscillator (ROSC) API
+ *
+ * A Ring Oscillator is an on-chip oscillator that requires no external crystal. Instead, the output is generated from a series of
+ * inverters that are chained together to create a feedback loop. RP2040 boots from the ring oscillator initially, meaning the
+ * first stages of the bootrom, including booting from SPI flash, will be clocked by the ring oscillator. If your design has a
+ * crystal oscillator, you’ll likely want to switch to this as your reference clock as soon as possible, because the frequency is
+ * more accurate than the ring oscillator.
+ */
+
+/*! \brief  Set frequency of the Ring Oscillator
+ *  \ingroup hardware_rosc
+ *
+ * \param code The drive strengths. See the RP2040 datasheet for information on this value.
+ */
+void rosc_set_freq(uint32_t code);
+
+/*! \brief  Set range of the Ring Oscillator
+ *  \ingroup hardware_rosc
+ *
+ * Frequency range. Frequencies will vary with Process, Voltage & Temperature (PVT).
+ * Clock output will not glitch when changing the range up one step at a time.
+ *
+ * \param range 0x01 Low, 0x02 Medium, 0x03 High, 0x04 Too High.
+ */
+void rosc_set_range(uint range);
+
+/*! \brief  Disable the Ring Oscillator
+ *  \ingroup hardware_rosc
+ *
+ */
+void rosc_disable(void);
+
+/*! \brief  Put Ring Oscillator in to dormant mode.
+ *  \ingroup hardware_rosc
+ *
+ * The ROSC supports a dormant mode,which stops oscillation until woken up up by an asynchronous interrupt.
+ * This can either come from the RTC, being clocked by an external clock, or a GPIO pin going high or low.
+ * If no IRQ is configured before going into dormant mode the ROSC will never restart.
+ *
+ * PLLs should be stopped before selecting dormant mode.
+ */
+void rosc_set_dormant(void);
+
+// FIXME: Add doxygen
+
+uint32_t next_rosc_code(uint32_t code);
+
+uint rosc_find_freq(uint32_t low_mhz, uint32_t high_mhz);
+
+void rosc_set_div(uint32_t div);
+
+inline static void rosc_clear_bad_write(void) {
+    hw_clear_bits(&rosc_hw->status, ROSC_STATUS_BADWRITE_BITS);
+}
+
+inline static bool rosc_write_okay(void) {
+    return !(rosc_hw->status & ROSC_STATUS_BADWRITE_BITS);
+}
+
+inline static void rosc_write(io_rw_32 *addr, uint32_t value) {
+    rosc_clear_bad_write();
+    assert(rosc_write_okay());
+    *addr = value;
+    assert(rosc_write_okay());
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/micropython/modules/picosleep/sleep.c
+++ b/micropython/modules/picosleep/sleep.c
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2020 Raspberry Pi (Trading) Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "pico.h"
+
+#include "pico/stdlib.h"
+#include "sleep.h"
+
+#include "hardware/rtc.h"
+#include "pll.h"
+#include "hardware/clocks.h"
+#include "xosc.h"
+#include "rosc.h"
+#include "hardware/regs/io_bank0.h"
+// For __wfi
+#include "hardware/sync.h"
+// For scb_hw so we can enable deep sleep
+#include "hardware/structs/scb.h"
+
+// The difference between sleep and dormant is that ALL clocks are stopped in dormant mode,
+// until the source (either xosc or rosc) is started again by an external event.
+// In sleep mode some clocks can be left running controlled by the SLEEP_EN registers in the clocks
+// block. For example you could keep clk_rtc running. Some destinations (proc0 and proc1 wakeup logic)
+// can't be stopped in sleep mode otherwise there wouldn't be enough logic to wake up again.
+
+
+// TODO: Optionally, memories can also be powered down.
+
+static dormant_source_t _dormant_source;
+
+bool dormant_source_valid(dormant_source_t dormant_source) {
+    return (dormant_source == DORMANT_SOURCE_XOSC) || (dormant_source == DORMANT_SOURCE_ROSC);
+}
+
+// In order to go into dormant mode we need to be running from a stoppable clock source:
+// either the xosc or rosc with no PLLs running. This means we disable the USB and ADC clocks
+// and all PLLs
+void sleep_run_from_dormant_source(dormant_source_t dormant_source) {
+    assert(dormant_source_valid(dormant_source));
+    _dormant_source = dormant_source;
+
+    // FIXME: Just defining average rosc freq here.
+    uint src_hz = (dormant_source == DORMANT_SOURCE_XOSC) ? XOSC_MHZ * MHZ : 6.5 * MHZ;
+    uint clk_ref_src = (dormant_source == DORMANT_SOURCE_XOSC) ?
+                       CLOCKS_CLK_REF_CTRL_SRC_VALUE_XOSC_CLKSRC :
+                       CLOCKS_CLK_REF_CTRL_SRC_VALUE_ROSC_CLKSRC_PH;
+
+    // CLK_REF = XOSC or ROSC
+    clock_configure(clk_ref,
+                    clk_ref_src,
+                    0, // No aux mux
+                    src_hz,
+                    src_hz);
+
+    // CLK SYS = CLK_REF
+    clock_configure(clk_sys,
+                    CLOCKS_CLK_SYS_CTRL_SRC_VALUE_CLK_REF,
+                    0, // Using glitchless mux
+                    src_hz,
+                    src_hz);
+
+    // CLK USB = 0MHz
+    clock_stop(clk_usb);
+
+    // CLK ADC = 0MHz
+    clock_stop(clk_adc);
+
+    // CLK RTC = ideally XOSC (12MHz) / 256 = 46875Hz but could be rosc
+    uint clk_rtc_src = (dormant_source == DORMANT_SOURCE_XOSC) ? 
+                       CLOCKS_CLK_RTC_CTRL_AUXSRC_VALUE_XOSC_CLKSRC : 
+                       CLOCKS_CLK_RTC_CTRL_AUXSRC_VALUE_ROSC_CLKSRC_PH;
+
+    clock_configure(clk_rtc,
+                    0, // No GLMUX
+                    clk_rtc_src,
+                    src_hz,
+                    46875);
+
+    // CLK PERI = clk_sys. Used as reference clock for Peripherals. No dividers so just select and enable
+    clock_configure(clk_peri,
+                    0,
+                    CLOCKS_CLK_PERI_CTRL_AUXSRC_VALUE_CLK_SYS,
+                    src_hz,
+                    src_hz);
+
+    pll_deinit(pll_sys);
+    pll_deinit(pll_usb);
+
+    // Assuming both xosc and rosc are running at the moment
+    if (dormant_source == DORMANT_SOURCE_XOSC) {
+        // Can disable rosc
+        rosc_disable();
+    } else {
+        // Can disable xosc
+        xosc_disable();
+    }
+
+    // Reconfigure uart with new clocks
+    setup_default_uart();
+}
+
+// Go to sleep until woken up by the RTC
+void sleep_goto_sleep_until(datetime_t *t, rtc_callback_t callback) {
+    // We should have already called the sleep_run_from_dormant_source function
+    assert(dormant_source_valid(_dormant_source));
+
+    // Turn off all clocks when in sleep mode except for RTC
+    clocks_hw->sleep_en0 = CLOCKS_SLEEP_EN0_CLK_RTC_RTC_BITS;
+    clocks_hw->sleep_en1 = 0x0;
+
+    rtc_set_alarm(t, callback);
+
+    uint save = scb_hw->scr;
+    // Enable deep sleep at the proc
+    scb_hw->scr = save | M0PLUS_SCR_SLEEPDEEP_BITS;
+
+    // Go to sleep
+    __wfi();
+}
+
+static void _go_dormant(void) {
+    assert(dormant_source_valid(_dormant_source));
+
+    if (_dormant_source == DORMANT_SOURCE_XOSC) {
+        xosc_dormant();
+    } else {
+        rosc_set_dormant();
+    }
+}
+
+void sleep_goto_dormant_until_pin(uint gpio_pin, bool edge, bool high) {
+    bool low = !high;
+    bool level = !edge;
+
+    // Configure the appropriate IRQ at IO bank 0
+    assert(gpio_pin < NUM_BANK0_GPIOS);
+
+    uint32_t event = 0;
+
+    if (level && low) event = IO_BANK0_DORMANT_WAKE_INTE0_GPIO0_LEVEL_LOW_BITS;
+    if (level && high) event = IO_BANK0_DORMANT_WAKE_INTE0_GPIO0_LEVEL_HIGH_BITS;
+    if (edge && high) event = IO_BANK0_DORMANT_WAKE_INTE0_GPIO0_EDGE_HIGH_BITS;
+    if (edge && low) event = IO_BANK0_DORMANT_WAKE_INTE0_GPIO0_EDGE_LOW_BITS;
+
+    gpio_set_dormant_irq_enabled(gpio_pin, event, true);
+
+    _go_dormant();
+    // Execution stops here until woken up
+
+    // Clear the irq so we can go back to dormant mode again if we want
+    gpio_acknowledge_irq(gpio_pin, event);
+}

--- a/micropython/modules/picosleep/sleep.h
+++ b/micropython/modules/picosleep/sleep.h
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2020 Raspberry Pi (Trading) Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef _PICO_SLEEP_H_
+#define _PICO_SLEEP_H_
+
+#include "pico.h"
+#include "hardware/rtc.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** \file sleep.h
+ *  \defgroup hardware_sleep hardware_sleep
+ *
+ * Lower Power Sleep API
+ *
+ * The difference between sleep and dormant is that ALL clocks are stopped in dormant mode,
+ * until the source (either xosc or rosc) is started again by an external event.
+ * In sleep mode some clocks can be left running controlled by the SLEEP_EN registers in the clocks
+ * block. For example you could keep clk_rtc running. Some destinations (proc0 and proc1 wakeup logic)
+ * can't be stopped in sleep mode otherwise there wouldn't be enough logic to wake up again.
+ *
+ * \subsection sleep_example Example
+ * \addtogroup hardware_sleep
+ * \include hello_sleep.c
+ */
+typedef enum {
+    DORMANT_SOURCE_NONE,
+    DORMANT_SOURCE_XOSC,
+    DORMANT_SOURCE_ROSC
+} dormant_source_t;
+
+/*! \brief Set all clock sources to the the dormant clock source to prepare for sleep.
+ *  \ingroup hardware_sleep
+ *
+ * \param dormant_source The dormant clock source to use
+ */
+void sleep_run_from_dormant_source(dormant_source_t dormant_source);
+
+/*! \brief Set the dormant clock source to be the crystal oscillator
+ *  \ingroup hardware_sleep
+ */
+static inline void sleep_run_from_xosc(void) {
+    sleep_run_from_dormant_source(DORMANT_SOURCE_XOSC);
+}
+
+/*! \brief Set the dormant clock source to be the ring oscillator
+ *  \ingroup hardware_sleep
+ */
+static inline void sleep_run_from_rosc(void) {
+    sleep_run_from_dormant_source(DORMANT_SOURCE_ROSC);
+}
+
+/*! \brief Send system to sleep until the specified time
+ *  \ingroup hardware_sleep
+ *
+ * One of the sleep_run_* functions must be called prior to this call
+ *
+ * \param t The time to wake up
+ * \param callback Function to call on wakeup.
+ */
+void sleep_goto_sleep_until(datetime_t *t, rtc_callback_t callback);
+
+/*! \brief Send system to sleep until the specified GPIO changes
+ *  \ingroup hardware_sleep
+ *
+ * One of the sleep_run_* functions must be called prior to this call
+ *
+ * \param gpio_pin The pin to provide the wake up
+ * \param edge true for leading edge, false for trailing edge
+ * \param high true for active high, false for active low
+ */
+void sleep_goto_dormant_until_pin(uint gpio_pin, bool edge, bool high);
+
+/*! \brief Send system to sleep until a leading high edge is detected on GPIO
+ *  \ingroup hardware_sleep
+ *
+ * One of the sleep_run_* functions must be called prior to this call
+ *
+ * \param gpio_pin The pin to provide the wake up
+ */
+static inline void sleep_goto_dormant_until_edge_high(uint gpio_pin) {
+    sleep_goto_dormant_until_pin(gpio_pin, true, true);
+}
+
+/*! \brief Send system to sleep until a high level is detected on GPIO
+ *  \ingroup hardware_sleep
+ *
+ * One of the sleep_run_* functions must be called prior to this call
+ *
+ * \param gpio_pin The pin to provide the wake up
+ */
+static inline void sleep_goto_dormant_until_level_high(uint gpio_pin) {
+    sleep_goto_dormant_until_pin(gpio_pin, false, true);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/micropython/modules/picosleep/xosc.h
+++ b/micropython/modules/picosleep/xosc.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2020 Raspberry Pi (Trading) Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef _HARDWARE_XOSC_H_
+#define _HARDWARE_XOSC_H_
+
+#include "pico.h"
+#include "hardware/structs/xosc.h"
+
+
+// Allow lengthening startup delay to accommodate slow-starting oscillators
+
+// PICO_CONFIG: PICO_XOSC_STARTUP_DELAY_MULTIPLIER, Multiplier to lengthen xosc startup delay to accommodate slow-starting oscillators, type=int, min=1, default=1, group=hardware_xosc
+#ifndef PICO_XOSC_STARTUP_DELAY_MULTIPLIER
+#define PICO_XOSC_STARTUP_DELAY_MULTIPLIER 1
+#endif
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** \file hardware/xosc.h
+ *  \defgroup hardware_xosc hardware_xosc
+ *
+ * Crystal Oscillator (XOSC) API
+ */
+
+/*! \brief  Initialise the crystal oscillator system
+ *  \ingroup hardware_xosc
+ *
+ * This function will block until the crystal oscillator has stabilised.
+ **/
+void xosc_init(void);
+
+/*! \brief  Disable the Crystal oscillator
+ *  \ingroup hardware_xosc
+ *
+ * Turns off the crystal oscillator source, and waits for it to become unstable
+ **/
+void xosc_disable(void);
+
+/*! \brief Set the crystal oscillator system to dormant
+ *  \ingroup hardware_xosc
+ *
+ * Turns off the crystal oscillator until it is woken by an interrupt. This will block and hence
+ * the entire system will stop, until an interrupt wakes it up. This function will
+ * continue to block until the oscillator becomes stable after its wakeup.
+ **/
+void xosc_dormant(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
This is a very experimental port of @ghubcoder's "picosleep" - https://github.com/ghubcoder/micropython-pico-deepsleep/

I have vendored Pico Extras `sleep.c` and `sleep.h` because life's too short to deal with extraneous submodules or repository clones for a couple of source files that are going to be version pinned anyway.