### PR TITLE
Plasma: Use m_new to alloc buffer on gc_heap if not supplied.

### DIFF
--- a/micropython/modules/plasma/plasma.cpp
+++ b/micropython/modules/plasma/plasma.cpp
@@ -89,9 +89,11 @@ mp_obj_t PlasmaWS2812_make_new(const mp_obj_type_t *type, size_t n_args, size_t 
         mp_buffer_info_t bufinfo;
         mp_get_buffer_raise(args[ARG_buffer].u_obj, &bufinfo, MP_BUFFER_RW);
         buffer = bufinfo.buf;
-        if(bufinfo.len < (size_t)(num_leds * 4)) {
+        if(bufinfo.len < (size_t)(num_leds * sizeof(WS2812::RGB))) {
             mp_raise_ValueError("Supplied buffer is too small for LED count!");
         }
+    } else {
+        buffer = m_new(WS2812::RGB, num_leds);
     }
 
     self = m_new_obj_with_finaliser(_PlasmaWS2812_obj_t);
@@ -294,13 +296,15 @@ mp_obj_t PlasmaAPA102_make_new(const mp_obj_type_t *type, size_t n_args, size_t 
         if(bufinfo.len < (size_t)(num_leds * 4)) {
             mp_raise_ValueError("Supplied buffer is too small for LED count!");
         }
-        // If a bytearray is supplied it'll be raw, uninitialized bytes
-        // iterate through the RGB elements and call "brightness"
-        // to set up the SOF bytes, otherwise a flickery mess will happen!
-        // Oh for such niceties as "placement new"...
-        for(auto i = 0; i < num_leds; i++) {
-            buffer[i].brightness(15);
-        }
+    } else {
+        buffer = m_new(APA102::RGB, num_leds);
+    }
+
+    // A supplied bytearray or new buffer will be raw, uninitialized bytes
+    // iterate through the RGB elements and call "brightness"
+    // to set up the SOF bytes, otherwise a flickery mess will happen!
+    for(auto i = 0; i < num_leds; i++) {
+        buffer[i].brightness(15);
     }
 
     self = m_new_obj_with_finaliser(_PlasmaAPA102_obj_t);


### PR DESCRIPTION
When no buffer was supplied it would fall upon the class to call "new" and allocate within C/C++'s (very small) heap.

Ensure a MicroPython managed buffer (allocated from gc_heap) is always supplied to the APA102/WS2812 classes.