### PR TITLE
clock.py: constrain hour to 0 to 24

### DIFF
--- a/micropython/examples/cosmic_unicorn/clock.py
+++ b/micropython/examples/cosmic_unicorn/clock.py
@@ -180,7 +180,7 @@ def redraw_display_if_reqd():
 
     year, month, day, wd, hour, minute, second, _ = rtc.datetime()
     if second != last_second:
-        hour += utc_offset
+        hour = (hour + utc_offset) % 24
         time_through_day = (((hour * 60) + minute) * 60) + second
         percent_through_day = time_through_day / 86400
         percent_to_midday = 1.0 - ((math.cos(percent_through_day * math.pi * 2) + 1) / 2)

--- a/micropython/examples/galactic_unicorn/clock.py
+++ b/micropython/examples/galactic_unicorn/clock.py
@@ -180,7 +180,7 @@ def redraw_display_if_reqd():
 
     year, month, day, wd, hour, minute, second, _ = rtc.datetime()
     if second != last_second:
-        hour += utc_offset
+        hour = (hour + utc_offset) % 24
         time_through_day = (((hour * 60) + minute) * 60) + second
         percent_through_day = time_through_day / 86400
         percent_to_midday = 1.0 - ((math.cos(percent_through_day * math.pi * 2) + 1) / 2)

--- a/micropython/examples/interstate75/75W/clock.py
+++ b/micropython/examples/interstate75/75W/clock.py
@@ -156,7 +156,7 @@ def redraw_display_if_reqd():
 
     year, month, day, wd, hour, minute, second, _ = rtc.datetime()
     if second != last_second:
-        hour += utc_offset
+        hour = (hour + utc_offset) % 24
         time_through_day = (((hour * 60) + minute) * 60) + second
         percent_through_day = time_through_day / 86400
         percent_to_midday = 1.0 - ((math.cos(percent_through_day * math.pi * 2) + 1) / 2)


### PR DESCRIPTION
Use a modulo to constrain the displayed hour to 0 - 24 after applying the UTC offset.

Very small change to the Galactic Unicorn, Cosmic Unicorn, and Interstate75 `clock.py` examples.