### PR TITLE
MicroPython: Update to support new slots mp_obj_type_t.

### DIFF
--- a/.github/workflows/micropython-badger2040.yml
+++ b/.github/workflows/micropython-badger2040.yml
@@ -7,7 +7,7 @@ on:
     types: [created]
 
 env:
-  MICROPYTHON_VERSION: eefd946e60aba3ac61c7bfbd0272d07be289e3f3
+  MICROPYTHON_VERSION: d1ed0f161099175319bbdb7a3546634c4a8c2b25
   BOARD_TYPE: PIMORONI_BADGER2040
   # MicroPython version will be contained in github.event.release.tag_name for releases
   RELEASE_FILE: pimoroni-badger2040-${{github.event.release.tag_name || github.sha}}-micropython

--- a/.github/workflows/micropython-badger2040.yml
+++ b/.github/workflows/micropython-badger2040.yml
@@ -7,7 +7,7 @@ on:
     types: [created]
 
 env:
-  MICROPYTHON_VERSION: bb77c1d5a37feab6bc386ca189bacc0c4cecada3
+  MICROPYTHON_VERSION: 699477d12d1aa1cb57ff6cfc3f5dc5e97524dbe6
   BOARD_TYPE: PIMORONI_BADGER2040
   # MicroPython version will be contained in github.event.release.tag_name for releases
   RELEASE_FILE: pimoroni-badger2040-${{github.event.release.tag_name || github.sha}}-micropython

--- a/.github/workflows/micropython-badger2040.yml
+++ b/.github/workflows/micropython-badger2040.yml
@@ -7,7 +7,7 @@ on:
     types: [created]
 
 env:
-  MICROPYTHON_VERSION: 9dfabcd6d3d080aced888e8474e921f11dc979bb
+  MICROPYTHON_VERSION: eefd946e60aba3ac61c7bfbd0272d07be289e3f3
   BOARD_TYPE: PIMORONI_BADGER2040
   # MicroPython version will be contained in github.event.release.tag_name for releases
   RELEASE_FILE: pimoroni-badger2040-${{github.event.release.tag_name || github.sha}}-micropython

--- a/.github/workflows/micropython-badger2040.yml
+++ b/.github/workflows/micropython-badger2040.yml
@@ -7,7 +7,7 @@ on:
     types: [created]
 
 env:
-  MICROPYTHON_VERSION: d1ed0f161099175319bbdb7a3546634c4a8c2b25
+  MICROPYTHON_VERSION: bb77c1d5a37feab6bc386ca189bacc0c4cecada3
   BOARD_TYPE: PIMORONI_BADGER2040
   # MicroPython version will be contained in github.event.release.tag_name for releases
   RELEASE_FILE: pimoroni-badger2040-${{github.event.release.tag_name || github.sha}}-micropython

--- a/.github/workflows/micropython-picow.yml
+++ b/.github/workflows/micropython-picow.yml
@@ -7,7 +7,7 @@ on:
     types: [created]
 
 env:
-  MICROPYTHON_VERSION: 4903e48e340bd9741577f30cacb31605cc70cf20
+  MICROPYTHON_VERSION: 46d02c2469ec7947fe3aae2d68e07236baf5c72e
 
 jobs:
   deps:

--- a/.github/workflows/micropython-picow.yml
+++ b/.github/workflows/micropython-picow.yml
@@ -7,7 +7,7 @@ on:
     types: [created]
 
 env:
-  MICROPYTHON_VERSION: eefd946e60aba3ac61c7bfbd0272d07be289e3f3
+  MICROPYTHON_VERSION: d1ed0f161099175319bbdb7a3546634c4a8c2b25
 
 jobs:
   deps:

--- a/.github/workflows/micropython-picow.yml
+++ b/.github/workflows/micropython-picow.yml
@@ -7,7 +7,7 @@ on:
     types: [created]
 
 env:
-  MICROPYTHON_VERSION: 9dfabcd6d3d080aced888e8474e921f11dc979bb
+  MICROPYTHON_VERSION: 4903e48e340bd9741577f30cacb31605cc70cf20
 
 jobs:
   deps:

--- a/.github/workflows/micropython-picow.yml
+++ b/.github/workflows/micropython-picow.yml
@@ -7,7 +7,7 @@ on:
     types: [created]
 
 env:
-  MICROPYTHON_VERSION: d1ed0f161099175319bbdb7a3546634c4a8c2b25
+  MICROPYTHON_VERSION: bb77c1d5a37feab6bc386ca189bacc0c4cecada3
 
 jobs:
   deps:

--- a/.github/workflows/micropython-picow.yml
+++ b/.github/workflows/micropython-picow.yml
@@ -7,7 +7,7 @@ on:
     types: [created]
 
 env:
-  MICROPYTHON_VERSION: bb77c1d5a37feab6bc386ca189bacc0c4cecada3
+  MICROPYTHON_VERSION: 699477d12d1aa1cb57ff6cfc3f5dc5e97524dbe6
 
 jobs:
   deps:

--- a/.github/workflows/micropython-picow.yml
+++ b/.github/workflows/micropython-picow.yml
@@ -7,7 +7,7 @@ on:
     types: [created]
 
 env:
-  MICROPYTHON_VERSION: 46d02c2469ec7947fe3aae2d68e07236baf5c72e
+  MICROPYTHON_VERSION: eefd946e60aba3ac61c7bfbd0272d07be289e3f3
 
 jobs:
   deps:

--- a/.github/workflows/micropython.yml
+++ b/.github/workflows/micropython.yml
@@ -7,7 +7,7 @@ on:
     types: [created]
 
 env:
-  MICROPYTHON_VERSION: eefd946e60aba3ac61c7bfbd0272d07be289e3f3
+  MICROPYTHON_VERSION: d1ed0f161099175319bbdb7a3546634c4a8c2b25
 
 jobs:
   deps:

--- a/.github/workflows/micropython.yml
+++ b/.github/workflows/micropython.yml
@@ -7,7 +7,7 @@ on:
     types: [created]
 
 env:
-  MICROPYTHON_VERSION: v1.19
+  MICROPYTHON_VERSION: eefd946e60aba3ac61c7bfbd0272d07be289e3f3
 
 jobs:
   deps:

--- a/.github/workflows/micropython.yml
+++ b/.github/workflows/micropython.yml
@@ -7,7 +7,7 @@ on:
     types: [created]
 
 env:
-  MICROPYTHON_VERSION: d1ed0f161099175319bbdb7a3546634c4a8c2b25
+  MICROPYTHON_VERSION: bb77c1d5a37feab6bc386ca189bacc0c4cecada3
 
 jobs:
   deps:

--- a/.github/workflows/micropython.yml
+++ b/.github/workflows/micropython.yml
@@ -7,7 +7,7 @@ on:
     types: [created]
 
 env:
-  MICROPYTHON_VERSION: bb77c1d5a37feab6bc386ca189bacc0c4cecada3
+  MICROPYTHON_VERSION: 699477d12d1aa1cb57ff6cfc3f5dc5e97524dbe6
 
 jobs:
   deps:

--- a/.gitmodules
+++ b/.gitmodules
@@ -17,6 +17,7 @@
 [submodule "micropython/modules/qrcode"]
 	path = micropython/modules/qrcode
 	url = https://github.com/pimoroni/QR-Code-Generator
+	branch = micropython/mp_obj_type_t_upgrade
 [submodule "drivers/vl53l5cx/src"]
 	path = drivers/vl53l5cx/src
 	url = https://github.com/ST-mirror/VL53L5CX_ULD_driver

--- a/micropython/_board/picow_enviro/PICO_W_ENVIRO/manifest.py
+++ b/micropython/_board/picow_enviro/PICO_W_ENVIRO/manifest.py
@@ -1,7 +1,6 @@
 include("../manifest.py")
 
-module("upip.py", base_path="$(MPY_DIR)/tools", opt=3)
-module("upip_utarfile.py", base_path="$(MPY_DIR)/tools", opt=3)
-
+require("mip")
+require("ntptime")
 require("urequests")
 require("umqtt.simple")

--- a/micropython/_board/picow_enviro/PICO_W_ENVIRO/manifest.py
+++ b/micropython/_board/picow_enviro/PICO_W_ENVIRO/manifest.py
@@ -2,7 +2,5 @@ include("../manifest.py")
 
 freeze("$(MPY_DIR)/tools", "upip.py")
 freeze("$(MPY_DIR)/tools", "upip_utarfile.py")
-
-if os.path.isdir(convert_path("$(MPY_LIB_DIR)")):
-    freeze("$(MPY_LIB_DIR)/python-ecosys/urequests", "urequests.py")
-    freeze("$(MPY_LIB_DIR)/micropython/umqtt.simple", "umqtt")
+freeze("$(MPY_LIB_DIR)/python-ecosys/urequests", "urequests.py")
+freeze("$(MPY_LIB_DIR)/micropython/umqtt.simple", "umqtt")

--- a/micropython/_board/picow_enviro/PICO_W_ENVIRO/manifest.py
+++ b/micropython/_board/picow_enviro/PICO_W_ENVIRO/manifest.py
@@ -1,6 +1,7 @@
 include("../manifest.py")
 
-freeze("$(MPY_DIR)/tools", "upip.py")
-freeze("$(MPY_DIR)/tools", "upip_utarfile.py")
-freeze("$(MPY_LIB_DIR)/python-ecosys/urequests", "urequests.py")
-freeze("$(MPY_LIB_DIR)/micropython/umqtt.simple", "umqtt")
+module("upip.py", base_path="$(MPY_DIR)/tools", opt=3)
+module("upip_utarfile.py", base_path="$(MPY_DIR)/tools", opt=3)
+
+require("urequests")
+require("umqtt.simple")

--- a/micropython/_board/picow_inky_frame/PICO_W_INKY/manifest.py
+++ b/micropython/_board/picow_inky_frame/PICO_W_INKY/manifest.py
@@ -1,8 +1,6 @@
 include("../manifest.py")
 
-freeze("$(MPY_DIR)/tools", "upip.py")
-freeze("$(MPY_DIR)/tools", "upip_utarfile.py")
-
-if os.path.isdir(convert_path("$(MPY_LIB_DIR)")):
-    freeze("$(MPY_LIB_DIR)/python-ecosys/urequests", "urequests.py")
-    freeze("$(MPY_LIB_DIR)/micropython/umqtt.simple", "umqtt")
+require("mip")
+require("ntptime")
+require("urequests")
+require("umqtt.simple")

--- a/micropython/modules/adcfft/adcfft.c
+++ b/micropython/modules/adcfft/adcfft.c
@@ -13,12 +13,22 @@ STATIC const mp_rom_map_elem_t adcfft_locals_dict_table[] = {
 
 STATIC MP_DEFINE_CONST_DICT(adcfft_locals_dict, adcfft_locals_dict_table);
 
+#ifdef MP_DEFINE_CONST_OBJ_TYPE
+MP_DEFINE_CONST_OBJ_TYPE(
+    adcfft_type,
+    MP_QSTR_ADCFFT,
+    MP_TYPE_FLAG_NONE,
+    make_new, adcfft_make_new,
+    locals_dict, (mp_obj_dict_t*)&adcfft_locals_dict
+);
+#else
 const mp_obj_type_t adcfft_type = {
     { &mp_type_type },
     .name = MP_QSTR_ADCFFT,
     .make_new = adcfft_make_new,
     .locals_dict = (mp_obj_dict_t*)&adcfft_locals_dict,
 };
+#endif
 
 // Module
 STATIC const mp_map_elem_t adcfft_globals_table[] = {

--- a/micropython/modules/badger2040/badger2040.c
+++ b/micropython/modules/badger2040/badger2040.c
@@ -75,12 +75,22 @@ STATIC const mp_rom_map_elem_t Badger2040_locals_dict_table[] = {
 STATIC MP_DEFINE_CONST_DICT(Badger2040_locals_dict, Badger2040_locals_dict_table);
 
 /***** Class Definition *****/
+#ifdef MP_DEFINE_CONST_OBJ_TYPE
+MP_DEFINE_CONST_OBJ_TYPE(
+    Badger2040_type,
+    MP_QSTR_Badger2040,
+    MP_TYPE_FLAG_NONE,
+    make_new, Badger2040_make_new,
+    locals_dict, (mp_obj_dict_t*)&Badger2040_locals_dict
+);
+#else
 const mp_obj_type_t Badger2040_type = {
     { &mp_type_type },
     .name = MP_QSTR_Badger2040,
     .make_new = Badger2040_make_new,
     .locals_dict = (mp_obj_dict_t*)&Badger2040_locals_dict,
 };
+#endif
 
 /***** Globals Table *****/
 

--- a/micropython/modules/breakout_as7262/breakout_as7262.c
+++ b/micropython/modules/breakout_as7262/breakout_as7262.c
@@ -57,12 +57,22 @@ STATIC const mp_rom_map_elem_t BreakoutAS7262_locals_dict_table[] = {
 STATIC MP_DEFINE_CONST_DICT(BreakoutAS7262_locals_dict, BreakoutAS7262_locals_dict_table);
 
 /***** Class Definition *****/
+#ifdef MP_DEFINE_CONST_OBJ_TYPE
+MP_DEFINE_CONST_OBJ_TYPE(
+    breakout_as7262_BreakoutAS7262_type,
+    MP_QSTR_BreakoutAS7262,
+    MP_TYPE_FLAG_NONE,
+    make_new, BreakoutAS7262_make_new,
+    locals_dict, (mp_obj_dict_t*)&BreakoutAS7262_locals_dict
+);
+#else
 const mp_obj_type_t breakout_as7262_BreakoutAS7262_type = {
     { &mp_type_type },
     .name = MP_QSTR_BreakoutAS7262,
     .make_new = BreakoutAS7262_make_new,
     .locals_dict = (mp_obj_dict_t*)&BreakoutAS7262_locals_dict,
 };
+#endif
 
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/micropython/modules/breakout_bh1745/breakout_bh1745.c
+++ b/micropython/modules/breakout_bh1745/breakout_bh1745.c
@@ -28,12 +28,22 @@ STATIC const mp_rom_map_elem_t BreakoutBH1745_locals_dict_table[] = {
 STATIC MP_DEFINE_CONST_DICT(BreakoutBH1745_locals_dict, BreakoutBH1745_locals_dict_table);
 
 /***** Class Definition *****/
+#ifdef MP_DEFINE_CONST_OBJ_TYPE
+MP_DEFINE_CONST_OBJ_TYPE(
+    breakout_bh1745_BreakoutBH1745_type,
+    MP_QSTR_BreakoutBH1745,
+    MP_TYPE_FLAG_NONE,
+    make_new, BreakoutBH1745_make_new,
+    locals_dict, (mp_obj_dict_t*)&BreakoutBH1745_locals_dict
+);
+#else
 const mp_obj_type_t breakout_bh1745_BreakoutBH1745_type = {
     { &mp_type_type },
     .name = MP_QSTR_BreakoutBH1745,
     .make_new = BreakoutBH1745_make_new,
     .locals_dict = (mp_obj_dict_t*)&BreakoutBH1745_locals_dict,
 };
+#endif
 
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/micropython/modules/breakout_bme280/breakout_bme280.c
+++ b/micropython/modules/breakout_bme280/breakout_bme280.c
@@ -16,12 +16,22 @@ STATIC const mp_rom_map_elem_t BreakoutBME280_locals_dict_table[] = {
 STATIC MP_DEFINE_CONST_DICT(BreakoutBME280_locals_dict, BreakoutBME280_locals_dict_table);
 
 /***** Class Definition *****/
+#ifdef MP_DEFINE_CONST_OBJ_TYPE
+MP_DEFINE_CONST_OBJ_TYPE(
+    breakout_bme280_BreakoutBME280_type,
+    MP_QSTR_BreakoutBME280,
+    MP_TYPE_FLAG_NONE,
+    make_new, BreakoutBME280_make_new,
+    locals_dict, (mp_obj_dict_t*)&BreakoutBME280_locals_dict
+);
+#else
 const mp_obj_type_t breakout_bme280_BreakoutBME280_type = {
     { &mp_type_type },
     .name = MP_QSTR_BreakoutBME280,
     .make_new = BreakoutBME280_make_new,
     .locals_dict = (mp_obj_dict_t*)&BreakoutBME280_locals_dict,
 };
+#endif
 
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/micropython/modules/breakout_bme68x/breakout_bme68x.c
+++ b/micropython/modules/breakout_bme68x/breakout_bme68x.c
@@ -15,13 +15,22 @@ STATIC const mp_rom_map_elem_t BreakoutBME68X_locals_dict_table[] = {
 STATIC MP_DEFINE_CONST_DICT(BreakoutBME68X_locals_dict, BreakoutBME68X_locals_dict_table);
 
 /***** Class Definition *****/
+#ifdef MP_DEFINE_CONST_OBJ_TYPE
+MP_DEFINE_CONST_OBJ_TYPE(
+    breakout_bme68x_BreakoutBME68X_type,
+    MP_QSTR_BreakoutBME68X,
+    MP_TYPE_FLAG_NONE,
+    make_new, BreakoutBME68X_make_new,
+    locals_dict, (mp_obj_dict_t*)&BreakoutBME68X_locals_dict
+);
+#else
 const mp_obj_type_t breakout_bme68x_BreakoutBME68X_type = {
     { &mp_type_type },
     .name = MP_QSTR_BreakoutBME68X,
     .make_new = BreakoutBME68X_make_new,
     .locals_dict = (mp_obj_dict_t*)&BreakoutBME68X_locals_dict,
 };
-
+#endif
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // breakout_bme68x Module

--- a/micropython/modules/breakout_bmp280/breakout_bmp280.c
+++ b/micropython/modules/breakout_bmp280/breakout_bmp280.c
@@ -16,12 +16,22 @@ STATIC const mp_rom_map_elem_t BreakoutBMP280_locals_dict_table[] = {
 STATIC MP_DEFINE_CONST_DICT(BreakoutBMP280_locals_dict, BreakoutBMP280_locals_dict_table);
 
 /***** Class Definition *****/
+#ifdef MP_DEFINE_CONST_OBJ_TYPE
+MP_DEFINE_CONST_OBJ_TYPE(
+    breakout_bmp280_BreakoutBMP280_type,
+    MP_QSTR_BreakoutBMP280,
+    MP_TYPE_FLAG_NONE,
+    make_new, BreakoutBMP280_make_new,
+    locals_dict, (mp_obj_dict_t*)&BreakoutBMP280_locals_dict
+);
+#else
 const mp_obj_type_t breakout_bmp280_BreakoutBMP280_type = {
     { &mp_type_type },
     .name = MP_QSTR_BreakoutBMP280,
     .make_new = BreakoutBMP280_make_new,
     .locals_dict = (mp_obj_dict_t*)&BreakoutBMP280_locals_dict,
 };
+#endif
 
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/micropython/modules/breakout_dotmatrix/breakout_dotmatrix.c
+++ b/micropython/modules/breakout_dotmatrix/breakout_dotmatrix.c
@@ -28,12 +28,22 @@ STATIC const mp_rom_map_elem_t BreakoutDotMatrix_locals_dict_table[] = {
 STATIC MP_DEFINE_CONST_DICT(BreakoutDotMatrix_locals_dict, BreakoutDotMatrix_locals_dict_table);
 
 /***** Class Definition *****/
+#ifdef MP_DEFINE_CONST_OBJ_TYPE
+MP_DEFINE_CONST_OBJ_TYPE(
+    breakout_dotmatrix_BreakoutDotMatrix_type,
+    MP_QSTR_BreakoutDotMatrix,
+    MP_TYPE_FLAG_NONE,
+    make_new, BreakoutDotMatrix_make_new,
+    locals_dict, (mp_obj_dict_t*)&BreakoutDotMatrix_locals_dict
+);
+#else
 const mp_obj_type_t breakout_dotmatrix_BreakoutDotMatrix_type = {
     { &mp_type_type },
     .name = MP_QSTR_BreakoutDotMatrix,
     .make_new = BreakoutDotMatrix_make_new,
     .locals_dict = (mp_obj_dict_t*)&BreakoutDotMatrix_locals_dict,
 };
+#endif
 
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/micropython/modules/breakout_encoder/breakout_encoder.c
+++ b/micropython/modules/breakout_encoder/breakout_encoder.c
@@ -34,12 +34,22 @@ STATIC const mp_rom_map_elem_t BreakoutEncoder_locals_dict_table[] = {
 STATIC MP_DEFINE_CONST_DICT(BreakoutEncoder_locals_dict, BreakoutEncoder_locals_dict_table);
 
 /***** Class Definition *****/
+#ifdef MP_DEFINE_CONST_OBJ_TYPE
+MP_DEFINE_CONST_OBJ_TYPE(
+    breakout_encoder_BreakoutEncoder_type,
+    MP_QSTR_BreakoutEncoder,
+    MP_TYPE_FLAG_NONE,
+    make_new, BreakoutEncoder_make_new,
+    locals_dict, (mp_obj_dict_t*)&BreakoutEncoder_locals_dict
+);
+#else
 const mp_obj_type_t breakout_encoder_BreakoutEncoder_type = {
     { &mp_type_type },
     .name = MP_QSTR_BreakoutEncoder,
     .make_new = BreakoutEncoder_make_new,
     .locals_dict = (mp_obj_dict_t*)&BreakoutEncoder_locals_dict,
 };
+#endif
 
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/micropython/modules/breakout_icp10125/breakout_icp10125.c
+++ b/micropython/modules/breakout_icp10125/breakout_icp10125.c
@@ -22,12 +22,22 @@ STATIC const mp_rom_map_elem_t BreakoutICP10125_locals_dict_table[] = {
 STATIC MP_DEFINE_CONST_DICT(BreakoutICP10125_locals_dict, BreakoutICP10125_locals_dict_table);
 
 /***** Class Definition *****/
+#ifdef MP_DEFINE_CONST_OBJ_TYPE
+MP_DEFINE_CONST_OBJ_TYPE(
+    breakout_icp10125_BreakoutICP10125_type,
+    MP_QSTR_BreakoutICP10125,
+    MP_TYPE_FLAG_NONE,
+    make_new, BreakoutICP10125_make_new,
+    locals_dict, (mp_obj_dict_t*)&BreakoutICP10125_locals_dict
+);
+#else
 const mp_obj_type_t breakout_icp10125_BreakoutICP10125_type = {
     { &mp_type_type },
     .name = MP_QSTR_BreakoutICP10125,
     .make_new = BreakoutICP10125_make_new,
     .locals_dict = (mp_obj_dict_t*)&BreakoutICP10125_locals_dict,
 };
+#endif
 
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/micropython/modules/breakout_ioexpander/breakout_ioexpander.c
+++ b/micropython/modules/breakout_ioexpander/breakout_ioexpander.c
@@ -63,13 +63,22 @@ STATIC const mp_rom_map_elem_t BreakoutIOExpander_locals_dict_table[] = {
 STATIC MP_DEFINE_CONST_DICT(BreakoutIOExpander_locals_dict, BreakoutIOExpander_locals_dict_table);
 
 /***** Class Definition *****/
+#ifdef MP_DEFINE_CONST_OBJ_TYPE
+MP_DEFINE_CONST_OBJ_TYPE(
+    breakout_ioexpander_BreakoutIOExpander_type,
+    MP_QSTR_BreakoutIOExpander,
+    MP_TYPE_FLAG_NONE,
+    make_new, BreakoutIOExpander_make_new,
+    locals_dict, (mp_obj_dict_t*)&BreakoutIOExpander_locals_dict
+);
+#else
 const mp_obj_type_t breakout_ioexpander_BreakoutIOExpander_type = {
     { &mp_type_type },
     .name = MP_QSTR_BreakoutIOExpander,
     .make_new = BreakoutIOExpander_make_new,
     .locals_dict = (mp_obj_dict_t*)&BreakoutIOExpander_locals_dict,
 };
-
+#endif
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // breakout_ioexpander Module

--- a/micropython/modules/breakout_ltr559/breakout_ltr559.c
+++ b/micropython/modules/breakout_ltr559/breakout_ltr559.c
@@ -45,12 +45,22 @@ STATIC const mp_rom_map_elem_t BreakoutLTR559_locals_dict_table[] = {
 STATIC MP_DEFINE_CONST_DICT(BreakoutLTR559_locals_dict, BreakoutLTR559_locals_dict_table);
 
 /***** Class Definition *****/
+#ifdef MP_DEFINE_CONST_OBJ_TYPE
+MP_DEFINE_CONST_OBJ_TYPE(
+    breakout_ltr559_BreakoutLTR559_type,
+    MP_QSTR_BreakoutLTR559,
+    MP_TYPE_FLAG_NONE,
+    make_new, BreakoutLTR559_make_new,
+    locals_dict, (mp_obj_dict_t*)&BreakoutLTR559_locals_dict
+);
+#else
 const mp_obj_type_t breakout_ltr559_BreakoutLTR559_type = {
     { &mp_type_type },
     .name = MP_QSTR_BreakoutLTR559,
     .make_new = BreakoutLTR559_make_new,
     .locals_dict = (mp_obj_dict_t*)&BreakoutLTR559_locals_dict,
 };
+#endif
 
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/micropython/modules/breakout_matrix11x7/breakout_matrix11x7.c
+++ b/micropython/modules/breakout_matrix11x7/breakout_matrix11x7.c
@@ -20,12 +20,22 @@ STATIC const mp_rom_map_elem_t BreakoutMatrix11x7_locals_dict_table[] = {
 STATIC MP_DEFINE_CONST_DICT(BreakoutMatrix11x7_locals_dict, BreakoutMatrix11x7_locals_dict_table);
 
 /***** Class Definition *****/
+#ifdef MP_DEFINE_CONST_OBJ_TYPE
+MP_DEFINE_CONST_OBJ_TYPE(
+    breakout_matrix11x7_BreakoutMatrix11x7_type,
+    MP_QSTR_BreakoutMatrix11x7,
+    MP_TYPE_FLAG_NONE,
+    make_new, BreakoutMatrix11x7_make_new,
+    locals_dict, (mp_obj_dict_t*)&BreakoutMatrix11x7_locals_dict
+);
+#else
 const mp_obj_type_t breakout_matrix11x7_BreakoutMatrix11x7_type = {
     { &mp_type_type },
     .name = MP_QSTR_BreakoutMatrix11x7,
     .make_new = BreakoutMatrix11x7_make_new,
     .locals_dict = (mp_obj_dict_t*)&BreakoutMatrix11x7_locals_dict,
 };
+#endif
 
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/micropython/modules/breakout_mics6814/breakout_mics6814.c
+++ b/micropython/modules/breakout_mics6814/breakout_mics6814.c
@@ -48,12 +48,22 @@ STATIC const mp_rom_map_elem_t BreakoutMICS6814_locals_dict_table[] = {
 STATIC MP_DEFINE_CONST_DICT(BreakoutMICS6814_locals_dict, BreakoutMICS6814_locals_dict_table);
 
 /***** Class Definition *****/
+#ifdef MP_DEFINE_CONST_OBJ_TYPE
+MP_DEFINE_CONST_OBJ_TYPE(
+    breakout_mics6814_BreakoutMICS6814_type,
+    MP_QSTR_BreakoutMICS6814,
+    MP_TYPE_FLAG_NONE,
+    make_new, BreakoutMICS6814_make_new,
+    locals_dict, (mp_obj_dict_t*)&BreakoutMICS6814_locals_dict
+);
+#else
 const mp_obj_type_t breakout_mics6814_BreakoutMICS6814_type = {
     { &mp_type_type },
     .name = MP_QSTR_BreakoutMICS6814,
     .make_new = BreakoutMICS6814_make_new,
     .locals_dict = (mp_obj_dict_t*)&BreakoutMICS6814_locals_dict,
 };
+#endif
 
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/micropython/modules/breakout_msa301/breakout_msa301.c
+++ b/micropython/modules/breakout_msa301/breakout_msa301.c
@@ -81,12 +81,22 @@ STATIC const mp_rom_map_elem_t BreakoutMSA301_locals_dict_table[] = {
 STATIC MP_DEFINE_CONST_DICT(BreakoutMSA301_locals_dict, BreakoutMSA301_locals_dict_table);
 
 /***** Class Definition *****/
+#ifdef MP_DEFINE_CONST_OBJ_TYPE
+MP_DEFINE_CONST_OBJ_TYPE(
+    breakout_msa301_BreakoutMSA301_type,
+    MP_QSTR_BreakoutMSA301,
+    MP_TYPE_FLAG_NONE,
+    make_new, BreakoutMSA301_make_new,
+    locals_dict, (mp_obj_dict_t*)&BreakoutMSA301_locals_dict
+);
+#else
 const mp_obj_type_t breakout_msa301_BreakoutMSA301_type = {
     { &mp_type_type },
     .name = MP_QSTR_BreakoutMSA301,
     .make_new = BreakoutMSA301_make_new,
     .locals_dict = (mp_obj_dict_t*)&BreakoutMSA301_locals_dict,
 };
+#endif
 
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/micropython/modules/breakout_pmw3901/breakout_paa5100.c
+++ b/micropython/modules/breakout_pmw3901/breakout_paa5100.c
@@ -32,6 +32,16 @@ STATIC const mp_rom_map_elem_t BreakoutPAA5100_locals_dict_table[] = {
 STATIC MP_DEFINE_CONST_DICT(BreakoutPAA5100_locals_dict, BreakoutPAA5100_locals_dict_table);
 
 /***** Class Definition *****/
+#ifdef MP_DEFINE_CONST_OBJ_TYPE
+MP_DEFINE_CONST_OBJ_TYPE(
+    breakout_paa5100_BreakoutPAA5100_type,
+    MP_QSTR_BreakoutPAA5100,
+    MP_TYPE_FLAG_NONE,
+    make_new, BreakoutPAA5100_make_new,
+    print, BreakoutPMW3901_print,
+    locals_dict, (mp_obj_dict_t*)&BreakoutPAA5100_locals_dict
+);
+#else
 const mp_obj_type_t breakout_paa5100_BreakoutPAA5100_type = {
     { &mp_type_type },
     .name = MP_QSTR_BreakoutPAA5100,
@@ -39,6 +49,7 @@ const mp_obj_type_t breakout_paa5100_BreakoutPAA5100_type = {
     .make_new = BreakoutPAA5100_make_new,
     .locals_dict = (mp_obj_dict_t*)&BreakoutPAA5100_locals_dict,
 };
+#endif
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // breakout_paa5100 Module

--- a/micropython/modules/breakout_pmw3901/breakout_pmw3901.c
+++ b/micropython/modules/breakout_pmw3901/breakout_pmw3901.c
@@ -32,6 +32,16 @@ STATIC const mp_rom_map_elem_t BreakoutPMW3901_locals_dict_table[] = {
 STATIC MP_DEFINE_CONST_DICT(BreakoutPMW3901_locals_dict, BreakoutPMW3901_locals_dict_table);
 
 /***** Class Definition *****/
+#ifdef MP_DEFINE_CONST_OBJ_TYPE
+MP_DEFINE_CONST_OBJ_TYPE(
+    breakout_pmw3901_BreakoutPMW3901_type,
+    MP_QSTR_BreakoutPMW3901,
+    MP_TYPE_FLAG_NONE,
+    make_new, BreakoutPMW3901_make_new,
+    print, BreakoutPMW3901_print,
+    locals_dict, (mp_obj_dict_t*)&BreakoutPMW3901_locals_dict
+);
+#else
 const mp_obj_type_t breakout_pmw3901_BreakoutPMW3901_type = {
     { &mp_type_type },
     .name = MP_QSTR_BreakoutPMW3901,
@@ -39,6 +49,7 @@ const mp_obj_type_t breakout_pmw3901_BreakoutPMW3901_type = {
     .make_new = BreakoutPMW3901_make_new,
     .locals_dict = (mp_obj_dict_t*)&BreakoutPMW3901_locals_dict,
 };
+#endif
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // breakout_pmw3901 Module

--- a/micropython/modules/breakout_potentiometer/breakout_potentiometer.c
+++ b/micropython/modules/breakout_potentiometer/breakout_potentiometer.c
@@ -32,12 +32,22 @@ STATIC const mp_rom_map_elem_t BreakoutPotentiometer_locals_dict_table[] = {
 STATIC MP_DEFINE_CONST_DICT(BreakoutPotentiometer_locals_dict, BreakoutPotentiometer_locals_dict_table);
 
 /***** Class Definition *****/
+#ifdef MP_DEFINE_CONST_OBJ_TYPE
+MP_DEFINE_CONST_OBJ_TYPE(
+    breakout_potentiometer_BreakoutPotentiometer_type,
+    MP_QSTR_BreakoutPotentiometer,
+    MP_TYPE_FLAG_NONE,
+    make_new, BreakoutPotentiometer_make_new,
+    locals_dict, (mp_obj_dict_t*)&BreakoutPotentiometer_locals_dict
+);
+#else
 const mp_obj_type_t breakout_potentiometer_BreakoutPotentiometer_type = {
     { &mp_type_type },
     .name = MP_QSTR_BreakoutPotentiometer,
     .make_new = BreakoutPotentiometer_make_new,
     .locals_dict = (mp_obj_dict_t*)&BreakoutPotentiometer_locals_dict,
 };
+#endif
 
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/micropython/modules/breakout_rgbmatrix5x5/breakout_rgbmatrix5x5.c
+++ b/micropython/modules/breakout_rgbmatrix5x5/breakout_rgbmatrix5x5.c
@@ -20,12 +20,22 @@ STATIC const mp_rom_map_elem_t BreakoutRGBMatrix5x5_locals_dict_table[] = {
 STATIC MP_DEFINE_CONST_DICT(BreakoutRGBMatrix5x5_locals_dict, BreakoutRGBMatrix5x5_locals_dict_table);
 
 /***** Class Definition *****/
+#ifdef MP_DEFINE_CONST_OBJ_TYPE
+MP_DEFINE_CONST_OBJ_TYPE(
+    breakout_rgbmatrix5x5_BreakoutRGBMatrix5x5_type,
+    MP_QSTR_BreakoutRGBMatrix5x5,
+    MP_TYPE_FLAG_NONE,
+    make_new, BreakoutRGBMatrix5x5_make_new,
+    locals_dict, (mp_obj_dict_t*)&BreakoutRGBMatrix5x5_locals_dict
+);
+#else
 const mp_obj_type_t breakout_rgbmatrix5x5_BreakoutRGBMatrix5x5_type = {
     { &mp_type_type },
     .name = MP_QSTR_BreakoutRGBMatrix5x5,
     .make_new = BreakoutRGBMatrix5x5_make_new,
     .locals_dict = (mp_obj_dict_t*)&BreakoutRGBMatrix5x5_locals_dict,
 };
+#endif
 
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/micropython/modules/breakout_rtc/breakout_rtc.c
+++ b/micropython/modules/breakout_rtc/breakout_rtc.c
@@ -136,12 +136,22 @@ STATIC const mp_rom_map_elem_t BreakoutRTC_locals_dict_table[] = {
 STATIC MP_DEFINE_CONST_DICT(BreakoutRTC_locals_dict, BreakoutRTC_locals_dict_table);
 
 /***** Class Definition *****/
+#ifdef MP_DEFINE_CONST_OBJ_TYPE
+MP_DEFINE_CONST_OBJ_TYPE(
+    breakout_rtc_BreakoutRTC_type,
+    MP_QSTR_BreakoutRTC,
+    MP_TYPE_FLAG_NONE,
+    make_new, BreakoutRTC_make_new,
+    locals_dict, (mp_obj_dict_t*)&BreakoutRTC_locals_dict
+);
+#else
 const mp_obj_type_t breakout_rtc_BreakoutRTC_type = {
     { &mp_type_type },
     .name = MP_QSTR_BreakoutRTC,
     .make_new = BreakoutRTC_make_new,
     .locals_dict = (mp_obj_dict_t*)&BreakoutRTC_locals_dict,
 };
+#endif
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // breakout_rtc Module

--- a/micropython/modules/breakout_sgp30/breakout_sgp30.c
+++ b/micropython/modules/breakout_sgp30/breakout_sgp30.c
@@ -34,12 +34,22 @@ STATIC const mp_rom_map_elem_t BreakoutSGP30_locals_dict_table[] = {
 STATIC MP_DEFINE_CONST_DICT(BreakoutSGP30_locals_dict, BreakoutSGP30_locals_dict_table);
 
 /***** Class Definition *****/
+#ifdef MP_DEFINE_CONST_OBJ_TYPE
+MP_DEFINE_CONST_OBJ_TYPE(
+    breakout_sgp30_BreakoutSGP30_type,
+    MP_QSTR_BreakoutSGP30,
+    MP_TYPE_FLAG_NONE,
+    make_new, BreakoutSGP30_make_new,
+    locals_dict, (mp_obj_dict_t*)&BreakoutSGP30_locals_dict
+);
+#else
 const mp_obj_type_t breakout_sgp30_BreakoutSGP30_type = {
     { &mp_type_type },
     .name = MP_QSTR_BreakoutSGP30,
     .make_new = BreakoutSGP30_make_new,
     .locals_dict = (mp_obj_dict_t*)&BreakoutSGP30_locals_dict,
 };
+#endif
 
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/micropython/modules/breakout_trackball/breakout_trackball.c
+++ b/micropython/modules/breakout_trackball/breakout_trackball.c
@@ -36,12 +36,22 @@ STATIC const mp_rom_map_elem_t BreakoutTrackball_locals_dict_table[] = {
 STATIC MP_DEFINE_CONST_DICT(BreakoutTrackball_locals_dict, BreakoutTrackball_locals_dict_table);
 
 /***** Class Definition *****/
+#ifdef MP_DEFINE_CONST_OBJ_TYPE
+MP_DEFINE_CONST_OBJ_TYPE(
+    breakout_trackball_BreakoutTrackball_type,
+    MP_QSTR_BreakoutTrackball,
+    MP_TYPE_FLAG_NONE,
+    make_new, BreakoutTrackball_make_new,
+    locals_dict, (mp_obj_dict_t*)&BreakoutTrackball_locals_dict
+);
+#else
 const mp_obj_type_t breakout_trackball_BreakoutTrackball_type = {
     { &mp_type_type },
     .name = MP_QSTR_BreakoutTrackball,
     .make_new = BreakoutTrackball_make_new,
     .locals_dict = (mp_obj_dict_t*)&BreakoutTrackball_locals_dict,
 };
+#endif
 
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/micropython/modules/breakout_vl53l5cx/vl53l5cx.c
+++ b/micropython/modules/breakout_vl53l5cx/vl53l5cx.c
@@ -47,12 +47,22 @@ STATIC const mp_rom_map_elem_t VL53L5CX_locals_dict_table[] = {
 STATIC MP_DEFINE_CONST_DICT(VL53L5CX_locals_dict, VL53L5CX_locals_dict_table);
 
 /***** Class Definition *****/
+#ifdef MP_DEFINE_CONST_OBJ_TYPE
+MP_DEFINE_CONST_OBJ_TYPE(
+    VL53L5CX_type,
+    MP_QSTR_VL53L5CX,
+    MP_TYPE_FLAG_NONE,
+    make_new, VL53L5CX_make_new,
+    locals_dict, (mp_obj_dict_t*)&VL53L5CX_locals_dict
+);
+#else
 const mp_obj_type_t VL53L5CX_type = {
     { &mp_type_type },
     .name = MP_QSTR_VL53L5CX,
     .make_new = VL53L5CX_make_new,
     .locals_dict = (mp_obj_dict_t*)&VL53L5CX_locals_dict,
 };
+#endif
 
 /***** Module Globals *****/
 STATIC const mp_map_elem_t vl53l5cx_globals_table[] = {

--- a/micropython/modules/encoder/encoder.c
+++ b/micropython/modules/encoder/encoder.c
@@ -40,6 +40,16 @@ STATIC const mp_rom_map_elem_t Encoder_locals_dict_table[] = {
 STATIC MP_DEFINE_CONST_DICT(Encoder_locals_dict, Encoder_locals_dict_table);
 
 /***** Class Definition *****/
+#ifdef MP_DEFINE_CONST_OBJ_TYPE
+MP_DEFINE_CONST_OBJ_TYPE(
+    Encoder_type,
+    MP_QSTR_encoder,
+    MP_TYPE_FLAG_NONE,
+    make_new, Encoder_make_new,
+    print, Encoder_print,
+    locals_dict, (mp_obj_dict_t*)&Encoder_locals_dict
+);
+#else
 const mp_obj_type_t Encoder_type = {
     { &mp_type_type },
     .name = MP_QSTR_encoder,
@@ -47,6 +57,7 @@ const mp_obj_type_t Encoder_type = {
     .make_new = Encoder_make_new,
     .locals_dict = (mp_obj_dict_t*)&Encoder_locals_dict,
 };
+#endif
 
 /***** Globals Table *****/
 STATIC const mp_map_elem_t encoder_globals_table[] = {

--- a/micropython/modules/galactic_unicorn/galactic_unicorn.c
+++ b/micropython/modules/galactic_unicorn/galactic_unicorn.c
@@ -94,6 +94,25 @@ STATIC MP_DEFINE_CONST_DICT(Channel_locals_dict, Channel_locals_dict_table);
 STATIC MP_DEFINE_CONST_DICT(GalacticUnicorn_locals_dict, GalacticUnicorn_locals_dict_table);
 
 /***** Class Definition *****/
+#ifdef MP_DEFINE_CONST_OBJ_TYPE
+MP_DEFINE_CONST_OBJ_TYPE(
+    Channel_type,
+    MP_QSTR_Channel,
+    MP_TYPE_FLAG_NONE,
+    make_new, Channel_make_new,
+    print, Channel_print,
+    locals_dict, (mp_obj_dict_t*)&Channel_locals_dict
+);
+
+MP_DEFINE_CONST_OBJ_TYPE(
+    GalacticUnicorn_type,
+    MP_QSTR_GalacticUnicorn,
+    MP_TYPE_FLAG_NONE,
+    make_new, GalacticUnicorn_make_new,
+    print, GalacticUnicorn_print,
+    locals_dict, (mp_obj_dict_t*)&GalacticUnicorn_locals_dict
+);
+#else
 const mp_obj_type_t Channel_type = {
     { &mp_type_type },
     .name = MP_QSTR_Channel,
@@ -109,6 +128,7 @@ const mp_obj_type_t GalacticUnicorn_type = {
     .make_new = GalacticUnicorn_make_new,
     .locals_dict = (mp_obj_dict_t*)&GalacticUnicorn_locals_dict,
 };
+#endif
 
 /***** Globals Table *****/
 STATIC const mp_map_elem_t galactic_globals_table[] = {

--- a/micropython/modules/hub75/hub75.c
+++ b/micropython/modules/hub75/hub75.c
@@ -23,6 +23,16 @@ STATIC const mp_rom_map_elem_t Hub75_locals_dict_table[] = {
 STATIC MP_DEFINE_CONST_DICT(Hub75_locals_dict, Hub75_locals_dict_table);
 
 /***** Class Definition *****/
+#ifdef MP_DEFINE_CONST_OBJ_TYPE
+MP_DEFINE_CONST_OBJ_TYPE(
+    Hub75_type,
+    MP_QSTR_hub75,
+    MP_TYPE_FLAG_NONE,
+    make_new, Hub75_make_new,
+    print, Hub75_print,
+    locals_dict, (mp_obj_dict_t*)&Hub75_locals_dict
+);
+#else
 const mp_obj_type_t Hub75_type = {
     { &mp_type_type },
     .name = MP_QSTR_hub75,
@@ -30,6 +40,7 @@ const mp_obj_type_t Hub75_type = {
     .make_new = Hub75_make_new,
     .locals_dict = (mp_obj_dict_t*)&Hub75_locals_dict,
 };
+#endif
 
 /***** Globals Table *****/
 

--- a/micropython/modules/jpegdec/jpegdec.c
+++ b/micropython/modules/jpegdec/jpegdec.c
@@ -20,6 +20,16 @@ STATIC const mp_rom_map_elem_t JPEG_locals_dict_table[] = {
 
 STATIC MP_DEFINE_CONST_DICT(JPEG_locals_dict, JPEG_locals_dict_table);
 
+#ifdef MP_DEFINE_CONST_OBJ_TYPE
+MP_DEFINE_CONST_OBJ_TYPE(
+    JPEG_type,
+    MP_QSTR_jpegdec,
+    MP_TYPE_FLAG_NONE,
+    make_new, _JPEG_make_new,
+    //print, _JPEG_print,
+    locals_dict, (mp_obj_dict_t*)&JPEG_locals_dict
+);
+#else
 const mp_obj_type_t JPEG_type = {
     { &mp_type_type },
     .name = MP_QSTR_jpegdec,
@@ -27,6 +37,7 @@ const mp_obj_type_t JPEG_type = {
     .make_new = _JPEG_make_new,
     .locals_dict = (mp_obj_dict_t*)&JPEG_locals_dict,
 };
+#endif
 
 // module
 STATIC const mp_map_elem_t JPEG_globals_table[] = {

--- a/micropython/modules/motor/motor.c
+++ b/micropython/modules/motor/motor.c
@@ -128,6 +128,16 @@ STATIC MP_DEFINE_CONST_DICT(Motor_locals_dict, Motor_locals_dict_table);
 STATIC MP_DEFINE_CONST_DICT(MotorCluster_locals_dict, MotorCluster_locals_dict_table);
 
 /***** Class Definition *****/
+#ifdef MP_DEFINE_CONST_OBJ_TYPE
+MP_DEFINE_CONST_OBJ_TYPE(
+    Motor_type,
+    MP_QSTR_motor,
+    MP_TYPE_FLAG_NONE,
+    make_new, Motor_make_new,
+    print, Motor_print,
+    locals_dict, (mp_obj_dict_t*)&Motor_locals_dict
+);
+#else
 const mp_obj_type_t Motor_type = {
     { &mp_type_type },
     .name = MP_QSTR_motor,
@@ -135,7 +145,18 @@ const mp_obj_type_t Motor_type = {
     .make_new = Motor_make_new,
     .locals_dict = (mp_obj_dict_t*)&Motor_locals_dict,
 };
+#endif
 
+#ifdef MP_DEFINE_CONST_OBJ_TYPE
+MP_DEFINE_CONST_OBJ_TYPE(
+    MotorCluster_type,
+    MP_QSTR_motor_cluster,
+    MP_TYPE_FLAG_NONE,
+    make_new, MotorCluster_make_new,
+    print, MotorCluster_print,
+    locals_dict, (mp_obj_dict_t*)&MotorCluster_locals_dict
+);
+#else
 const mp_obj_type_t MotorCluster_type = {
     { &mp_type_type },
     .name = MP_QSTR_motor_cluster,
@@ -143,6 +164,7 @@ const mp_obj_type_t MotorCluster_type = {
     .make_new = MotorCluster_make_new,
     .locals_dict = (mp_obj_dict_t*)&MotorCluster_locals_dict,
 };
+#endif
 
 
 /***** Module Constants *****/

--- a/micropython/modules/pcf85063a/pcf85063a.c
+++ b/micropython/modules/pcf85063a/pcf85063a.c
@@ -64,12 +64,22 @@ STATIC const mp_rom_map_elem_t PCF85063A_locals_dict_table[] = {
 STATIC MP_DEFINE_CONST_DICT(PCF85063A_locals_dict, PCF85063A_locals_dict_table);
 
 /***** Class Definition *****/
+#ifdef MP_DEFINE_CONST_OBJ_TYPE
+MP_DEFINE_CONST_OBJ_TYPE(
+    pcf85063a_PCF85063A_type,
+    MP_QSTR_pcf85063a,
+    MP_TYPE_FLAG_NONE,
+    make_new, PCF85063A_make_new,
+    locals_dict, (mp_obj_dict_t*)&PCF85063A_locals_dict
+);
+#else
 const mp_obj_type_t pcf85063a_PCF85063A_type = {
     { &mp_type_type },
     .name = MP_QSTR_pcf85063a,
     .make_new = PCF85063A_make_new,
     .locals_dict = (mp_obj_dict_t*)&PCF85063A_locals_dict,
 };
+#endif
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // pcf85063a Module

--- a/micropython/modules/picographics/picographics.c
+++ b/micropython/modules/picographics/picographics.c
@@ -93,6 +93,16 @@ STATIC const mp_rom_map_elem_t ModPicoGraphics_locals_dict_table[] = {
 STATIC MP_DEFINE_CONST_DICT(ModPicoGraphics_locals_dict, ModPicoGraphics_locals_dict_table);
 
 /***** Class Definition *****/
+#ifdef MP_DEFINE_CONST_OBJ_TYPE
+MP_DEFINE_CONST_OBJ_TYPE(
+    ModPicoGraphics_type,
+    MP_QSTR_picographics,
+    MP_TYPE_FLAG_NONE,
+    make_new, ModPicoGraphics_make_new,
+    buffer, ModPicoGraphics_get_framebuffer,
+    locals_dict, (mp_obj_dict_t*)&ModPicoGraphics_locals_dict
+);
+#else
 const mp_obj_type_t ModPicoGraphics_type = {
     { &mp_type_type },
     .name = MP_QSTR_picographics,
@@ -100,6 +110,7 @@ const mp_obj_type_t ModPicoGraphics_type = {
     .buffer_p = { .get_buffer = ModPicoGraphics_get_framebuffer },
     .locals_dict = (mp_obj_dict_t*)&ModPicoGraphics_locals_dict,
 };
+#endif
 
 /***** Module Globals *****/
 STATIC const mp_map_elem_t picographics_globals_table[] = {

--- a/micropython/modules/picographics/picographics.cpp
+++ b/micropython/modules/picographics/picographics.cpp
@@ -265,7 +265,7 @@ mp_obj_t ModPicoGraphics_make_new(const mp_obj_type_t *type, size_t n_args, size
         _PimoroniBus_obj_t *bus = (_PimoroniBus_obj_t *)MP_OBJ_TO_PTR(args[ARG_bus].u_obj);
         parallel_bus = *(ParallelPins *)(bus->pins);
 
-    } else if (mp_obj_is_type(args[ARG_bus].u_obj, &PimoroniI2C_type) || MP_OBJ_IS_TYPE(args[ARG_bus].u_obj, &machine_hw_i2c_type)) {
+    } else if (mp_obj_is_type(args[ARG_bus].u_obj, &PimoroniI2C_type) || MP_OBJ_IS_TYPE(args[ARG_bus].u_obj, &machine_i2c_type)) {
         if(bus_type != BUS_I2C) mp_raise_ValueError("unexpected I2C bus!");
         self->i2c = PimoroniI2C_from_machine_i2c_or_native(args[ARG_bus].u_obj);
         i2c_bus = (pimoroni::I2C *)(self->i2c->i2c);

--- a/micropython/modules/pimoroni_bus/pimoroni_bus.c
+++ b/micropython/modules/pimoroni_bus/pimoroni_bus.c
@@ -2,19 +2,39 @@
 
 MP_DEFINE_CONST_FUN_OBJ_1(SPISlot_obj, SPISlot);
 
+#ifdef MP_DEFINE_CONST_OBJ_TYPE
+MP_DEFINE_CONST_OBJ_TYPE(
+    SPIPins_type,
+    MP_QSTR_SPIBus,
+    MP_TYPE_FLAG_NONE,
+    make_new, SPIPins_make_new,
+    print, PimoroniBus_print
+);
+#else
 const mp_obj_type_t SPIPins_type = {
     { &mp_type_type },
     .name = MP_QSTR_SPIBus,
     .print = PimoroniBus_print,
     .make_new = SPIPins_make_new
 };
+#endif
 
+#ifdef MP_DEFINE_CONST_OBJ_TYPE
+MP_DEFINE_CONST_OBJ_TYPE(
+    ParallelPins_type,
+    MP_QSTR_ParallelBus,
+    MP_TYPE_FLAG_NONE,
+    make_new, ParallelPins_make_new,
+    print, PimoroniBus_print
+);
+#else
 const mp_obj_type_t ParallelPins_type = {
     { &mp_type_type },
     .name = MP_QSTR_ParallelBus,
     .print = PimoroniBus_print,
     .make_new = ParallelPins_make_new
 };
+#endif
 
 STATIC const mp_map_elem_t pimoroni_bus_globals_table[] = {
     { MP_OBJ_NEW_QSTR(MP_QSTR___name__), MP_OBJ_NEW_QSTR(MP_QSTR_pimoroni_bus) },

--- a/micropython/modules/pimoroni_i2c/pimoroni_i2c.c
+++ b/micropython/modules/pimoroni_i2c/pimoroni_i2c.c
@@ -21,6 +21,17 @@ STATIC const mp_machine_i2c_p_t machine_i2c_p = {
 };
 
 /***** Class Definition *****/
+#ifdef MP_DEFINE_CONST_OBJ_TYPE
+MP_DEFINE_CONST_OBJ_TYPE(
+    PimoroniI2C_type,
+    MP_QSTR_pimoroni_i2c,
+    MP_TYPE_FLAG_NONE,
+    make_new, PimoroniI2C_make_new,
+    print, PimoroniI2C_print,
+    protocol, &machine_i2c_p,
+    locals_dict, (mp_obj_dict_t*)&mp_machine_i2c_locals_dict
+);
+#else
 const mp_obj_type_t PimoroniI2C_type = {
     { &mp_type_type },
     .name = MP_QSTR_pimoroni_i2c,
@@ -29,7 +40,7 @@ const mp_obj_type_t PimoroniI2C_type = {
     .protocol = &machine_i2c_p,
     .locals_dict = (mp_obj_dict_t*)&mp_machine_i2c_locals_dict,
 };
-
+#endif
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // breakout_potentiometer Module

--- a/micropython/modules/pimoroni_i2c/pimoroni_i2c.cpp
+++ b/micropython/modules/pimoroni_i2c/pimoroni_i2c.cpp
@@ -14,7 +14,7 @@ extern "C" {
 _PimoroniI2C_obj_t*  PimoroniI2C_from_machine_i2c_or_native(mp_obj_t i2c_obj) {
     if(MP_OBJ_IS_TYPE(i2c_obj, &PimoroniI2C_type)) {
         return (_PimoroniI2C_obj_t *)MP_OBJ_TO_PTR(i2c_obj);
-    } else if(MP_OBJ_IS_TYPE(i2c_obj, &machine_hw_i2c_type)) {
+    } else if(MP_OBJ_IS_TYPE(i2c_obj, &machine_i2c_type)) {
         _PimoroniI2C_obj_t *pimoroni_i2c = m_new_obj(_PimoroniI2C_obj_t);
         machine_i2c_obj_t *machine_i2c = (machine_i2c_obj_t *)MP_OBJ_TO_PTR(i2c_obj);
         pimoroni_i2c = m_new_obj(_PimoroniI2C_obj_t);

--- a/micropython/modules/pimoroni_i2c/pimoroni_i2c.h
+++ b/micropython/modules/pimoroni_i2c/pimoroni_i2c.h
@@ -18,7 +18,7 @@ extern mp_obj_t PimoroniI2C___del__(mp_obj_t self_in);
 
 extern bool Pimoroni_mp_obj_to_i2c(mp_obj_t in, void *out);
 
-extern const mp_obj_type_t machine_hw_i2c_type;
+extern const mp_obj_type_t machine_i2c_type;
 
 typedef struct _machine_i2c_obj_t {
     mp_obj_base_t base;

--- a/micropython/modules/plasma/plasma.c
+++ b/micropython/modules/plasma/plasma.c
@@ -44,6 +44,16 @@ STATIC MP_DEFINE_CONST_DICT(PlasmaAPA102_locals_dict, PlasmaAPA102_locals_dict_t
 STATIC MP_DEFINE_CONST_DICT(PlasmaWS2812_locals_dict, PlasmaWS2812_locals_dict_table);
 
 /***** Class Definition *****/
+#ifdef MP_DEFINE_CONST_OBJ_TYPE
+MP_DEFINE_CONST_OBJ_TYPE(
+    PlasmaAPA102_type,
+    MP_QSTR_plasma_apa102,
+    MP_TYPE_FLAG_NONE,
+    make_new, PlasmaAPA102_make_new,
+    print, PlasmaAPA102_print,
+    locals_dict, (mp_obj_dict_t*)&PlasmaAPA102_locals_dict
+);
+#else
 const mp_obj_type_t PlasmaAPA102_type = {
     { &mp_type_type },
     .name = MP_QSTR_plasma_apa102,
@@ -51,7 +61,18 @@ const mp_obj_type_t PlasmaAPA102_type = {
     .make_new = PlasmaAPA102_make_new,
     .locals_dict = (mp_obj_dict_t*)&PlasmaAPA102_locals_dict,
 };
+#endif
 
+#ifdef MP_DEFINE_CONST_OBJ_TYPE
+MP_DEFINE_CONST_OBJ_TYPE(
+    PlasmaWS2812_type,
+    MP_QSTR_plasma_ws2812,
+    MP_TYPE_FLAG_NONE,
+    make_new, PlasmaWS2812_print,
+    print, PlasmaWS2812_make_new,
+    locals_dict, (mp_obj_dict_t*)&PlasmaWS2812_locals_dict
+);
+#else
 const mp_obj_type_t PlasmaWS2812_type = {
     { &mp_type_type },
     .name = MP_QSTR_plasma_ws2812,
@@ -59,6 +80,7 @@ const mp_obj_type_t PlasmaWS2812_type = {
     .make_new = PlasmaWS2812_make_new,
     .locals_dict = (mp_obj_dict_t*)&PlasmaWS2812_locals_dict,
 };
+#endif
 
 typedef struct _mp_obj_float_t {
     mp_obj_base_t base;

--- a/micropython/modules/servo/servo.c
+++ b/micropython/modules/servo/servo.c
@@ -150,6 +150,16 @@ STATIC MP_DEFINE_CONST_DICT(Servo_locals_dict, Servo_locals_dict_table);
 STATIC MP_DEFINE_CONST_DICT(ServoCluster_locals_dict, ServoCluster_locals_dict_table);
 
 /***** Class Definition *****/
+#ifdef MP_DEFINE_CONST_OBJ_TYPE
+MP_DEFINE_CONST_OBJ_TYPE(
+    Calibration_type,
+    MP_QSTR_calibration,
+    MP_TYPE_FLAG_NONE,
+    make_new, Calibration_make_new,
+    print, Calibration_print,
+    locals_dict, (mp_obj_dict_t*)&Calibration_locals_dict
+);
+#else
 const mp_obj_type_t Calibration_type = {
     { &mp_type_type },
     .name = MP_QSTR_calibration,
@@ -157,7 +167,18 @@ const mp_obj_type_t Calibration_type = {
     .make_new = Calibration_make_new,
     .locals_dict = (mp_obj_dict_t*)&Calibration_locals_dict,
 };
+#endif
 
+#ifdef MP_DEFINE_CONST_OBJ_TYPE
+MP_DEFINE_CONST_OBJ_TYPE(
+    Servo_type,
+    MP_QSTR_servo,
+    MP_TYPE_FLAG_NONE,
+    make_new, Servo_make_new,
+    print, Servo_print,
+    locals_dict, (mp_obj_dict_t*)&Servo_locals_dict
+);
+#else
 const mp_obj_type_t Servo_type = {
     { &mp_type_type },
     .name = MP_QSTR_servo,
@@ -165,7 +186,18 @@ const mp_obj_type_t Servo_type = {
     .make_new = Servo_make_new,
     .locals_dict = (mp_obj_dict_t*)&Servo_locals_dict,
 };
+#endif
 
+#ifdef MP_DEFINE_CONST_OBJ_TYPE
+MP_DEFINE_CONST_OBJ_TYPE(
+    ServoCluster_type,
+    MP_QSTR_servo_cluster,
+    MP_TYPE_FLAG_NONE,
+    make_new, ServoCluster_make_new,
+    print, ServoCluster_print,
+    locals_dict, (mp_obj_dict_t*)&ServoCluster_locals_dict
+);
+#else
 const mp_obj_type_t ServoCluster_type = {
     { &mp_type_type },
     .name = MP_QSTR_servo_cluster,
@@ -173,6 +205,7 @@ const mp_obj_type_t ServoCluster_type = {
     .make_new = ServoCluster_make_new,
     .locals_dict = (mp_obj_dict_t*)&ServoCluster_locals_dict,
 };
+#endif
 
 typedef struct _mp_obj_float_t {
     mp_obj_base_t base;


### PR DESCRIPTION
Follows the lead from: https://github.com/micropython/micropython/commit/662b9761b37b054f08fe2f7c00d0fce3a418d0b0

Update to support MP_DEFINE_CONST_OBJ_TYPE with backwards compatibility.

TODO

* [ ] Move to updated `ulab` when it's available
* [x] Fix and update `qrcode`