### PR TITLE
Update to Badger 2040 W getting started

### DIFF
--- a/micropython/modules/badger2040w/README.md
+++ b/micropython/modules/badger2040w/README.md
@@ -50,7 +50,7 @@ Additionally Badger 2040 W does not have a "user" button since the BOOTSEL butto
 
 ## Getting Started
 
-:warning: If you're using the examples-included firmware you're good to go, otherwise you'll need to copy `examples/badger2040w/lib/badger2040w.py` and `examples/badger2040w/lib/network_manager.py` over to your Badger 2040 W.
+:warning: If you're using the examples-included firmware you're good to go, otherwise you'll need to copy `examples/badger2040w/lib/badger2040w.py`, `micropython/examples/badger2040w/WIFI_CONFIG.py`and `examples/badger2040w/lib/network_manager.py` over to your Badger 2040 W.
 
 To start coding your Badger 2040 W, you will need to add the following lines of code to the start of your code file.
 


### PR DESCRIPTION
When installing the alternative firmware I saw the notice at the top of the README that the "badger2040w.py" and "network_manager.py" files need to be downloaded separately. After adding these two scrips to the Badgerw it gave `ImportError: no module named 'WIFI_CONFIG'`. This was not something that the README said was required. Therefore my PR adds the "WIFI_CONFIG.py" to the top README file.