### PR TITLE
PicoGraphics: Fix a bug that broke #422

### DIFF
--- a/libraries/pico_graphics/pico_graphics.cpp
+++ b/libraries/pico_graphics/pico_graphics.cpp
@@ -342,22 +342,22 @@ namespace pimoroni {
     const int BUF_LEN = 64;
     uint16_t row_buf[2][BUF_LEN];
     int buf_idx = 0;
-    for(auto y = 0; y < bounds.h; y++) {
-        for(auto x = 0; x < bounds.w; x++) {
-            int buf_entry = x & (BUF_LEN - 1);
-            row_buf[buf_idx][buf_entry] = get_next_pixel();
+    int buf_entry = 0;
+    for(auto i = 0; i < bounds.w * bounds.h; i++) {
+      row_buf[buf_idx][buf_entry] = get_next_pixel();
+      buf_entry++;
 
-            if (buf_entry == BUF_LEN - 1) {
-                callback(row_buf[buf_idx], BUF_LEN * sizeof(RGB565));
-                buf_idx ^= 1;
-            }
-        }
+      // Transfer a filled buffer and swap to the next one
+      if (buf_entry == BUF_LEN) {
+          callback(row_buf[buf_idx], BUF_LEN * sizeof(RGB565));
+          buf_idx ^= 1;
+          buf_entry = 0;
+      }
+    }
 
-        if ((bounds.w & (BUF_LEN - 1)) != 0) {
-            // Callback to the driver with the remaining row data
-            callback(row_buf[buf_idx], (bounds.w & (BUF_LEN - 1)) * sizeof(RGB565));
-            buf_idx ^= 1;
-        }
+    // Transfer any remaining pixels ( < BUF_LEN )
+    if(buf_entry > 0) {
+        callback(row_buf[buf_idx], buf_entry * sizeof(RGB565));
     }
 
     // Callback with zero length to ensure previous buffer is fully written

--- a/libraries/pico_graphics/pico_graphics_pen_p4.cpp
+++ b/libraries/pico_graphics/pico_graphics_pen_p4.cpp
@@ -51,11 +51,13 @@ namespace pimoroni {
         return i;
     }
     void PicoGraphics_PenP4::set_pixel(const Point &p) {
+        auto i = (p.x + p.y * bounds.w);
+
         // pointer to byte in framebuffer that contains this pixel
         uint8_t *buf = (uint8_t *)frame_buffer;
-        uint8_t *f = &buf[(p.x / 2) + (p.y * bounds.w / 2)];
+        uint8_t *f = &buf[i / 2];
 
-        uint8_t  o = (~p.x & 0b1) * 4; // bit offset within byte
+        uint8_t  o = (~i & 0b1) * 4;   // bit offset within byte
         uint8_t  m = ~(0b1111 << o);   // bit mask for byte
         uint8_t  b = color << o;       // bit value shifted to position
 
@@ -64,15 +66,17 @@ namespace pimoroni {
     }
 
     void PicoGraphics_PenP4::set_pixel_span(const Point &p, uint l) {
+        auto i = (p.x + p.y * bounds.w);
+
         // pointer to byte in framebuffer that contains this pixel
         uint8_t *buf = (uint8_t *)frame_buffer;
-        uint8_t *f = &buf[(p.x / 2) + (p.y * bounds.w / 2)];
+        uint8_t *f = &buf[i / 2];
 
         // doubled up color value, so the color is stored in both nibbles
         uint8_t cc = color | (color << 4);
         
         // handle the first pixel if not byte aligned
-        if(p.x & 0b1) {*f &= 0b11110000; *f |= (cc & 0b00001111); f++; l--;}
+        if(i & 0b1) {*f &= 0b11110000; *f |= (cc & 0b00001111); f++; l--;}
 
         // write any double nibble pixels
         while(l > 1) {*f++ = cc; l -= 2;}


### PR DESCRIPTION
The 4-bit paletted pen mode was using *only* the `x` coordinate of a pixel to determine which nibble to set. This resulted in the wrong nibble being set for displays with an uneven width. EG: Pico Display is 135x240 in portrait. See #422 for an example.