### PR TITLE
Fix relative link to PicoGraphics documentation

### DIFF
--- a/micropython/modules_py/inky_frame.md
+++ b/micropython/modules_py/inky_frame.md
@@ -19,7 +19,7 @@ Most of your interaction with Inky Frame will be via the PicoGraphics library, b
 ## Pico Graphics
 
 You can draw on Inky Frame using our PicoGraphics display library.
-- [PicoGraphics MicroPython function reference](../../modules/picographics)
+- [PicoGraphics MicroPython function reference](../modules/picographics)
 
 ### Colour & Dithering
 


### PR DESCRIPTION
It also seems to have changed the last line in the file - I guess it's added a carriage return or something similar.