### PR TITLE
usb-fix for Inky Frame Launcher

### DIFF
--- a/micropython/examples/inky_frame/inkylauncher/main.py
+++ b/micropython/examples/inky_frame/inkylauncher/main.py
@@ -11,7 +11,7 @@ import inky_helper as ih
 # WIFI_PASSWORD = "Your WiFi password"
 
 # A short delay to give USB chance to initialise
-time.sleep(0.1)
+time.sleep(0.5)
 
 # Setup for the display.
 graphics = PicoGraphics(DISPLAY)


### PR DESCRIPTION
Increased the delay to give the USB a little longer to initialise on startup.