### PR TITLE
Switched the Plasma Stick colour order and fixed BME280 example

### DIFF
--- a/examples/plasma_stick/plasma_stick_alternating_blinkies.cpp
+++ b/examples/plasma_stick/plasma_stick_alternating_blinkies.cpp
@@ -22,8 +22,8 @@ constexpr float BRIGHTNESS = 0.5f;
 // Set up speed (wait time between colour changes, in seconds)
 constexpr float SPEED = 1.0f;
 
-// WS2812 / NeoPixel™ LEDs
-WS2812 led_strip(NUM_LEDS, pio0, 0, plasma_stick::DAT);
+// Set up the WS2812 / NeoPixel™ LEDs, with RGB color order to work with the LED wire that comes with Skully
+WS2812 led_strip(NUM_LEDS, pio0, 0, plasma_stick::DAT, WS2812::DEFAULT_SERIAL_FREQ, false, WS2812::COLOR_ORDER::RGB);
 
 
 int main() {

--- a/examples/plasma_stick/plasma_stick_encoder.cpp
+++ b/examples/plasma_stick/plasma_stick_encoder.cpp
@@ -17,8 +17,8 @@ const uint NUM_LEDS = 50;
 // Make this number bigger for more precise colour adjustments
 const uint STEPS_PER_REV = 24;
 
-// WS28X-style LEDs with a single signal line. AKA NeoPixel
-WS2812 led_strip(NUM_LEDS, pio0, 0, plasma_stick::DAT);
+// Set up the WS2812 / NeoPixel™ LEDs, with RGB color order to work with the LED wire that comes with Skully
+WS2812 led_strip(NUM_LEDS, pio0, 0, plasma_stick::DAT, WS2812::DEFAULT_SERIAL_FREQ, false, WS2812::COLOR_ORDER::RGB);
 
 I2C i2c(BOARD::PLASMA_STICK);
 BreakoutEncoder enc(&i2c);

--- a/examples/plasma_stick/plasma_stick_fire.cpp
+++ b/examples/plasma_stick/plasma_stick_fire.cpp
@@ -12,8 +12,8 @@ using namespace plasma;
 // Set how many LEDs you have
 const uint NUM_LEDS = 50;
 
-// WS2812 / NeoPixel™ LEDs
-WS2812 led_strip(NUM_LEDS, pio0, 0, plasma_stick::DAT);
+// Set up the WS2812 / NeoPixel™ LEDs, with RGB color order to work with the LED wire that comes with Skully
+WS2812 led_strip(NUM_LEDS, pio0, 0, plasma_stick::DAT, WS2812::DEFAULT_SERIAL_FREQ, false, WS2812::COLOR_ORDER::RGB);
 
 // Maps a value from one range to another
 float map(float x, float in_min, float in_max, float out_min, float out_max) {

--- a/examples/plasma_stick/plasma_stick_rainbows.cpp
+++ b/examples/plasma_stick/plasma_stick_rainbows.cpp
@@ -18,8 +18,8 @@ const uint SPEED = 20;
 // How many times the LEDs will be updated per second
 const uint UPDATES = 60;
 
-// WS2812 / NeoPixel™ LEDs
-WS2812 led_strip(NUM_LEDS, pio0, 0, plasma_stick::DAT);
+// Set up the WS2812 / NeoPixel™ LEDs, with RGB color order to work with the LED wire that comes with Skully
+WS2812 led_strip(NUM_LEDS, pio0, 0, plasma_stick::DAT, WS2812::DEFAULT_SERIAL_FREQ, false, WS2812::COLOR_ORDER::RGB);
 
 
 int main() {

--- a/examples/plasma_stick/plasma_stick_temperature_bme280.cpp
+++ b/examples/plasma_stick/plasma_stick_temperature_bme280.cpp
@@ -28,8 +28,8 @@ const uint MAX = 30;
 const uint HUE_START = 230; // blue
 const uint HUE_END = 359;  // red
 
-// WS28X-style LEDs with a single signal line. AKA NeoPixel
-WS2812 led_strip(NUM_LEDS, pio0, 0, plasma_stick::DAT);
+// Set up the WS2812 / NeoPixel™ LEDs, with RGB color order to work with the LED wire that comes with Skully
+WS2812 led_strip(NUM_LEDS, pio0, 0, plasma_stick::DAT, WS2812::DEFAULT_SERIAL_FREQ, false, WS2812::COLOR_ORDER::RGB);
 
 I2C i2c(BOARD::PLASMA_STICK);
 BME280 bme(&i2c);
@@ -54,6 +54,8 @@ int main() {
       for(auto i = 0u; i < NUM_LEDS; i++) {
         led_strip.set_hsv(i, hue / 360.0f, 1.0, BRIGHTNESS);
       }
+
+      sleep_ms(500);
     }
   }
   else {


### PR DESCRIPTION
Skully kit uses RGB rather than GRB LEDs, so made examples like fire.py show as green.