### PR TITLE
MicroPython: Tidy up CMake files for our boards.

### DIFF
--- a/micropython/modules/micropython-common.cmake
+++ b/micropython/modules/micropython-common.cmake
@@ -29,4 +29,12 @@ include(galactic_unicorn/micropython)
 
 include(modules_py/modules_py)
 
+# Most board specific ports wont need all of these
+copy_module(gfx_pack.py)
+copy_module(interstate75.py)
+if(PICO_BOARD STREQUAL "pico_w")
+    copy_module(automation.py)
+    copy_module(inventor.py)
+endif()
+
 include(micropython-common-ulab)

--- a/micropython/modules/micropython-picow_inky_frame.cmake
+++ b/micropython/modules/micropython-picow_inky_frame.cmake
@@ -40,7 +40,6 @@ include(servo/micropython)
 include(encoder/micropython)
 include(motor/micropython)
 
-# include(micropython-common)
-
 include(modules_py/modules_py)
 
+copy_module(inky_frame.py)

--- a/micropython/modules/micropython-tufty2040.cmake
+++ b/micropython/modules/micropython-tufty2040.cmake
@@ -4,4 +4,36 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/../")
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/../../")
 
-include(micropython-common)
+# Essential
+include(pimoroni_i2c/micropython)
+include(pimoroni_bus/micropython)
+
+# Pico Graphics Essential
+include(hershey_fonts/micropython)
+include(bitmap_fonts/micropython)
+include(picographics/micropython)
+
+# Pico Graphics Extra
+include(jpegdec/micropython)
+include(qrcode/micropython/micropython)
+
+# Sensors & Breakouts
+include(micropython-common-breakouts)
+include(pcf85063a/micropython)
+
+# Utility
+include(adcfft/micropython)
+
+# LEDs & Matrices
+include(plasma/micropython)
+
+# Servos & Motors
+include(pwm/micropython)
+include(servo/micropython)
+include(encoder/micropython)
+include(motor/micropython)
+
+include(micropython-common-ulab)
+enable_ulab()
+
+include(modules_py/modules_py)

--- a/micropython/modules/test.cmake
+++ b/micropython/modules/test.cmake
@@ -1,0 +1,14 @@
+include_directories(${CMAKE_CURRENT_LIST_DIR}/../../)
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/../")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/../../")
+
+# Essential
+include(pimoroni_i2c/micropython)
+include(pimoroni_bus/micropython)
+
+# Pico Graphics Essential
+include(hershey_fonts/micropython)
+include(bitmap_fonts/micropython)
+include(picographics/micropython)

--- a/micropython/modules_py/modules_py.cmake
+++ b/micropython/modules_py/modules_py.cmake
@@ -1,42 +1,36 @@
-function (copy_module TARGET SRC DST)
+set(MODULES_DIR ${CMAKE_CURRENT_LIST_DIR})
+
+function (copy_module MODULE)
     add_custom_command(
-        OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/../modules/${DST}.py
+        OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/../modules/${MODULE}
 
         COMMAND
-            cp ${SRC} ${CMAKE_CURRENT_BINARY_DIR}/../modules/${DST}.py
+            cp ${MODULES_DIR}/${MODULE} ${CMAKE_CURRENT_BINARY_DIR}/../modules/${MODULE}
 
-        DEPENDS ${src}
+        DEPENDS ${MODULES_DIR}/${MODULE}
     )
 
-    target_sources(${TARGET} INTERFACE ${CMAKE_CURRENT_BINARY_DIR}/../modules/${DST}.py)
+    target_sources(usermod_modules_py INTERFACE ${CMAKE_CURRENT_BINARY_DIR}/../modules/${MODULE})
 endfunction()
 
-function (genversion TARGET DST)
+function (genversion VERSION_FILE)
     add_custom_command(
-        OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/../modules/${DST}.py
+        OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/../modules/${VERSION_FILE}
 
         COMMAND
-            bash ${CMAKE_CURRENT_LIST_DIR}/genversion.sh ${CMAKE_CURRENT_BINARY_DIR}/../modules/${DST}.py
+            bash ${MODULES_DIR}/genversion.sh ${CMAKE_CURRENT_BINARY_DIR}/../modules/${VERSION_FILE}
 
-        DEPENDS ${CMAKE_CURRENT_LIST_DIR}/genversion.sh
+        DEPENDS ${MODULES_DIR}/genversion.sh
     )
 
-    target_sources(${TARGET} INTERFACE ${CMAKE_CURRENT_BINARY_DIR}/../modules/${DST}.py)
+    target_sources(usermod_modules_py INTERFACE ${CMAKE_CURRENT_BINARY_DIR}/../modules/${VERSION_FILE})
 endfunction()
 
 # Create a dummy usermod to hang our .py copies from
 add_library(usermod_modules_py INTERFACE)
 target_link_libraries(usermod INTERFACE usermod_modules_py)
 
-genversion(usermod_modules_py version)
+genversion(version.py)
 
 # .py files to copy from modules_py to ports/rp2/modules
-#copy_module(usermod_modules_py ${CMAKE_CURRENT_LIST_DIR}/picosystem.py picosystem)
-copy_module(usermod_modules_py ${CMAKE_CURRENT_LIST_DIR}/pimoroni.py pimoroni)
-copy_module(usermod_modules_py ${CMAKE_CURRENT_LIST_DIR}/gfx_pack.py gfx_pack)
-copy_module(usermod_modules_py ${CMAKE_CURRENT_LIST_DIR}/interstate75.py interstate75)
-if(PICO_BOARD STREQUAL "pico_w")
-    copy_module(usermod_modules_py ${CMAKE_CURRENT_LIST_DIR}/automation.py automation)
-    copy_module(usermod_modules_py ${CMAKE_CURRENT_LIST_DIR}/inventor.py inventor)
-    copy_module(usermod_modules_py ${CMAKE_CURRENT_LIST_DIR}/inky_frame.py inky_frame)
-endif()
+copy_module(pimoroni.py)


### PR DESCRIPTION
* Feature parity between Badger 2040 and Tufty 2040.
* Add ulab to Tufty 2040.
* Don't include modules_py modules for boards that don't use/need them.
* Tweak modules_py.cmake so modules can be copied by parent CMake files.
* Simplify copy_module function to avoid repetition.