### PR TITLE
CI: Separate CCache cache for Pico/PicoW.

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -28,8 +28,9 @@ jobs:
       uses: actions/cache@v3
       with:
         path: /home/runner/.ccache
-        key: ccache-cmake-${{github.ref}}-${{github.sha}}
+        key: ccache-cmake-${{github.ref}}-${{matrix.board}}-${{github.sha}}
         restore-keys: |
+          ccache-cmake-${{github.ref}}-${{matrix.board}}
           ccache-cmake-${{github.ref}}
           ccache-cmake
 


### PR DESCRIPTION
Try to fix the LONG CMake compile for Pico W mentioned in #642

Note: It's expected that this will probably *not* speed up the first time it's run... so poke this PR when it finishes.