### PR TITLE
Added PEN_RGB332 support

### DIFF
--- a/libraries/galactic_unicorn/galactic_unicorn.cpp
+++ b/libraries/galactic_unicorn/galactic_unicorn.cpp
@@ -560,6 +560,21 @@ namespace pimoroni {
           set_pixel(x, y, r, g, b);
         }
       }
+      else if(graphics->pen_type == PicoGraphics::PEN_RGB332) {
+        uint8_t *p = (uint8_t *)graphics->frame_buffer;
+        for(size_t j = 0; j < 53 * 11; j++) {
+          int x = j % 53;
+          int y = j / 53;
+
+          uint8_t col = *p;
+          uint8_t r = (col & 0b11100000);
+          uint8_t g = (col & 0b00011100) << 3;
+          uint8_t b = (col & 0b00000011) << 6;
+          p++;
+
+          set_pixel(x, y, r, g, b);
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Enables support for PEN_RGB332 on the Galactic Unicorn; this is necessary to support the sprite functions of PicoGraphics, which only work with that pen.

(This replaces https://github.com/pimoroni/pimoroni-pico/pull/616 with a single commit PR that doesn't mess up random other line endings too, after I made a *real* mess of that original branch trying to make it better - sorry!)