### PR TITLE
List index out of range fix, remove default QR message if text files are available and file housekeeping

### DIFF
--- a/micropython/examples/badger2040/qrgen.py
+++ b/micropython/examples/badger2040/qrgen.py
@@ -19,9 +19,9 @@ except OSError:
 # create demo QR code file if no QR code files exist
 if len(CODES) == 0:
     try:
-        newQRcodeFilename = "qrcode.txt"
-        text = open("qrcodes/{}".format(newQRcodeFilename), "w")
-        text.write("""https://pimoroni.com/badger2040
+        new_qr_code_filename = "qrcode.txt"
+        with open(f"/qrcodes/{new_qr_code_filename}", "w") as text:
+            text.write("""https://pimoroni.com/badger2040
 Badger 2040
 * 296x128 1-bit e-ink
 * six user buttons
@@ -31,13 +31,12 @@ Badger 2040
 Scan this code to learn
 more about Badger 2040.
 """)
-        text.flush()
-        text.close()
+            text.flush()
 
-        # Set the CODES list to contain the newQRcodeFilename (created above)
-        CODES = [newQRcodeFilename]
+        # Set the CODES list to contain the new_qr_code_filename (created above)
+        CODES = [new_qr_code_filename]
 
-    except:
+    except OSError:
         CODES = []
 
 TOTAL_CODES = len(CODES)
@@ -51,18 +50,15 @@ state = {
     "current_qr": 0
 }
 
+
 def set_state_current_index_in_range():
     badger_os.state_load("qrcodes", state)
-    
     if state["current_qr"] >= len(CODES):
         state["current_qr"] = len(CODES) - 1  # set to last index (zero-based). Note: will set to -1 if currently 0
-
-    # check that the index is not negative, thus still out of range
-    if state["current_qr"] < 0:
+    if state["current_qr"] < 0:  # check that the index is not negative, thus still out of range
         state["current_qr"] = 0
-        
     badger_os.state_save("qrcodes", state)
-    
+
 
 def measure_qr_code(size, code):
     w, h = code.get_size()
@@ -86,12 +82,9 @@ def draw_qr_file(n):
     file = CODES[n]
 
     try:
-        codetext = open("qrcodes/{}".format(file), "r")
-
-        lines = codetext.read().strip().split("\n")
-        
-        codetext.close()
-    except:
+        with open(f"/qrcodes/{file}", "r") as codetext:
+            lines = codetext.read().strip().split("\n")
+    except OSError:
         lines = ["", "", "", "", "", "", "", "", "", ""]
 
     code_text = lines.pop(0)

--- a/micropython/examples/badger2040/qrgen.py
+++ b/micropython/examples/badger2040/qrgen.py
@@ -10,12 +10,18 @@ try:
 except OSError:
     pass
 
-# Check that there is a qrcode.txt, if not preload
+# Load all available QR Code Files
 try:
-    text = open("qrcodes/qrcode.txt", "r")
+    CODES = [f for f in os.listdir("/qrcodes") if f.endswith(".txt")]
 except OSError:
-    text = open("qrcodes/qrcode.txt", "w")
-    text.write("""https://pimoroni.com/badger2040
+    CODES = []
+
+# create demo QR code file if no QR code files exist
+if len(CODES) == 0:
+    try:
+        newQRcodeFilename = "qrcode.txt"
+        text = open("qrcodes/{}".format(newQRcodeFilename), "w")
+        text.write("""https://pimoroni.com/badger2040
 Badger 2040
 * 296x128 1-bit e-ink
 * six user buttons
@@ -25,20 +31,16 @@ Badger 2040
 Scan this code to learn
 more about Badger 2040.
 """)
-    text.flush()
-    text.seek(0)
+        text.flush()
+        text.seek(0)
 
-# Load all available QR Code Files
-try:
-    CODES = [f for f in os.listdir("/qrcodes") if f.endswith(".txt")]
-    TOTAL_CODES = len(CODES)
-except OSError:
-    pass
+        # Set the CODES list to contain the newQRcodeFilename (created above)
+        CODES = [newQRcodeFilename]
 
+    except:
+        CODES = []
 
-print(f'There are {TOTAL_CODES} QR Codes available:')
-for codename in CODES:
-    print(f'File: {codename}')
+TOTAL_CODES = len(CODES)
 
 display = badger2040.Badger2040()
 
@@ -60,7 +62,7 @@ def set_state_current_index_in_range():
         state["current_qr"] = 0
         
     badger_os.state_save("qrcodes", state)
-
+    
 
 def measure_qr_code(size, code):
     w, h = code.get_size()

--- a/micropython/examples/badger2040/qrgen.py
+++ b/micropython/examples/badger2040/qrgen.py
@@ -49,6 +49,18 @@ state = {
     "current_qr": 0
 }
 
+def set_state_current_index_in_range():
+    badger_os.state_load("qrcodes", state)
+    
+    if state["current_qr"] >= len(CODES):
+        state["current_qr"] = len(CODES) - 1  # set to last index (zero-based). Note: will set to -1 if currently 0
+
+    # check that the index is not negative, thus still out of range
+    if state["current_qr"] < 0:
+        state["current_qr"] = 0
+        
+    badger_os.state_save("qrcodes", state)
+
 
 def measure_qr_code(size, code):
     w, h = code.get_size()
@@ -110,7 +122,7 @@ def draw_qr_file(n):
     display.update()
 
 
-badger_os.state_load("qrcodes", state)
+set_state_current_index_in_range()
 changed = not badger2040.woken_by_button()
 
 while True:

--- a/micropython/examples/badger2040/qrgen.py
+++ b/micropython/examples/badger2040/qrgen.py
@@ -32,7 +32,7 @@ Scan this code to learn
 more about Badger 2040.
 """)
         text.flush()
-        text.seek(0)
+        text.close()
 
         # Set the CODES list to contain the newQRcodeFilename (created above)
         CODES = [newQRcodeFilename]
@@ -84,9 +84,16 @@ def draw_qr_code(ox, oy, size, code):
 def draw_qr_file(n):
     display.led(128)
     file = CODES[n]
-    codetext = open("qrcodes/{}".format(file), "r")
 
-    lines = codetext.read().strip().split("\n")
+    try:
+        codetext = open("qrcodes/{}".format(file), "r")
+
+        lines = codetext.read().strip().split("\n")
+        
+        codetext.close()
+    except:
+        lines = ["", "", "", "", "", "", "", "", "", ""]
+
     code_text = lines.pop(0)
     title_text = lines.pop(0)
     detail_text = lines


### PR DESCRIPTION
Hello!

I'm planning on taking my Badger2040 to an event soon and in doing so, needed to update the QR codes that were available for display in qrgen.py. In setting up the new files, I ended up with one fewer file than I had previously uploaded and so when trying to display the QR codes from the launcher, instead of seeing the first QR code, I received a warning saying "List index out of range".

After some debugging, I discovered that this was because the state/qrcodes.json file had remembered the last QR code viewed and that the index of this was now higher than the count of text files in the qrcodes folder.

Commit [eb7eaae](https://github.com/pimoroni/pimoroni-pico/commit/eb7eaae88532d29cb392947ff464544b39899841) loads the state, checks to see if the last viewed index is in range and if the index isn't, set it in range. Finally, saving the state back.

It is a little annoying for the demo QR code to show, regardless of whether QR code files have been uploaded, so commit  [77ee234](https://github.com/pimoroni/pimoroni-pico/commit/77ee234caa1815693c02ae7847bb511336b807cf) checks to see if there are any QR code text files in the qrcodes directory and only create the demo screen file if there aren't any.

I also noticed that files are being opened on screen refresh but not closed. I don't know if micropython automatically closes these file handles after a set period (like garbage collection) but commit [9aedf16](https://github.com/pimoroni/pimoroni-pico/commit/9aedf16bb5d5f75d2b12a1339f6487ef115d0235) closes them explicitly, in case these aren't tidied up automatically.