### PR TITLE
fix: Only set time if the wlan is connected

### DIFF
--- a/micropython/examples/interstate75/75W/clock.py
+++ b/micropython/examples/interstate75/75W/clock.py
@@ -129,7 +129,7 @@ def sync_time():
 
         redraw_display_if_reqd()
 
-    if max_wait > 0:
+    if wlan.status() == 3:
         print("Connected")
 
         try:


### PR DESCRIPTION
Previously, if we dropped out of the wlan loop early because of an error (wlan.status() < 0) it would still print "Connected", and try to set the time.