### PR TITLE
Fix out of box failure when ARM toolchain is not in path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ function(add_resource target file)
             ${CMAKE_CURRENT_SOURCE_DIR}/${FILENAME}
             ${CMAKE_CURRENT_BINARY_DIR}
 
-    COMMAND arm-none-eabi-ld -r -b binary -o ${NAME}.o ${FILENAME}
+    COMMAND $ENV{PICO_TOOLCHAIN_PATH}arm-none-eabi-ld -r -b binary -o ${NAME}.o ${FILENAME}
     DEPENDS ${FILENAME}
   )
 


### PR DESCRIPTION
When the ARM toolchain is not on the path and is specified with the environment variable `PICO_TOOLCHAIN_PATH`, linking in the pico_explorer example fails as it can't find `arm-none-eabi-ld`.

  - Add expansion of PICO_TOOLCHAIN_PATH for arm-none-eabi-ld into base `CMakeLists.txt`

Tested on Linux (Kubuntu 22.04) and macOS (Monterey).