### PR TITLE
Fixes for compilation under macOS / GCC 13.3.1

### DIFF
--- a/drivers/ltp305/ltp305.cpp
+++ b/drivers/ltp305/ltp305.cpp
@@ -64,8 +64,8 @@ namespace pimoroni {
   }
 
   void LTP305::set_character(uint8_t x, uint16_t ch) {
-    uint8_t *data = nullptr;
-    for(auto c : dotfont) {
+    const uint8_t *data = nullptr;
+    for(const auto& c : dotfont) {
       if(c.code == ch) {
         data = &c.data[0];
         break;

--- a/drivers/vl53l1x/vl53l1x.cpp
+++ b/drivers/vl53l1x/vl53l1x.cpp
@@ -217,7 +217,7 @@ namespace pimoroni {
     i2c->read_blocking(address, (uint8_t *)&value, 4, false);
 
     // TODO do we need to bswap this return value?
-    return __bswap32(value);
+    return __builtin_bswap32(value);
   }
 
   // set distance mode to Short, Medium, or Long

--- a/libraries/hershey_fonts/hershey_fonts.hpp
+++ b/libraries/hershey_fonts/hershey_fonts.hpp
@@ -1,6 +1,7 @@
 #include <map>
 #include <string>
 #include <functional>
+#include <cstdint>
 
 namespace hershey {
   struct font_glyph_t {


### PR DESCRIPTION
These fixes were required to make the current `main` branch compile on macOS 13.3.1 using `arm-none-eabi-gcc @13.1.0` from MacPorts.
