### PR TITLE
set pen for text to 15 for better visibility

### DIFF
--- a/examples/inky_pack/inky_pack_demo.cpp
+++ b/examples/inky_pack/inky_pack_demo.cpp
@@ -46,7 +46,7 @@ int main() {
     graphics.set_pen(0);
     graphics.clear();
 
-    graphics.set_pen(1);
+    graphics.set_pen(15);
     graphics.set_font("bitmap8");
     graphics.text("Hello World", {0, 0}, 296);
     graphics.text("Has this worked?!", {0, 16}, 296);


### PR DESCRIPTION
I am using the inky pack. When setting the pen to 1 to write text against a black background (pen = 0), the text is not legible.  Setting it to 15 (white) is much more legible and serves as a much better demo.