### PR TITLE
MicroPython: Bump PicoW to 4903e48.

### DIFF
--- a/.github/workflows/micropython-picow.yml
+++ b/.github/workflows/micropython-picow.yml
@@ -7,7 +7,7 @@ on:
     types: [created]
 
 env:
-  MICROPYTHON_VERSION: 9dfabcd6d3d080aced888e8474e921f11dc979bb
+  MICROPYTHON_VERSION: 4903e48e340bd9741577f30cacb31605cc70cf20
 
 jobs:
   deps:

--- a/micropython/_board/picow_enviro/PICO_W_ENVIRO/manifest.py
+++ b/micropython/_board/picow_enviro/PICO_W_ENVIRO/manifest.py
@@ -2,7 +2,5 @@ include("../manifest.py")
 
 freeze("$(MPY_DIR)/tools", "upip.py")
 freeze("$(MPY_DIR)/tools", "upip_utarfile.py")
-
-if os.path.isdir(convert_path("$(MPY_LIB_DIR)")):
-    freeze("$(MPY_LIB_DIR)/python-ecosys/urequests", "urequests.py")
-    freeze("$(MPY_LIB_DIR)/micropython/umqtt.simple", "umqtt")
+freeze("$(MPY_LIB_DIR)/python-ecosys/urequests", "urequests.py")
+freeze("$(MPY_LIB_DIR)/micropython/umqtt.simple", "umqtt")

--- a/micropython/_board/picow_enviro/PICO_W_ENVIRO/manifest.py
+++ b/micropython/_board/picow_enviro/PICO_W_ENVIRO/manifest.py
@@ -1,6 +1,7 @@
 include("../manifest.py")
 
-freeze("$(MPY_DIR)/tools", "upip.py")
-freeze("$(MPY_DIR)/tools", "upip_utarfile.py")
-freeze("$(MPY_LIB_DIR)/python-ecosys/urequests", "urequests.py")
-freeze("$(MPY_LIB_DIR)/micropython/umqtt.simple", "umqtt")
+module("upip.py", base_path="$(MPY_DIR)/tools", opt=3)
+module("upip_utarfile.py", base_path="$(MPY_DIR)/tools", opt=3)
+
+require("urequests")
+require("umqtt.simple")


### PR DESCRIPTION
Full diff from current commit - https://github.com/micropython/micropython/compare/9dfabcd6d3d080aced888e8474e921f11dc979bb...4903e48e340bd9741577f30cacb31605cc70cf20

Notable changes from us:
* Mark GC_HEAP "NOLOAD" for faster boot - https://github.com/micropython/micropython/commit/71f6eb5ac953637e815ec9c5cbc785b4027a8759
* Add start/len support to rp2.Flash() constructor.  - https://github.com/micropython/micropython/commit/6aa3c946347281875165392c09753547d8c77fc3
