### PR TITLE
Remove `picoexplorer` references

### DIFF
--- a/micropython/examples/pico_explorer/button_test.py
+++ b/micropython/examples/pico_explorer/button_test.py
@@ -3,21 +3,14 @@
 import time
 from pimoroni import Button
 from picographics import PicoGraphics, DISPLAY_PICO_EXPLORER, PEN_P4
-import picoexplorer
 
 # We're only using a few colours so we can use a 4 bit/16 colour palette and save RAM!
 display = PicoGraphics(display=DISPLAY_PICO_EXPLORER, pen_type=PEN_P4)
 
-button_a = Button(picoexplorer.BUTTON_A)
-button_b = Button(picoexplorer.BUTTON_B)
-button_x = Button(picoexplorer.BUTTON_X)
-button_y = Button(picoexplorer.BUTTON_Y)
-
-# alternatively, you could set up the buttons using pin number if you prefer
-# button_a = Button(12)
-# button_b = Button(13)
-# button_x = Button(14)
-# button_y = Button(15)
+button_a = Button(12)
+button_b = Button(13)
+button_x = Button(14)
+button_y = Button(15)
 
 WHITE = display.create_pen(255, 255, 255)
 BLACK = display.create_pen(0, 0, 0)

--- a/micropython/examples/pico_explorer/demo.py
+++ b/micropython/examples/pico_explorer/demo.py
@@ -1,19 +1,18 @@
 import time
 from picographics import PicoGraphics, DISPLAY_PICO_EXPLORER
 from motor import Motor
-import picoexplorer
 from pimoroni import Button, Analog, Buzzer
 
 display = PicoGraphics(display=DISPLAY_PICO_EXPLORER)
 
-adc0 = Analog(picoexplorer.ADC0)
-adc1 = Analog(picoexplorer.ADC1)
-adc2 = Analog(picoexplorer.ADC2)
+adc0 = Analog(26)
+adc1 = Analog(27)
+adc2 = Analog(28)
 
-button_a = Button(picoexplorer.BUTTON_A)
-button_b = Button(picoexplorer.BUTTON_B)
-button_x = Button(picoexplorer.BUTTON_X)
-button_y = Button(picoexplorer.BUTTON_Y)
+button_a = Button(12)
+button_b = Button(13)
+button_x = Button(14)
+button_y = Button(15)
 
 BG = display.create_pen(32, 32, 64)
 WHITE = display.create_pen(255, 255, 255)
@@ -22,8 +21,8 @@ ADC0_PEN = display.create_pen(255, 0, 0)
 ADC1_PEN = display.create_pen(0, 255, 0)
 ADC2_PEN = display.create_pen(0, 0, 255)
 
-MOTOR1 = Motor(picoexplorer.MOTOR_1)
-MOTOR2 = Motor(picoexplorer.MOTOR_2)
+MOTOR1 = Motor((8, 9))
+MOTOR2 = Motor((10, 11))
 
 BUZZER = Buzzer(0)
 

--- a/micropython/examples/pico_lipo_shim/battery_pico.py
+++ b/micropython/examples/pico_lipo_shim/battery_pico.py
@@ -1,27 +1,29 @@
-# This example shows how to read the voltage from a LiPo battery connected to a Raspberry Pi Pico via our Pico Lipo SHIM...
-# ...and uses this reading to calculate how much charge is left in the battery.
-# It then displays the info on the screen of Pico Display or Pico Explorer.
+# This example shows how to read the voltage from a LiPo battery connected to a Raspberry Pi Pico via our Pico Lipo SHIM
+# and uses this reading to calculate how much charge is left in the battery.
+# It then displays the info on the screen of Pico Display.
 # Remember to save this code as main.py on your Pico if you want it to run automatically!
 
 from machine import ADC, Pin
 import time
 
-# Uncomment one of these lines, depending on what display you have
-import picodisplay as display
-# import picodisplay2 as display
-# import picoexplorer as display
+# change to DISPLAY_PICO_DISPLAY_2 for Pico Display 2.0
+from picographics import PicoGraphics, DISPLAY_PICO_DISPLAY
+display = PicoGraphics(display=DISPLAY_PICO_DISPLAY, rotate=0)
 
-# Set up and initialise display
-buf = bytearray(display.get_width() * display.get_height() * 2)
-display.init(buf)
-display.set_backlight(0.8)          # comment out this line if you have a Pico Explorer as it doesn't have a controllable backlight
+display.set_backlight(0.8)
 
-vsys = ADC(29)              # reads the system input voltage
-charging = Pin(24, Pin.IN)  # reading GP24 tells us whether or not USB power is connected
+vsys = ADC(29)                      # reads the system input voltage
+charging = Pin(24, Pin.IN)          # reading GP24 tells us whether or not USB power is connected
 conversion_factor = 3 * 3.3 / 65535
 
 full_battery = 4.2                  # these are our reference voltages for a full/empty battery, in volts
 empty_battery = 2.8                 # the values could vary by battery size/manufacturer so you might need to adjust them
+
+# Create some pen colours for drawing with
+BLACK = display.create_pen(0, 0, 0)
+GREY = display.create_pen(190, 190, 190)
+GREEN = display.create_pen(0, 255, 0)
+RED = display.create_pen(255, 0, 0)
 
 while True:
     # convert the raw ADC read into a voltage, and then a percentage
@@ -31,30 +33,25 @@ while True:
         percentage = 100.00
 
     # draw the battery outline
-    display.set_pen(0, 0, 0)
+    display.set_pen(BLACK)
     display.clear()
-    display.set_pen(190, 190, 190)
+    display.set_pen(GREY)
     display.rectangle(0, 0, 220, 135)
     display.rectangle(220, 40, 20, 55)
-    display.set_pen(0, 0, 0)
+    display.set_pen(GREEN)
     display.rectangle(3, 3, 214, 129)
 
     # draw a green box for the battery level
-    display.set_pen(0, 255, 0)
+    display.set_pen(GREEN)
     display.rectangle(5, 5, round(210 / 100 * percentage), 125)
 
     # add text
-    display.set_pen(255, 0, 0)
+    display.set_pen(RED)
     if charging.value() == 1:         # if it's plugged into USB power...
         display.text("Charging!", 15, 55, 240, 4)
     else:                             # if not, display the battery stats
         display.text('{:.2f}'.format(voltage) + "v", 15, 10, 240, 5)
         display.text('{:.0f}%'.format(percentage), 15, 50, 240, 5)
-
-    # uncomment for low battery alarm (Pico Explorer only, you'll need to have GP0 and AUDIO connected with a jumper wire)
-    # display.set_audio_pin(0)
-    # if percentage < 5:               # if the battery is less than 5%
-    #     display.set_tone(262)        # then make an annoying noise
 
     display.update()
     time.sleep(0.5)

--- a/micropython/examples/pimoroni_pico_lipo/battery_pico_display.py
+++ b/micropython/examples/pimoroni_pico_lipo/battery_pico_display.py
@@ -1,21 +1,17 @@
-# This example reads the voltage from a LiPo battery connected to Pimoroni Pico LiPo...
-# ...and uses this reading to calculate how much charge is left in the battery.
-# It then displays the info on the screen of Pico Display or Pico Explorer.
+# This example reads the voltage from a LiPo battery connected to Pimoroni Pico LiPo
+# and uses this reading to calculate how much charge is left in the battery.
+# It then displays the info on the screen of Pico Display (or Pico Display 2.0).
 # With Pimoroni Pico LiPo, you can read the battery percentage while it's charging.
 # Save this code as main.py on your Pico if you want it to run automatically!
 
 from machine import ADC, Pin
 import time
+# change to DISPLAY_PICO_DISPLAY_2 for Pico Display 2.0
+from picographics import PicoGraphics, DISPLAY_PICO_DISPLAY
 
-# Uncomment one of these lines, depending on what display you have
-import picodisplay as display
-# import picodisplay2 as display
-# import picoexplorer as display
+display = PicoGraphics(display=DISPLAY_PICO_DISPLAY, rotate=0)
 
-# Set up and initialise display
-buf = bytearray(display.get_width() * display.get_height() * 2)
-display.init(buf)
-display.set_backlight(0.8)          # comment out this line if you have a Pico Explorer, it doesn't have a controllable backlight
+display.set_backlight(0.8)
 
 vsys = ADC(29)                      # reads the system input voltage
 charging = Pin(24, Pin.IN)          # reading GP24 tells us whether or not USB power is connected
@@ -23,6 +19,12 @@ conversion_factor = 3 * 3.3 / 65535
 
 full_battery = 4.2                  # reference voltages for a full/empty battery, in volts
 empty_battery = 2.8                 # the values could vary by battery size/manufacturer so you might need to adjust them
+
+# Create some pen colours for drawing with
+BLACK = display.create_pen(0, 0, 0)
+GREY = display.create_pen(190, 190, 190)
+GREEN = display.create_pen(0, 255, 0)
+RED = display.create_pen(255, 0, 0)
 
 while True:
     # convert the raw ADC read into a voltage, and then a percentage
@@ -32,30 +34,25 @@ while True:
         percentage = 100
 
     # draw the battery outline
-    display.set_pen(0, 0, 0)
+    display.set_pen(BLACK)
     display.clear()
-    display.set_pen(190, 190, 190)
+    display.set_pen(GREY)
     display.rectangle(0, 0, 220, 135)
     display.rectangle(220, 40, 20, 55)
-    display.set_pen(0, 0, 0)
+    display.set_pen(BLACK)
     display.rectangle(3, 3, 214, 129)
 
     # draw a green box for the battery level
-    display.set_pen(0, 255, 0)
+    display.set_pen(GREEN)
     display.rectangle(5, 5, int((210 / 100) * percentage), 125)
 
     # add text
-    display.set_pen(255, 0, 0)
+    display.set_pen(RED)
     if charging.value() == 1:         # if it's plugged into USB power...
         display.text("Charging!", 15, 90, 240, 4)
 
     display.text('{:.2f}'.format(voltage) + "v", 15, 10, 240, 5)
     display.text('{:.0f}%'.format(percentage), 15, 50, 240, 5)
-
-    # uncomment for low battery alarm (Pico Explorer only, you'll need to have GP0 and AUDIO connected with a jumper wire)
-    # display.set_audio_pin(0)
-    # if percentage < 5:               # if the battery is less than 5%
-    #     display.set_tone(262)        # then make an annoying noise
 
     display.update()
     time.sleep(0.5)

--- a/micropython/examples/pimoroni_pico_lipo/battery_pico_explorer.py
+++ b/micropython/examples/pimoroni_pico_lipo/battery_pico_explorer.py
@@ -1,0 +1,64 @@
+# This example reads the voltage from a LiPo battery connected to Pimoroni Pico LiPo
+# and uses this reading to calculate how much charge is left in the battery.
+# It then displays the info on the screen of Pico Explorer.
+# With Pimoroni Pico LiPo, you can read the battery percentage while it's charging.
+# Save this code as main.py on your Pico if you want it to run automatically!
+
+from machine import ADC, Pin
+import time
+from pimoroni import Buzzer
+from picographics import PicoGraphics, DISPLAY_PICO_EXPLORER
+
+display = PicoGraphics(display=DISPLAY_PICO_EXPLORER)
+
+buzzer = Buzzer(0)
+
+vsys = ADC(29)                      # reads the system input voltage
+charging = Pin(24, Pin.IN)          # reading GP24 tells us whether or not USB power is connected
+conversion_factor = 3 * 3.3 / 65535
+
+full_battery = 4.2                  # reference voltages for a full/empty battery, in volts
+empty_battery = 2.8                 # the values could vary by battery size/manufacturer so you might need to adjust them
+
+# Create some pen colours for drawing with
+BLACK = display.create_pen(0, 0, 0)
+GREY = display.create_pen(190, 190, 190)
+GREEN = display.create_pen(0, 255, 0)
+RED = display.create_pen(255, 0, 0)
+
+while True:
+    buzzer.set_tone(0)
+
+    # convert the raw ADC read into a voltage, and then a percentage
+    voltage = vsys.read_u16() * conversion_factor
+    percentage = 100 * ((voltage - empty_battery) / (full_battery - empty_battery))
+    if percentage > 100:
+        percentage = 100
+
+    # draw the battery outline
+    display.set_pen(BLACK)
+    display.clear()
+    display.set_pen(GREY)
+    display.rectangle(0, 0, 220, 135)
+    display.rectangle(220, 40, 20, 55)
+    display.set_pen(BLACK)
+    display.rectangle(3, 3, 214, 129)
+
+    # draw a green box for the battery level
+    display.set_pen(GREEN)
+    display.rectangle(5, 5, int((210 / 100) * percentage), 125)
+
+    # add text
+    display.set_pen(RED)
+    if charging.value() == 1:         # if it's plugged into USB power...
+        display.text("Charging!", 15, 90, 240, 4)
+
+    display.text('{:.2f}'.format(voltage) + "v", 15, 10, 240, 5)
+    display.text('{:.0f}%'.format(percentage), 15, 50, 240, 5)
+
+    # Low battery alarm! (you'll need to have GP0 and AUDIO connected with a jumper wire)
+    if percentage < 5:              # if the battery is less than 5%
+        buzzer.set_tone(262)        # then make an annoying noise
+
+    display.update()
+    time.sleep(0.5)

--- a/micropython/modules/pico_explorer/README.md
+++ b/micropython/modules/pico_explorer/README.md
@@ -4,8 +4,6 @@ Pico Explorer Base straps a whole host of physical computing goodies to your Pic
 
 [You can buy one here!](https://shop.pimoroni.com/products/pico-explorer-base)
 
-The `picoexplorer` module contains constants you can use with our shared libraries to make it easy to draw to the screen and interface with the buttons, piezo buzzer and motor driver. You don't need to use the constants of course, you can skip the `import pico_explorer` and just enter the pin number/s if you prefer. There's a handy reference of what pins are used for which functions on the bottom of the board.
-
 - [Board Functions](#board-functions)
   - [Display](#display)
   - [Buttons](#buttons)
@@ -14,7 +12,7 @@ The `picoexplorer` module contains constants you can use with our shared librari
   - [Audio](#audio)
   - [GPIO](#gpio)
   - [Breakout Garden slots / I2C](#breakout-garden-slots--i2c)
-- [Pin Constants](#pin-constants)
+- [Pins](#pins)
 
 ## Board Functions
 
@@ -24,7 +22,7 @@ Pico Explorer uses a shared Pico Graphics library to draw graphics and text on i
 
 - [PicoGraphics MicroPython function reference](https://github.com/pimoroni/pimoroni-pico/tree/main/micropython/modules/picographics)
 
-Please note that the backlight on Pico Explorer is not dimmable (we needed the pins to hook up other functions) so `set_backlight` won't do anything on this board.
+Please note that the backlight on Pico Explorer is not dimmable (we needed the pins to hook up all the other functions) so `set_backlight` won't do anything on this board.
 
 Here's a simple Hello World example that uses PicoGraphics to set up the display and draw some text on the screen.
 
@@ -56,20 +54,19 @@ The four buttons, A, B, X and Y have corresponding constants set to their respec
 Button(button, invert=True, repeat_time=200, hold_time=1000)
 ```
 
-To set up the buttons, first import the `Button` class from the `pimoroni` module and the pin constants from `picoexplorer`:
+To set up the buttons, first import the `Button` class from the `pimoroni` module:
 
 ```
 from pimoroni import Button
-import picoexplorer
 ```
 
-Then create instances of `Button` using our constants:
+Then create instances of `Button` using the correct pin numbers:
 
 ```
-button_a = Button(picoexplorer.BUTTON_A)
-button_b = Button(picoexplorer.BUTTON_B)
-button_x = Button(picoexplorer.BUTTON_X)
-button_y = Button(picoexplorer.BUTTON_Y)
+button_a = Button(12)
+button_b = Button(13)
+button_x = Button(14)
+button_y = Button(15)
 ```
 
 To get the button state, call `.read()`. If the button is held down, then this will return `True` at the interval specified by `repeat_time` until `hold_time` is reached, at which point it will return `True` every `repeat_time / 3` milliseconds. This is useful for rapidly increasing/decreasing values:
@@ -88,19 +85,18 @@ state = button_a.raw()
 
 Pico Explorer's ADC channels are connected to Pico's ADC-capable pins (26, 27 and 28). You can read the voltages from them using the `Analog` class in the shared `pimoroni` module.
 
-First import the `Analog` class from the `pimoroni` module and the pin constants from `picoexplorer`:
+First import the `Analog` class from the `pimoroni` module:
 
 ```
 from pimoroni import Analog
-import pico explorer
 ```
 
-Then create instances of `Analog` using our constants:
+Then create instances of `Analog` using the correct pin numbers:
 
 ```python
- adc0 = Analog(picoexplorer.ADC0)
- adc1 = Analog(picoexplorer.ADC1)
- adc2 = Analog(picoexplorer.ADC2)
+ adc0 = Analog(26)
+ adc1 = Analog(27)
+ adc2 = Analog(28)
 ```
 
 And read them like this
@@ -111,26 +107,25 @@ reading =  adc0.read_voltage()
 
 ### Motors
 
-Motors are driven by PWM via an onboard DRV8833.  We'd recommend using our fully featured Motor library to drive them - here's a quick example:
+Motors are driven by PWM via an onboard DRV8833.  We'd recommend using our fully featured Motor library to drive them - here's a quick example for how to drive motor 1:
 
 ``` python
-import picoexplorer
 from motor import Motor
 import time
 
-m = Motor(picoexplorer.MOTOR_1)
+m1 = Motor((8, 9))
 
-m.enable()
+m1.enable()
 
 # run the motor full speed in one direction for 2 seconds
-m.speed(1.0)
+m1.speed(1.0)
 time.sleep(2)
 
 # and in the opposite direction for 2 seconds
-m.speed(-1.0)
+m1.speed(-1.0)
 time.sleep(2)
 
-m.disable()
+m1.disable()
 ```
 
 You can find much more info about working with motors in the [Motor library documentation](https://github.com/pimoroni/pimoroni-pico/tree/main/micropython/modules/motor).
@@ -139,19 +134,18 @@ The red LED next to the motor connectors is part of the motor driver circuit - i
 
 ### Audio
 
-To make noise with Explorer, you must select one of the GP0 to GP7 pins to PWM for audio. You'll then need to connect this pin to AUDIO with a jumper wire.
+To make noise with Explorer, you must select one of the GP0 to GP7 pins to PWM for audio (We're using GP0 in the code below). You'll then need to connect this pin to AUDIO with a jumper wire.
 
-To set up the buzzer, first import the `Buzzer` class from the `pimoroni` module and the pin constants from `picoexplorer`:
+To set up the buzzer, first import the `Buzzer` class from the `pimoroni` module:
 
 ``` python
 from pimoroni import Buzzer
-import picoexplorer
 ```
 
 Then create a `Buzzer` instance:
 
 ``` python
-BUZZER = Buzzer(picoexplorer.GP0)
+BUZZER = Buzzer(0)
 ```
 
 You can then play audio tones like this - frequency should probably be a number between 1 and 5000 if you have human ears. 
@@ -194,7 +188,7 @@ The slots at the top of the board let you plug (I2C) Breakout Garden breakouts i
 
 - [List of Pico-compatible breakouts](https://github.com/pimoroni/pimoroni-pico/blob/main/README.md#breakouts)
 
-Pico Explorer uses GP20 and GP21 for its I2C interface - these pins differ from our default Breakout Garden pins so you will specify you're using a Pico Explorer when running breakout examples. You can use the constants in the shared `pimoroni` module to set up the I2C interface:
+Pico Explorer uses GP20 and GP21 for its I2C interface - these pins differ from our default Breakout Garden pins so you will need to specify you're using a Pico Explorer when running breakout examples. You can use the constants in the shared `pimoroni` module to set up the I2C interface:
 
 ``` python
 from pimoroni_i2c import PimoroniI2C
@@ -210,24 +204,50 @@ from pimoroni_i2c import PimoroniI2C
 
 i2c = PimoroniI2C(sda=(20), scl=(21))
 ```
-## Pin Constants
+## Pins
 
-Here's a list of constants that are available in `picoexplorer`, and the pin numbers that they correspond to on the Pico.
+Here's a list of the pins associated with the various features of Pico Explorer. You can also find a list of pins on the underneath of the board!
 
-**Buttons**
+**GPIO (General Purpose Input Output) pins**
 
-- `BUTTON_A` = `12`
-- `BUTTON_B` = `13`
-- `BUTTON_X` = `14`
-- `BUTTON_Y` = `15`
+- GP0 = `0`
+- GP1 = `1`
+- GP2 = `2`
+- GP3 = `3`
+- GP4 = `4`
+- GP5 = `5`
+- GP6 = `6`
+- GP7 = `7`
 
-**ADC**
+**Buttons/Switches**
 
-- `ADC0` = `26`
-- `ADC1` = `27`
-- `ADC2` = `28`
+- Button A = `12`
+- Button B = `13`
+- Button X = `14`
+- Button Y = `15`
 
 **Motors**
 
-- `MOTOR_1` = `8, 9`
-- `MOTOR_2` = `10, 11`
+- Motor 1 (-) = `8`
+- Motor 1 (+) = `9`
+- Motor 2 (-) = `10`
+- Motor 2 (+) = `11`
+
+**SPI pins (used for the display)**
+
+- SPI MISO - `16`
+- LCD CS - `17`
+- SPI SCK - `18`
+- SPI MOSI - `19`
+
+**I2C pins**
+
+- I2C SDA - `20`
+- I2C SCL - `21`
+- I2C INT - `22`
+
+**Analog pins**
+
+- ADC0 = `26`
+- ADC1 = `27`
+- ADC2 = `28`

--- a/micropython/modules/pico_explorer/README.md
+++ b/micropython/modules/pico_explorer/README.md
@@ -109,7 +109,7 @@ reading =  adc0.read_voltage()
 
 Motors are driven by PWM via an onboard DRV8833.  We'd recommend using our fully featured Motor library to drive them - here's a quick example for how to drive motor 1:
 
-``` python
+```python
 from motor import Motor
 import time
 
@@ -138,25 +138,25 @@ To make noise with Explorer, you must select one of the GP0 to GP7 pins to PWM f
 
 To set up the buzzer, first import the `Buzzer` class from the `pimoroni` module:
 
-``` python
+```python
 from pimoroni import Buzzer
 ```
 
 Then create a `Buzzer` instance:
 
-``` python
-BUZZER = Buzzer(0)
+```python
+buzzer = Buzzer(0)
 ```
 
 You can then play audio tones like this - frequency should probably be a number between 1 and 5000 if you have human ears. 
 
-``` python
+```python
 buzzer.set_tone(frequency)
 ```
 
 To make the buzzer be quiet, you can:
 
-``` python
+```python
 buzzer.set_tone(0)
 ```
 
@@ -176,8 +176,8 @@ You can also use these pins as outputs, if you wanted to connect up stuff like L
 import machine
 
 GPO = machine.Pin(0, machine.Pin.OUT)
-
 ```
+
 Note that if you're connecting external LEDs up to Explorer Base, GP0-7 have built in 100 Ohm resistors, so you don't need to include a resistor in your circuit to protect your LED from drawing too much current.
 
 There's lots more info about how to use `machine` in the [Raspberry Pi documentation](https://www.raspberrypi.org/documentation/rp2040/getting-started/#getting-started-with-micropython).
@@ -190,7 +190,7 @@ The slots at the top of the board let you plug (I2C) Breakout Garden breakouts i
 
 Pico Explorer uses GP20 and GP21 for its I2C interface - these pins differ from our default Breakout Garden pins so you will need to specify you're using a Pico Explorer when running breakout examples. You can use the constants in the shared `pimoroni` module to set up the I2C interface:
 
-``` python
+```python
 from pimoroni_i2c import PimoroniI2C
 from pimoroni import PICO_EXPLORER_I2C_PINS
 
@@ -199,11 +199,12 @@ i2c = PimoroniI2C(**PICO_EXPLORER_I2C_PINS)
 
 Alternatively, you can specify the pin numbers directly:
 
-``` python
+```python
 from pimoroni_i2c import PimoroniI2C
 
 i2c = PimoroniI2C(sda=(20), scl=(21))
 ```
+
 ## Pins
 
 Here's a list of the pins associated with the various features of Pico Explorer. You can also find a list of pins on the underneath of the board!


### PR DESCRIPTION
The constants in the `picoexplorer` module were available in the Pico build but not the Pico W build, which was causing confusion. 

Removed remaining references to the old picoexplorer module and updated docs and examples to use pin numbers instead of constants (which makes more sense for Explorer, as it has a handy pin number reference on the bottom of the board). I guess `picoexplorer` can now be removed from all builds!

I've also updated a few display examples that escaped my last rush of Picographics updates.

Fixes #499 