### PR TITLE
MicroPython: Set board manifest for Inky, Enviro.

### DIFF
--- a/micropython/board/PICO_W_ENVIRO/mpconfigboard.cmake
+++ b/micropython/board/PICO_W_ENVIRO/mpconfigboard.cmake
@@ -1,5 +1,7 @@
-# cmake file for Raspberry Pi Pico W
+# cmake file for Pimoroni Enviro with Raspberry Pi Pico W
 set(MICROPY_BOARD PICO_W)
 
 set(MICROPY_PY_LWIP ON)
 set(MICROPY_PY_NETWORK_CYW43 ON)
+
+set(MICROPY_FROZEN_MANIFEST ${MICROPY_BOARD_DIR}/manifest.py)

--- a/micropython/board/PICO_W_INKY/mpconfigboard.cmake
+++ b/micropython/board/PICO_W_INKY/mpconfigboard.cmake
@@ -1,5 +1,7 @@
-# cmake file for Raspberry Pi Pico W
+# cmake file for Pimoroni Inky with Raspberry Pi Pico W
 set(MICROPY_BOARD PICO_W)
 
 set(MICROPY_PY_LWIP ON)
 set(MICROPY_PY_NETWORK_CYW43 ON)
+
+set(MICROPY_FROZEN_MANIFEST ${MICROPY_BOARD_DIR}/manifest.py)


### PR DESCRIPTION
Inky was missing `ntptime` since the `manifest.py` file was not being processed.