### PR TITLE
Inky Frame: longer sleep_for

### DIFF
--- a/micropython/modules_py/inky_frame.py
+++ b/micropython/modules_py/inky_frame.py
@@ -87,17 +87,21 @@ def sleep_for(minutes):
     if second >= 55:
         minute += 1
 
-    minute += minutes
+    # Can't sleep beyond a month, so clamp the sleep to a 28 day maximum
+    minutes = min(minutes, 40320)
 
-    while minute >= 60:
-        minute -= 60
-        hour += 1
+    # Calculate the future alarm date; first, turn the current time into seconds since epoch
+    sec_since_epoch = time.mktime((year, month, day, hour, minute, second, dow, 0))
 
-    if hour >= 24:
-        hour -= 24
+    # Add the required minutes to this
+    sec_since_epoch += minutes * 60
 
+    # And convert it back into a more useful tuple
+    (ayear, amonth, aday, ahour, aminute, asecond, adow, adoy) = time.localtime(sec_since_epoch)
+
+    # And now set the alarm as before, now including the day
     rtc.clear_alarm_flag()
-    rtc.set_alarm(0, minute, hour)
+    rtc.set_alarm(0, aminute, ahour, aday)
     rtc.enable_alarm_interrupt(True)
 
     turn_off()


### PR DESCRIPTION
Expanded `sleep_for()` function to allow for sleeps longer than 24 hours - by adding the day component to the alarm, this maximum can be stretched to a month (capped at 28 days)

I've validated the code as best I can, but I don't actually possess an Inky Frame myself :-)

ref: https://github.com/pimoroni/pimoroni-pico/issues/744