### PR TITLE
St7789 async dma and partial update

### DIFF
--- a/drivers/st7789/st7789.cpp
+++ b/drivers/st7789/st7789.cpp
@@ -110,10 +110,16 @@ namespace pimoroni {
   }
 
   void ST7789::cleanup() {
-    if(dma_channel_is_claimed(st_dma)) {
-      dma_channel_abort(st_dma);
-      dma_channel_unclaim(st_dma);
+    if(dma_channel_is_claimed(st_dma_data)) {
+      dma_channel_abort(st_dma_data);
+      dma_channel_unclaim(st_dma_data);
     }
+
+    if(use_async_dma && dma_channel_is_claimed(st_dma_control_chain)) {
+      dma_channel_abort(st_dma_control_chain);
+      dma_channel_unclaim(st_dma_control_chain);
+    }
+		
     if(spi) return; // SPI mode needs no further tear down
 
     if(pio_sm_is_claimed(parallel_pio, parallel_sm)) {
@@ -130,6 +136,10 @@ namespace pimoroni {
     if(rotate == ROTATE_90 || rotate == ROTATE_270) {
       std::swap(width, height);
     }
+		
+		// setup full and current regions
+		full_screen_region = {0, 0, width, height};
+		current_update_region = {0, 0, width, height};
 
     // 240x240 Square and Round LCD Breakouts
     if(width == 240 && height == 240) {
@@ -176,20 +186,28 @@ namespace pimoroni {
 
     // Pico Display
     if(width == 240 && height == 135) {
-      caset[0] = 40;   // 240 cols
-      caset[1] = 279;
-      raset[0] = 53;   // 135 rows
-      raset[1] = 187;
+      int col_offset = 40;
+      int row_offset = 53-rotate180; // something a little weird here, needs offsetting by -1 if rotateing 180!
+
+      caset[0] = col_offset;   
+      caset[1] = width + col_offset - 1;
+      raset[0] = row_offset;   
+      raset[1] = height + row_offset - 1;
+
       madctl = rotate180 ? MADCTL::ROW_ORDER : MADCTL::COL_ORDER;
       madctl |= MADCTL::SWAP_XY | MADCTL::SCAN_ORDER;
     }
 
     // Pico Display at 90 degree rotation
     if(width == 135 && height == 240) {
-      caset[0] = 52;   // 135 cols
-      caset[1] = 186;
-      raset[0] = 40;   // 240 rows
-      raset[1] = 279;
+      int col_offset = 52+rotate180; // something a little weird here, needs offsetting by +1 if rotateing 180!
+      int row_offset = 40; 
+
+      caset[0] = col_offset;   
+      caset[1] = width + col_offset - 1;
+      raset[0] = row_offset;   
+      raset[1] = height + row_offset - 1;
+
       madctl = rotate180 ? (MADCTL::COL_ORDER | MADCTL::ROW_ORDER) : 0;
     }
 
@@ -213,21 +231,24 @@ namespace pimoroni {
     }
 
     // Byte swap the 16bit rows/cols values
-    caset[0] = __builtin_bswap16(caset[0]);
-    caset[1] = __builtin_bswap16(caset[1]);
-    raset[0] = __builtin_bswap16(raset[0]);
-    raset[1] = __builtin_bswap16(raset[1]);
+		uint16_t scaset[2] = {0, 0};
+  	uint16_t sraset[2] = {0, 0};
 
-    command(reg::CASET,  4, (char *)caset);
-    command(reg::RASET,  4, (char *)raset);
+    scaset[0] = __builtin_bswap16(caset[0]);
+    scaset[1] = __builtin_bswap16(caset[1]);
+    sraset[0] = __builtin_bswap16(raset[0]);
+    sraset[1] = __builtin_bswap16(raset[1]);
+
+    command(reg::CASET,  4, (char *)scaset);
+    command(reg::RASET,  4, (char *)sraset);
     command(reg::MADCTL, 1, (char *)&madctl);
   }
 
   void ST7789::write_blocking_dma(const uint8_t *src, size_t len) {
-    while (dma_channel_is_busy(st_dma))
+    while (dma_channel_is_busy(st_dma_data))
       ;
-    dma_channel_set_trans_count(st_dma, len, false);
-    dma_channel_set_read_addr(st_dma, src, true);
+    dma_channel_set_trans_count(st_dma_data, len, false);
+    dma_channel_set_read_addr(st_dma_data, src, true);
   }
 
   void ST7789::write_blocking_parallel(const uint8_t *src, size_t len) {
@@ -270,20 +291,105 @@ namespace pimoroni {
     if(data) {
       gpio_put(dc, 1); // data mode
       if(spi) {
-        spi_write_blocking(spi, (const uint8_t*)data, len);
+				if(bDataDma) {
+         	write_blocking_dma((const uint8_t*)data, len);
+				}
+				else {
+        	spi_write_blocking(spi, (const uint8_t*)data, len);
+				}
       } else {
         write_blocking_parallel((const uint8_t*)data, len);
       }
     }
 
-    gpio_put(cs, 1);
+		if(!bDataDma)
+			gpio_put(cs, 1);    
   }
   
+	void ST7789::partial_update(PicoGraphics *display, Rect region) {
+		// check sanity flag
+		if(in_dma_update) {
+			panic("When use_async_dma is set you must call waitForUpdateToFinish() between updates");
+		}
+		else {
+			in_dma_update = use_async_dma;
+		}
+
+    uint8_t cmd = reg::RAMWR;
+		if(set_update_region(region)){
+			// select and enter command mode
+      gpio_put(cs, 0);
+      gpio_put(dc, 0); 
+
+			// send RAMWR command
+      if(spi) { // SPI Bus
+        spi_write_blocking(spi, &cmd, 1);
+      } else { // Parallel Bus
+        write_blocking_parallel(&cmd, 1);
+      }
+
+			// enter data mode
+      gpio_put(dc, 1); // data mode
+
+			if(display->pen_type == PicoGraphics::PEN_RGB565) { // Display buffer is screen native
+				uint16_t* framePtr = (uint16_t*)display->frame_buffer + region.x + (region.y * width);
+
+				if(use_async_dma) {
+					// TODO for dma the pico doesn't support dma stride so we need chained dma channels
+					// simple first test wait for dma to complete
+					enable_dma_control(true);
+					
+					for(int32_t control_idx = 0; control_idx < region.h; control_idx++) {
+						dma_control_chain_blocks[control_idx] = { region.w * sizeof(uint16_t), (uint8_t*)framePtr };
+						framePtr+=(width);
+					}
+					dma_control_chain_blocks[region.h] = { 0, 0 };
+					start_dma_control();
+
+				}
+				else {
+					for(int32_t row = region.y; row < region.y + region.h; row++) {
+						spi_write_blocking(spi, (uint8_t*)framePtr, region.w * sizeof(uint16_t));
+						framePtr+=(width);
+					}
+				}
+			}
+			else
+			{
+				// use rect_convert to convert to 565
+				display->rect_convert(PicoGraphics::PEN_RGB565, region, [this](void *data, size_t length) {
+					if (length > 0) {
+						write_blocking_dma((const uint8_t*)data, length);
+					}
+					else {
+						dma_channel_wait_for_finish_blocking(st_dma_data);
+					}
+				});
+			}
+
+			// if we are using async dma leave CS alone
+			if(!use_async_dma) {
+				gpio_put(cs, 1);
+			}
+		}
+	}
+
   void ST7789::update(PicoGraphics *graphics) {
+		// check sanity flag
+		if(in_dma_update) {
+			panic("When use_async_dma is set you must call waitForUpdateToFinish() between updates");
+		}
+		else {
+			in_dma_update = use_async_dma;
+		}
+
+		// set update rect to the full screen
+		set_update_region(full_screen_region);
+
     uint8_t cmd = reg::RAMWR;
 
     if(graphics->pen_type == PicoGraphics::PEN_RGB565) { // Display buffer is screen native
-      command(cmd, width * height * sizeof(uint16_t), (const char*)graphics->frame_buffer);
+      command(cmd, width * height * sizeof(uint16_t), (const char*)graphics->frame_buffer, use_async_dma);
     } else {
       gpio_put(dc, 0); // command mode
       gpio_put(cs, 0);
@@ -300,7 +406,7 @@ namespace pimoroni {
           write_blocking_dma((const uint8_t*)data, length);
         }
         else {
-          dma_channel_wait_for_finish_blocking(st_dma);
+          dma_channel_wait_for_finish_blocking(st_dma_data);
         }
       });
 
@@ -315,4 +421,81 @@ namespace pimoroni {
     uint16_t value = (uint16_t)(pow((float)(brightness) / 255.0f, gamma) * 65535.0f + 0.5f);
     pwm_set_gpio_level(bl, value);
   }
+
+	void ST7789::setup_dma_control_if_needed() {
+		if(use_async_dma) {
+			dma_control_chain_blocks = new DMAControlBlock[height+1];
+			st_dma_control_chain = dma_claim_unused_channel(true);
+
+			// config to write 32 bit registers in spi dma
+			dma_control_config = dma_channel_get_default_config(st_dma_control_chain);
+			channel_config_set_transfer_data_size(&dma_control_config, DMA_SIZE_32);
+			channel_config_set_read_increment(&dma_control_config, true);
+			channel_config_set_write_increment(&dma_control_config, true);
+			channel_config_set_ring(&dma_control_config, true, 3); // wrap at 8 bytes to repeatedly write the count and address registers
+
+			// configure to write to count and address registers from our dma_control_chain_blocks array, write two 32 bit values for len and addr
+			dma_channel_configure(st_dma_control_chain,	&dma_control_config, &dma_hw->ch[st_dma_data].al3_transfer_count, &dma_control_chain_blocks[0], 2, false);
+		}
+	}
+
+	void ST7789::enable_dma_control(bool enable) {
+		if(use_async_dma) {
+			if(dma_control_chain_is_enabled != enable){
+				dma_control_chain_is_enabled = enable;
+				if(dma_control_chain_is_enabled) {
+					// enable dma control chain, chain to control dma and only set irq at end of chain
+					channel_config_set_chain_to(&dma_data_config, st_dma_control_chain);
+					channel_config_set_irq_quiet(&dma_data_config, true);
+				}
+				else {
+					// disable dma control chain, chain to data dma and set irq at end of transfer
+					channel_config_set_chain_to(&dma_data_config, st_dma_data);
+					channel_config_set_irq_quiet(&dma_data_config, false);
+				}
+
+				// configure the data dma
+				if(spi) {
+					dma_channel_configure(st_dma_data, &dma_data_config, &spi_get_hw(spi)->dr, NULL, 0, false);
+				}
+				else {
+					dma_channel_configure(st_dma_data, &dma_data_config, &parallel_pio->txf[parallel_sm], NULL, 0, false);
+				}
+
+				// configure control chain dma
+				dma_channel_configure(st_dma_control_chain,	&dma_control_config, &dma_hw->ch[st_dma_data].al3_transfer_count, &dma_control_chain_blocks[0], 2, false);
+			}
+		}
+	}
+
+	void ST7789::start_dma_control() {
+		if(use_async_dma && dma_control_chain_is_enabled) {
+   		dma_hw->ints0 = 1u << st_dma_data;
+			dma_start_channel_mask(1u << st_dma_control_chain);
+		}
+	}
+
+	bool ST7789::set_update_region(Rect& update_region){
+		// find intersection with display
+		update_region = Rect(0,0,width,height).intersection(update_region);
+
+		// check we have a valid region
+		bool valid_region = !update_region.empty();
+
+		// if we have a valid region and it is different to the current update rect
+		if(valid_region && !update_region.equals(current_update_region)) {
+			// offset the rect
+			uint16_t scaset[2] = {__builtin_bswap16(caset[0]+update_region.x), __builtin_bswap16(caset[0]+update_region.x+update_region.w-1)};
+	  	uint16_t sraset[2] = {__builtin_bswap16(raset[0]+update_region.y), __builtin_bswap16(raset[0]+update_region.y+update_region.h-1)};
+
+			// update display row and column
+			command(reg::CASET,  4, (char *)scaset);
+			command(reg::RASET,  4, (char *)sraset);
+
+			// update our current region
+			current_update_region = update_region;
+		}
+
+		return valid_region;
+	}
 }

--- a/drivers/st7789/st7789.cpp
+++ b/drivers/st7789/st7789.cpp
@@ -277,7 +277,7 @@ namespace pimoroni {
     }*/
   }
 
-  void ST7789::command(uint8_t command, size_t len, const char *data) {
+  void ST7789::command(uint8_t command, size_t len, const char *data, bool use_async_dma) {
     gpio_put(dc, 0); // command mode
 
     gpio_put(cs, 0);
@@ -291,7 +291,7 @@ namespace pimoroni {
     if(data) {
       gpio_put(dc, 1); // data mode
       if(spi) {
-				if(bDataDma) {
+				if(use_async_dma) {
          	write_blocking_dma((const uint8_t*)data, len);
 				}
 				else {
@@ -302,7 +302,7 @@ namespace pimoroni {
       }
     }
 
-		if(!bDataDma)
+		if(!use_async_dma)
 			gpio_put(cs, 1);    
   }
   

--- a/drivers/st7789/st7789.cpp
+++ b/drivers/st7789/st7789.cpp
@@ -309,7 +309,7 @@ namespace pimoroni {
 	void ST7789::partial_update(PicoGraphics *display, Rect region) {
 		// check sanity flag
 		if(in_dma_update) {
-			panic("When use_async_dma is set you must call waitForUpdateToFinish() between updates");
+			panic("When use_async_dma is set you must call wait_for_update_to_finish() between updates");
 		}
 		else {
 			in_dma_update = use_async_dma;
@@ -377,7 +377,7 @@ namespace pimoroni {
   void ST7789::update(PicoGraphics *graphics) {
 		// check sanity flag
 		if(in_dma_update) {
-			panic("When use_async_dma is set you must call waitForUpdateToFinish() between updates");
+			panic("When use_async_dma is set you must call wait_for_update_to_finish() between updates");
 		}
 		else {
 			in_dma_update = use_async_dma;

--- a/drivers/st7789/st7789.hpp
+++ b/drivers/st7789/st7789.hpp
@@ -173,7 +173,7 @@ namespace pimoroni {
 			}
 		}
 
-		void waitForUpdateToFinish()
+		void wait_for_update_to_finish()
 		{
 			if(use_async_dma && dma_control_chain_is_enabled) {
 				while (!(dma_hw->intr & 1u << st_dma_data)) {

--- a/drivers/st7789/st7789.hpp
+++ b/drivers/st7789/st7789.hpp
@@ -199,7 +199,7 @@ namespace pimoroni {
     void configure_display(Rotation rotate);
     void write_blocking_dma(const uint8_t *src, size_t len);
     void write_blocking_parallel(const uint8_t *src, size_t len);
-    void command(uint8_t command, size_t len = 0, const char *data = NULL, bool bDataDma = false);
+    void command(uint8_t command, size_t len = 0, const char *data = NULL, bool use_async_dma = false);
 		void setup_dma_control_if_needed();
 		void enable_dma_control(bool enable);
 		void start_dma_control();

--- a/examples/pico_display/CMakeLists.txt
+++ b/examples/pico_display/CMakeLists.txt
@@ -9,3 +9,15 @@ target_link_libraries(pico_display_demo pico_stdlib hardware_spi hardware_pwm ha
 
 # create map/bin/hex file etc.
 pico_add_extra_outputs(pico_display_demo)
+
+
+add_executable(
+  pico_display_async_region
+  pico_display_async_region.cpp
+)
+
+# Pull in pico libraries that we need
+target_link_libraries(pico_display_async_region pico_stdlib hardware_spi hardware_pwm hardware_dma rgbled pico_display pico_graphics st7789 button)
+
+# create map/bin/hex file etc.
+pico_add_extra_outputs(pico_display_demo)

--- a/examples/pico_display/pico_display_async_region.cpp
+++ b/examples/pico_display/pico_display_async_region.cpp
@@ -1,0 +1,318 @@
+// Example for testing Async DMA and Partial Updates
+// 
+// Button A: Cycles arround screen rotations
+// Button B: Cycles around pen (display) format - PenRGB565, PenRGB332, Pen* and Pen4
+// Button C: Turns Async DMA on and off
+// Button D: Cycles around Partial Region updates: None, Half, Bounce and Full
+//
+// Timings are logged to the screen and also the console
+// I = The pen format, Async status and region.
+// C = The time taken in ms for calculations
+// D = The remaining free DMA time in ms, so the amount of free time you have for more calculations.
+// R = The time to render the frame in ms.
+// U = The time blocked in updating the display in ms.
+// T = The total time in ms.
+//
+// Async Updates
+// -------------
+// Async updates will only have an effect if you are using the native pen format 565
+// If this is turned on then when you call Update() it will return immediately after setting up the DMA
+// At this point you can use the processor as usual apart from you must not send anything to the spi
+// or to the display buffer. In this example we are doing the calculations for the bouncing pixels here.
+// Async updates also work for region updates using 565.
+//
+// So when this example first starts dma is off, in a release build here we see these timings:
+//  C=8.92, D=0.00, R=7.67, U=9.86, T=26.46
+// If we turn Async DMA on with the X button we see:
+//  C=8.92, D=0.92, R=7.65, U=0.02, T=17.52
+//
+// So we can see the time we take to do the calculations (C) stays the same.
+// The time to render stays (R) the same
+// The time to update the display has dropped from 9.86ms to 0.02ms though
+//  What is happening is that the display is now being updated via DMA
+//  So now we are doing our cacluations whilst this is happening.
+//  D is now set to .92ms, this is the time remaining till the display is ready (not using the dma)
+//  if we add C, D and U we get 9.86ms which is the time taken when without async we were blocked updateing the display. 
+//  so now with Async on we can use that previously blocked time for our calculations.
+// We can see the total time drop from 26.46ms to 17.52ms, a nice little speedup.
+//
+// Partial Updates
+// ===============
+//
+// There may be cases where you don't want to update the whole display.
+// If you know you have only updated a small part of the framebuffer then you can use Partial Updates to only send that part to the display.
+//
+// This example allows you to test partial_update()
+// Using Button Y you can cycle around different modes:
+// None:   Partial updates turned off.
+// Half:   The left half of the display is updated.
+// Bounce: A quarter of the display is updated with this region bouncing around. For testing clipping.
+// Full:	 The full display is updated as a partial area, Currently this can speed things up for some pens
+//         For example P4 drops from around 34.3ms to 26.1ms when using partial updates for the full screen.
+
+#include <string.h>
+#include <math.h>
+#include <vector>
+#include <cstdlib>
+
+#include "pico_display.hpp"
+#include "drivers/st7789/st7789.hpp"
+#include "libraries/pico_graphics/pico_graphics.hpp"
+#include "rgbled.hpp"
+#include "button.hpp"
+
+class ElapsedUs
+{
+public:
+	ElapsedUs()
+	{
+		last_time = time_us_64();
+	}
+
+	uint64_t elapsed(void)
+	{
+		uint64_t time_now = time_us_64();
+		uint64_t elapsed = time_now - last_time;
+		last_time = time_now;
+		return elapsed;
+	}
+
+private:
+	uint64_t last_time;
+};
+
+using namespace pimoroni;
+
+
+Button button_a(PicoDisplay::A);
+Button button_b(PicoDisplay::B);
+Button button_x(PicoDisplay::X);
+Button button_y(PicoDisplay::Y);
+
+enum UsePen{up565, up332, up8, up4, upCount};
+enum UseRegion {urNone, urHalf, urBounce, urFull, urCount};
+
+static const char* pen_strings[] = {"565", "332", "P8", "P4"};
+static const char* region_strings[] = {"None", "Half", "Bounce", "Full"};
+
+
+int main() {
+	stdio_init_all();
+
+	// default to async dma off
+	bool use_async_dma = false;
+
+	// default to no rotation
+	Rotation rotation = ROTATE_0;
+
+	// default to 565
+	UsePen use_pen = up565;
+
+	// default to no region
+	UseRegion use_region = urNone;
+	Rect region;
+	Point bounce = {0, 0};
+	Point bounce_inc = {1, 1};
+
+
+	ST7789* st7789 = nullptr;
+	PicoGraphics* graphics = nullptr;
+
+	char  log_buffer[64];
+
+	// turn the led off
+	RGBLED led(PicoDisplay::LED_R, PicoDisplay::LED_G, PicoDisplay::LED_B);
+	led.set_rgb(0, 0, 0);
+
+
+  struct pt {
+    float      x;
+    float      y;
+    float     dx;
+    float     dy;
+    uint16_t use_pen;
+  };
+
+  
+	Pen black_pen, white_pen;
+
+	std::vector<pt> pixels;
+	uint update_time = 0;
+	uint calc_time = 0;
+	uint dma_time = 0;
+	uint render_time = 0;
+	uint total_time = 0;
+		
+	
+  while(true) {
+		ElapsedUs total_timer;
+		ElapsedUs timer;
+
+		bool change_rotation = button_a.read();
+		bool change_pen = button_b.read();
+		bool change_async = button_x.read();
+		bool change_region = button_y.read();
+
+		// cycle arounf regions
+		if(change_region){
+			use_region = (UseRegion)((use_region+1) % urCount);
+		}
+
+		if(st7789 == nullptr || change_rotation || change_pen || change_async) {
+			// switch async DMA mode
+			if(change_async) {
+				use_async_dma = ! use_async_dma;
+				delete st7789;
+				st7789 = nullptr;
+			}
+
+			// cycle around rotations
+			if(change_rotation) {
+				rotation = (Rotation)((rotation + 90) % 360);
+				delete st7789;
+				st7789 = nullptr;
+			}
+
+			// cycle around pens (graphics mode)
+			if(change_pen) {
+				use_pen = (UsePen)((use_pen + 1) % upCount);
+			}
+
+			if(st7789 == nullptr)
+				st7789 = new ST7789(PicoDisplay::WIDTH, PicoDisplay::HEIGHT, rotation, false, get_spi_pins(BG_SPI_FRONT), use_async_dma);
+
+			delete graphics;
+			switch(use_pen)
+			{
+				case up565 : 	graphics = new PicoGraphics_PenRGB565(st7789->width, st7789->height, nullptr); break;
+				case up332 : 	graphics = new PicoGraphics_PenRGB332(st7789->width, st7789->height, nullptr); break;
+				case up8  : 	graphics = new PicoGraphics_PenP8(st7789->width, st7789->height, nullptr); break;
+				case up4   : 	graphics = new PicoGraphics_PenP4(st7789->width, st7789->height, nullptr); break;
+				default: break;
+			}
+
+		  st7789->set_backlight(150);
+		  black_pen = graphics->create_pen(0, 0, 0);
+			white_pen = graphics->create_pen(255, 255, 255);
+
+			graphics->set_font("bitmap8");
+
+			pixels.clear();
+			for(int i = 0; i < 3000; i++) {
+				pt pixel;
+				pixel.x = rand() % graphics->bounds.w;
+				pixel.y = rand() % graphics->bounds.h;
+				pixel.dx = float(rand() % 255) / 128.0f;
+				pixel.dy = float(rand() % 255) / 128.0f;
+				pixel.use_pen = graphics->create_pen(rand() % 255, rand() % 255, rand() % 255);
+				pixels.push_back(pixel);
+			}
+		}
+
+		switch (use_region)
+		{
+			case urFull   : region = Rect(0, 0, st7789->width, st7789->height); break;
+			case urHalf   : region = Rect(0, 0, st7789->width / 2, st7789->height); break;
+			case urBounce : region = Rect(bounce.x - (st7789->width / 4), bounce.y - (st7789->height / 4), st7789->width / 2, st7789->height / 2); break;
+			default: break;
+		}
+
+		// update data
+    for(auto &pixel : pixels) {
+      pixel.x += pixel.dx;
+      pixel.y += pixel.dy;
+      if(pixel.x < 0) pixel.dx *= -1;
+      if(pixel.x >= graphics->bounds.w) pixel.dx *= -1;
+      if(pixel.y < 0) pixel.dy *= -1;
+      if(pixel.y >= graphics->bounds.h) pixel.dy *= -1;
+    }
+
+		bounce.x += bounce_inc.x;
+		bounce.y += bounce_inc.y;
+		if(bounce.x < 0) bounce_inc.x = 1;
+		if(bounce.x >= graphics->bounds.w) bounce_inc.x = -1;
+		if(bounce.y < 0) bounce_inc.y = 1;
+		if(bounce.y >= graphics->bounds.h) bounce_inc.y = -1;
+		
+   
+		calc_time = timer.elapsed();
+
+		// if async wait for last update to finish before rendering
+		if(use_async_dma) {
+			st7789->waitForUpdateToFinish();
+		}
+
+		dma_time = timer.elapsed();
+
+		// render
+    graphics->set_pen(black_pen);
+    graphics->clear();
+
+    for(auto &pixel : pixels) {
+      graphics->set_pen(pixel.use_pen);
+			graphics->pixel(Point(pixel.x, pixel.y));
+    }
+
+		graphics->set_pen(white_pen);
+
+		graphics->line(Point(0,0), Point(graphics->bounds.w-1, 0));
+		graphics->line(Point(0,0), Point(0, graphics->bounds.h-1));
+
+		graphics->line(Point(graphics->bounds.w-1,0), Point(graphics->bounds.w-1, graphics->bounds.h-1));
+		graphics->line(Point(0,graphics->bounds.h-1), Point(graphics->bounds.w-1, graphics->bounds.h-1));
+
+		graphics->set_pen(white_pen);
+
+		uint spacing = 20;
+		float scale = 2;
+		int y = -(spacing/2);
+		sprintf(log_buffer,"I=%s, %s, %s", pen_strings[use_pen], use_async_dma ? "A" : "S", region_strings[use_region]);
+		printf("%s, ", log_buffer);
+		graphics->text(std::string(log_buffer), Point(10, y+=spacing), graphics->bounds.w, scale);
+
+		sprintf(log_buffer,"C=%u.%.2u", calc_time/1000, (calc_time - ((calc_time/1000)*1000)) / 10);
+		printf("%s, ", log_buffer);
+		graphics->text(std::string(log_buffer), Point(10, y+=spacing), graphics->bounds.w, scale);
+
+		sprintf(log_buffer,"D=%u.%.2u", dma_time/1000, (dma_time - ((dma_time/1000)*1000)) / 10);
+		printf("%s, ", log_buffer);
+		graphics->text(std::string(log_buffer), Point(10, y+=spacing), graphics->bounds.w, scale);
+
+		sprintf(log_buffer,"R=%u.%.2u", render_time/1000, (render_time - ((render_time/1000)*1000)) / 10);
+		printf("%s, ", log_buffer);
+		graphics->text(std::string(log_buffer), Point(10, y+=spacing), graphics->bounds.w, scale);
+
+		sprintf(log_buffer,"U=%u.%.2u", update_time/1000, (update_time - ((update_time/1000)*1000)) / 10);
+		printf("%s, ", log_buffer);
+		graphics->text(std::string(log_buffer), Point(10, y+=spacing), graphics->bounds.w, scale);
+
+		sprintf(log_buffer,"T=%u.%.2u", total_time/1000, (total_time - ((total_time/1000)*1000)) / 10);
+		printf("%s\n", log_buffer);
+		graphics->text(std::string(log_buffer), Point(10, y+=spacing), graphics->bounds.w, scale);
+
+		if(use_region == urBounce)
+		{
+			graphics->set_pen(white_pen);
+			graphics->line(Point(region.x+1, region.y+1), Point(region.x+1+region.w-3, region.y+1));
+			graphics->line(Point(region.x+1+region.w-3, region.y+1), Point(region.x+1+region.w-3, region.y+1+region.h-3));
+			graphics->line(Point(region.x+1+region.w-3, region.y+1+region.h-3), Point(region.x+1, region.y+1+region.h-3));
+			graphics->line(Point(region.x+1, region.y+1+region.h-3), Point(region.x+1, region.y+1));
+		}
+
+		render_time = timer.elapsed();
+
+		// now update the display
+		if(use_region != urNone){
+	    st7789->partial_update(graphics, region);
+		}
+		else {
+    	st7789->update(graphics);
+		}
+
+		update_time = timer.elapsed();
+		total_time  = total_timer.elapsed();
+
+  }
+
+  return 0;
+}

--- a/examples/pico_display/pico_display_async_region.cpp
+++ b/examples/pico_display/pico_display_async_region.cpp
@@ -239,7 +239,7 @@ int main() {
 
 		// if async wait for last update to finish before rendering
 		if(use_async_dma) {
-			st7789->waitForUpdateToFinish();
+			st7789->wait_for_update_to_finish();
 		}
 
 		dma_time = timer.elapsed();

--- a/libraries/pico_graphics/README.md
+++ b/libraries/pico_graphics/README.md
@@ -129,6 +129,28 @@ Rect b(15, 10, 10, 10);
 a.intersects(b) == true
 ```
 
+##### Rect.equals
+
+```c++
+bool Rect::equals(const Rect &r);
+```
+
+`equals` allows you to check if a `Rect` is equal to another `Rect`, so the rectangles are the same:
+
+```c++
+Rect a(10, 10, 10, 10);
+Rect b(30, 10, 10, 10);
+a.equals(b) == false
+```
+
+And these do:
+
+```c++
+Rect a(10, 10, 10, 10);
+Rect b(10, 10, 10, 10);
+a.equals(b) == true
+```
+
 ##### Rect.intersection
 
 ```c++

--- a/libraries/pico_graphics/pico_graphics.cpp
+++ b/libraries/pico_graphics/pico_graphics.cpp
@@ -11,6 +11,7 @@ namespace pimoroni {
   void PicoGraphics::set_pixel_dither(const Point &p, const RGB565 &c) {};
   void PicoGraphics::set_pixel_dither(const Point &p, const uint8_t &c) {};
   void PicoGraphics::frame_convert(PenType type, conversion_callback_func callback) {};
+  void PicoGraphics::rect_convert(PenType type, Rect rect, conversion_callback_func callback) {};
   void PicoGraphics::sprite(void* data, const Point &sprite, const Point &dest, const int scale, const int transparent) {};
 
   void PicoGraphics::set_dimensions(int width, int height) {
@@ -359,4 +360,28 @@ namespace pimoroni {
     // Callback with zero length to ensure previous buffer is fully written
     callback(row_buf[buf_idx], 0);
   }
+
+	void PicoGraphics::rect_convert_rgb565(Rect rect, conversion_callback_func callback, next_scanline_func get_next_scanline)
+  {
+    // Allocate two temporary buffers, as the callback may transfer by DMA
+    // while we're preparing the next part of the row
+    uint16_t row_buf[2][rect.w];
+    int buf_idx = 0;
+    for(auto i = 0; i < rect.h; i++) {
+			get_next_scanline(row_buf[buf_idx]);
+
+			// Transfer a filled buffer and swap to the next one
+			callback(row_buf[buf_idx], rect.w * sizeof(RGB565));
+			buf_idx ^= 1;
+    }
+
+    // Callback with zero length to ensure previous buffer is fully written
+    callback(row_buf[buf_idx], 0);
+  }
+
+	void PicoGraphics::create_owned_frame_buffer(size_t size_in_bytes) {
+		frame_buffer = (void*)new uint8_t[size_in_bytes];
+		owned_frame_buffer = true;
+	}
+
 }

--- a/libraries/pico_graphics/pico_graphics.hpp
+++ b/libraries/pico_graphics/pico_graphics.hpp
@@ -222,7 +222,8 @@ namespace pimoroni {
 
 		virtual ~PicoGraphics() 
 		{
-			delete (uint8_t*)frame_buffer;
+			if(owned_frame_buffer)
+				delete (uint8_t*)frame_buffer;
 		};
 
     virtual void set_pen(uint c) = 0;

--- a/libraries/pico_graphics/pico_graphics_pen_1bit.cpp
+++ b/libraries/pico_graphics/pico_graphics_pen_1bit.cpp
@@ -6,7 +6,7 @@ namespace pimoroni {
     : PicoGraphics(width, height, frame_buffer) {
     this->pen_type = PEN_1BIT;
     if(this->frame_buffer == nullptr) {
-      this->frame_buffer = (void *)(new uint8_t[buffer_size(width, height)]);
+			create_owned_frame_buffer(buffer_size(width, height));
     }
   }
 

--- a/libraries/pico_graphics/pico_graphics_pen_1bitY.cpp
+++ b/libraries/pico_graphics/pico_graphics_pen_1bitY.cpp
@@ -6,7 +6,7 @@ namespace pimoroni {
     : PicoGraphics(width, height, frame_buffer) {
     this->pen_type = PEN_1BIT;
     if(this->frame_buffer == nullptr) {
-      this->frame_buffer = (void *)(new uint8_t[buffer_size(width, height)]);
+      create_owned_frame_buffer(buffer_size(width, height));
     }
   }
 

--- a/libraries/pico_graphics/pico_graphics_pen_3bit.cpp
+++ b/libraries/pico_graphics/pico_graphics_pen_3bit.cpp
@@ -6,7 +6,7 @@ namespace pimoroni {
     : PicoGraphics(width, height, frame_buffer) {
         this->pen_type = PEN_3BIT;
         if(this->frame_buffer == nullptr) {
-            this->frame_buffer = (void *)(new uint8_t[buffer_size(width, height)]);
+            create_owned_frame_buffer(buffer_size(width, height));
         }
         cache_built = false;
     }

--- a/libraries/pico_graphics/pico_graphics_pen_3bit.cpp
+++ b/libraries/pico_graphics/pico_graphics_pen_3bit.cpp
@@ -118,4 +118,6 @@ namespace pimoroni {
             }
         }
     }
+		void PicoGraphics_Pen3Bit::rect_convert(PenType type, Rect rect, conversion_callback_func callback) {
+		};
 }

--- a/libraries/pico_graphics/pico_graphics_pen_p4.cpp
+++ b/libraries/pico_graphics/pico_graphics_pen_p4.cpp
@@ -6,7 +6,7 @@ namespace pimoroni {
     : PicoGraphics(width, height, frame_buffer) {
         this->pen_type = PEN_P4;
         if(this->frame_buffer == nullptr) {
-            this->frame_buffer = (void *)(new uint8_t[buffer_size(width, height)]);
+            create_owned_frame_buffer(buffer_size(width, height));
         }
         for(auto i = 0u; i < palette_size; i++) {
             palette[i] = {
@@ -150,6 +150,34 @@ namespace pimoroni {
 
                 return cache[b];
             });
+        }
+    }
+    void PicoGraphics_PenP4::rect_convert(PenType type, Rect rect, conversion_callback_func callback) {
+        if(type == PEN_RGB565) {
+						// Cache the RGB888 palette as RGB565
+						RGB565 cache[palette_size];
+						for(auto i = 0u; i < palette_size; i++) {
+								cache[i] = palette[i].to_rgb565();
+						}
+
+						uint scan_line = 0;
+						rect_convert_rgb565(rect, callback, [&](RGB565 *data) {
+								uint8_t *src = (uint8_t *)frame_buffer + (rect.x + ((rect.y + scan_line) * bounds.w)) / 2;
+								uint8_t o = (rect.x % 2 == 1) ? 0 : 4;
+
+								for(int32_t i= 0; i < rect.w; i++) {
+										uint8_t c = *src;
+										uint8_t b = (c >> o) & 0xf; // bit value shifted to position
+										
+										// Increment to next 4-bit entry 
+										o ^= 4;
+										if (o != 0) ++src;
+										
+										data[i] = cache[b];
+								}
+								
+								scan_line++;
+						});
         }
     }
 }

--- a/libraries/pico_graphics/pico_graphics_pen_p8.cpp
+++ b/libraries/pico_graphics/pico_graphics_pen_p8.cpp
@@ -5,7 +5,7 @@ namespace pimoroni {
     : PicoGraphics(width, height, frame_buffer) {
         this->pen_type = PEN_P8;
         if(this->frame_buffer == nullptr) {
-            this->frame_buffer = (void *)(new uint8_t[buffer_size(width, height)]);
+            create_owned_frame_buffer(buffer_size(width, height));
         }
         for(auto i = 0u; i < palette_size; i++) {
             palette[i] = {uint8_t(i), uint8_t(i), uint8_t(i)};
@@ -114,4 +114,24 @@ namespace pimoroni {
             });
         }
     }
+
+    void PicoGraphics_PenP8::rect_convert(PenType type, Rect rect, conversion_callback_func callback) {
+        if(type == PEN_RGB565) {
+            // Cache the RGB888 palette as RGB565
+            RGB565 cache[palette_size];
+            for(auto i = 0u; i < palette_size; i++) {
+                cache[i] = palette[i].to_rgb565();
+            }
+
+            // Treat our void* frame_buffer as uint8_t
+   					uint8_t *src = (uint8_t *)frame_buffer + rect.x + (rect.y * bounds.w);
+						rect_convert_rgb565(rect, callback, [&](RGB565 *data) {
+								for(int32_t i= 0; i < rect.w; i++) {
+									data[i] = cache[*src++]; 
+								}
+								src+=bounds.w - rect.w;
+            });
+        }
+    }
+		
 }

--- a/libraries/pico_graphics/pico_graphics_pen_rgb332.cpp
+++ b/libraries/pico_graphics/pico_graphics_pen_rgb332.cpp
@@ -6,7 +6,7 @@ namespace pimoroni {
     : PicoGraphics(width, height, frame_buffer) {
         this->pen_type = PEN_RGB332;
         if(this->frame_buffer == nullptr) {
-            this->frame_buffer = (void *)(new uint8_t[buffer_size(width, height)]);
+            create_owned_frame_buffer(buffer_size(width, height));
         }
     }
     void PicoGraphics_PenRGB332::set_pen(uint c) {
@@ -86,6 +86,17 @@ namespace pimoroni {
 
             frame_convert_rgb565(callback, [&]() {
                 return rgb332_to_rgb565_lut[*src++];
+            });
+        }
+    }
+    void PicoGraphics_PenRGB332::rect_convert(PenType type, Rect rect, conversion_callback_func callback) {
+        if(type == PEN_RGB565) {
+            // Treat our void* frame_buffer as uint8_t
+            uint8_t *src = (uint8_t *)frame_buffer + rect.x + (rect.y * bounds.w);
+            rect_convert_rgb565(rect, callback, [&](RGB565 *data) {
+								for(int32_t i= 0; i < rect.w; i++)
+									data[i] = rgb332_to_rgb565_lut[*src++];
+								src += bounds.w - rect.w;
             });
         }
     }

--- a/libraries/pico_graphics/pico_graphics_pen_rgb565.cpp
+++ b/libraries/pico_graphics/pico_graphics_pen_rgb565.cpp
@@ -5,7 +5,7 @@ namespace pimoroni {
     : PicoGraphics(width, height, frame_buffer) {
         this->pen_type = PEN_RGB565;
         if(this->frame_buffer == nullptr) {
-            this->frame_buffer = (void *)(new uint8_t[buffer_size(width, height)]);
+            create_owned_frame_buffer(buffer_size(width, height));
         }
     }
     void PicoGraphics_PenRGB565::set_pen(uint c) {

--- a/libraries/pico_graphics/pico_graphics_pen_rgb888.cpp
+++ b/libraries/pico_graphics/pico_graphics_pen_rgb888.cpp
@@ -5,7 +5,7 @@ namespace pimoroni {
     : PicoGraphics(width, height, frame_buffer) {
         this->pen_type = PEN_RGB888;
         if(this->frame_buffer == nullptr) {
-            this->frame_buffer = (void *)(new uint8_t[buffer_size(width, height)]);
+            create_owned_frame_buffer(buffer_size(width, height));
         }
     }
     void PicoGraphics_PenRGB888::set_pen(uint c) {

--- a/libraries/pico_graphics/types.cpp
+++ b/libraries/pico_graphics/types.cpp
@@ -28,6 +28,10 @@ namespace pimoroni {
     return !(x > r.x + r.w || x + w < r.x || y > r.y + r.h || y + h < r.y);
   }
 
+  bool Rect::equals(const Rect &r) const {
+    return r.x == x && r.y == y && r.w == w && r.h == h; 
+  }
+
   Rect Rect::intersection(const Rect &r) const {
     return Rect(std::max(x, r.x),
                 std::max(y, r.y),


### PR DESCRIPTION
I put in this PR to ask for some help testing this, basically it adds async DMA transfers for the st7789 and also partial updates.

There is a test example for the pico display for testing the new code, I am also waiting for a pico display 2. When that arrives I will port over the example for that.

I do not have the other st7789 Pimoroni displays though so these will not be tested, the PIO route is also not tested.

So is this PR something you guys would like to add in, you can get a nice speedup with these changes? 

Can someone help with testing these other displays?

Cheers

Andy




Changes
=======

Added async DMA for st7789. For 565  we don’t have to wait for the SPI transfer now.

Added partial update of display so we can just update a region via SPI.

Async DMA is also implemented for partial update for 565. As the DMA on the pico doesn’t support stride this is done using two DMA channels with chained transfers.

Added ability to destruct graphics and display.

For an overview look at pico_display_async_region.cpp, this is a test example, comments at top showing what is going on.


st7789 changes
============

Constructors changed to take use_async_dma parameter, defaults to false.

command() changed to take use_async_dma flag.

is_busy() implemented, returns true if waiting for async DMA.

wait_for_update_to_finish() added, this needs to be called if using async dma. Waits for dma to finish and disables the DMA chain.

Fix for display rotating for rotate180.

Added partial_update() implementation.

setup_dma_control_if_needed() added, sets up a second DMA channel for chained transfers.



Examples changes
===============

Added example test code for the pico display: pico_display_async_region.cpp



pico_graphics changes
=====================

rect_convert_rgb565() added, like frame+convert_rgb565() but for Rects/Regions.

rect_convert() added for each pen.

create_owned_frame_buffer() added to create frame buffer owned by us

destructor added to free up frame buffer if owned.


types 
====

Rect.equals() added to test equality of Rects.


pico_graphics_pen_1bit changes
=========================

Use create_owned_frame_buffer(0 to create frame buffer if none provided.


pico_graphics_pen_1bitY changes
==========================

Use create_owned_frame_buffer(0 to create frame buffer if none provided.


pico_graphics_pen_3bit changes
=========================

Use create_owned_frame_buffer(0 to create frame buffer if none provided.
Add empty rect_convert()


pico_graphics_pen_P4 changes
=========================

Use create_owned_frame_buffer(0 to create frame buffer if none provided.
Add rect_convert()


pico_graphics_pen_P8 changes
=========================

Use create_owned_frame_buffer(0 to create frame buffer if none provided.
Add rect_convert()


pico_graphics_pen_RGB332 changes
=============================

Use create_owned_frame_buffer(0 to create frame buffer if none provided.
Add rect_convert()


pico_graphics_pen_RGB565 changes
=============================

Use create_owned_frame_buffer(0 to create frame buffer if none provided.


pico_graphics_pen_RGB888 changes
=============================

Use create_owned_frame_buffer(0 to create frame buffer if none provided.






