### PR TITLE
Unicorn volume fix

### DIFF
--- a/libraries/galactic_unicorn/galactic_unicorn.cpp
+++ b/libraries/galactic_unicorn/galactic_unicorn.cpp
@@ -517,6 +517,7 @@ namespace pimoroni {
     value = value < 0.0f ? 0.0f : value;
     value = value > 1.0f ? 1.0f : value;
     this->volume = floor(value * 255.0f);
+    this->synth.volume = this->volume * 255.0f;
   }
 
   float GalacticUnicorn::get_volume() {

--- a/libraries/pico_synth/pico_synth.hpp
+++ b/libraries/pico_synth/pico_synth.hpp
@@ -106,7 +106,7 @@ namespace pimoroni {
 
   class PicoSynth {
   public:
-    const uint16_t volume = 0x2fff;
+    uint16_t volume = 0x2fff;
 
     static const uint CHANNEL_COUNT = 8;
     AudioChannel channels[CHANNEL_COUNT];


### PR DESCRIPTION
In reference to [#595](https://github.com/pimoroni/pimoroni-pico/issues/595), this makes the volume in PicoSynth changeable, and then reflects the volume setting in the GalacticUnicorn library into that.

side question: should there be a distinct `volume` within GalacticUnicorn at all, or should it just fully reflect PicoSynth? I've taken the approach of touching the bare minimum, but it could be done more thoroughly if desired...

I *think* that volume is currently only `const` because the bulk of the logic has been borrowed from the 32blit synth stuff, which has an externally set volume (via the firmware) but if I'm wrong and there's a really good reason for it, feel free to torpedo this PR :smiley_cat: 