### PR TITLE
Update network_manager.py

### DIFF
--- a/micropython/examples/common/network_manager.py
+++ b/micropython/examples/common/network_manager.py
@@ -23,6 +23,9 @@ class NetworkManager:
         return self._sta_if.isconnected() or self._ap_if.isconnected()
 
     def config(self, var):
+        # to handle joining some (slow) wifi APs. set power mode to get WiFi power-saving off
+        self._sta_if.config(pm = 0xa11140)
+
         if self._sta_if.active():
             return self._sta_if.config(var)
         else:


### PR DESCRIPTION
In order to successfully connect to more complicated AP setups (ie WPA-WPA2-WPA3) mesh networks, the power save mode needs to be in place. It is possible that a different mode can be set once a socket is opened. For now this is necessary for a range of ASUS routers/APs to be able to negotiate a connection.