### PR TITLE
Inky Frame word clock example - swapping out NTP for Open Meteo API

### DIFF
--- a/micropython/examples/inky_frame/inkylauncher/word_clock.py
+++ b/micropython/examples/inky_frame/inkylauncher/word_clock.py
@@ -57,7 +57,7 @@ def update():
         datetime = datetime.replace(":", "-")
         (year, month, day, hours, minutes) = datetime.split("-")
         print(f"Local time derived from Open-Meteo API: {year}, {month}, {day}, {hours}, {minutes}")
-        rtc.datetime()
+        rtc.datetime((int(year), int(month), int(day), int(hours), int(minutes), 0, 0, 0))
     except OSError as e:
         print("Unable to contact Time server")
 


### PR DESCRIPTION
This PR swaps out the NTP call  for the word clock app and replaces it with the Badger 2040W weather app code which calls the Open Meteo API, then it tries to set the RTC based on the results of the Open Meteo API call. With a following wind we should end up with the correct local time for the lat/long supplied, rather than UTC. Just a quick hack so not expecting you to commit to the repo, but might be useful somewhere!