### PR TITLE
Added some PicoGraphics based MP examples for the PicoUnicorn

### DIFF
--- a/micropython/examples/pico_unicorn/demo-picographics.py
+++ b/micropython/examples/pico_unicorn/demo-picographics.py
@@ -1,0 +1,38 @@
+# This is a PicoGraphics version of the original demo.py
+
+from picounicorn import PicoUnicorn
+from picographics import PicoGraphics, DISPLAY_UNICORN_PACK
+
+picounicorn = PicoUnicorn()
+graphics = PicoGraphics(display=DISPLAY_UNICORN_PACK)
+
+w = picounicorn.get_width()
+h = picounicorn.get_height()
+
+# Display a rainbow across Pico Unicorn
+for x in range(w):
+    for y in range(h):
+        # PicoGraphics allows us to set HSV pens directly
+        PEN = graphics.create_pen_hsv(x / w, y / h, 1.0)
+        graphics.set_pen(PEN)
+        graphics.pixel(x, y)
+
+# Ask the Unicorn to update the graphics
+picounicorn.update(graphics)
+
+print("Press Button A")
+
+while not picounicorn.is_pressed(picounicorn.BUTTON_A):  # Wait for Button A to be pressed
+    pass
+
+# Clear the display
+
+# Set the pen to black
+BLACK = graphics.create_pen(0, 0, 0)
+graphics.set_pen(BLACK)
+graphics.clear()
+
+# Ask the Unicorn to update the graphics
+picounicorn.update(graphics)
+
+print("Button A pressed!")

--- a/micropython/examples/pico_unicorn/rainbow-picographics.py
+++ b/micropython/examples/pico_unicorn/rainbow-picographics.py
@@ -1,0 +1,26 @@
+# This is a PicoGraphics version of the original demo.py
+
+from picounicorn import PicoUnicorn
+from picographics import PicoGraphics, DISPLAY_UNICORN_PACK
+import time
+
+picounicorn = PicoUnicorn()
+graphics = PicoGraphics(display=DISPLAY_UNICORN_PACK)
+
+w = picounicorn.get_width()
+h = picounicorn.get_height()
+
+while True:
+    t = time.ticks_ms() / 3600
+    for x in range(w):
+        for y in range(h):
+            # PicoGraphics allows us to set HSV pens directly
+            PEN = graphics.create_pen_hsv(t + ((x + y) / w / 4), 1.0, 1.0)
+            graphics.set_pen(PEN)
+            graphics.pixel(x, y)
+
+    # Ask the Unicorn to update the graphics
+    picounicorn.update(graphics)
+
+    # And sleep, so we update ~ 60fps
+    time.sleep(1.0 / 60)

--- a/micropython/examples/pico_unicorn/vertical-fire.py
+++ b/micropython/examples/pico_unicorn/vertical-fire.py
@@ -1,0 +1,91 @@
+import time
+import random
+from picounicorn import PicoUnicorn
+from picographics import PicoGraphics, DISPLAY_UNICORN_PACK
+
+'''
+A pretty, procedural fire effect. Based on fire_effect.py from bigger Unicorns!
+'''
+
+picounicorn = PicoUnicorn()
+graphics = PicoGraphics(display=DISPLAY_UNICORN_PACK)
+
+fire_colours = [graphics.create_pen(0, 0, 0),
+                graphics.create_pen(20, 20, 20),
+                graphics.create_pen(180, 30, 0),
+                graphics.create_pen(220, 160, 0),
+                graphics.create_pen(255, 255, 180)]
+
+
+@micropython.native  # noqa: F821
+def update():
+    # take local references as it's quicker than accessing the global
+    # and we access it a lot in this method
+    _heat = heat
+
+    # clear the bottom row and then add a new fire seed to it
+    for x in range(width):
+        _heat[x][height - 1] = 0.0
+        _heat[x][height - 2] = 0.0
+
+    for c in range(fire_spawns):
+        x = random.randint(0, width - 4) + 2
+        _heat[x + 0][height - 1] = 1.0
+        _heat[x + 1][height - 1] = 1.0
+        _heat[x - 1][height - 1] = 1.0
+        _heat[x + 0][height - 2] = 1.0
+        _heat[x + 1][height - 2] = 1.0
+        _heat[x - 1][height - 2] = 1.0
+
+    factor = damping_factor / 5.0
+    for y in range(0, height - 2):
+        for x in range(1, width - 1):
+            _heat[x][y] += _heat[x][y + 1] + _heat[x][y + 2] + _heat[x - 1][y + 1] + _heat[x + 1][y + 1]
+            _heat[x][y] *= factor
+
+
+@micropython.native  # noqa: F821
+def draw():
+    # take local references as it's quicker than accessing the global
+    # and we access it a lot in this method
+    _graphics = graphics
+    _heat = heat
+    _set_pen = graphics.set_pen
+    _pixel = graphics.pixel
+    _fire_colours = fire_colours
+
+    for y in range(picounicorn.get_height()):
+        for x in range(picounicorn.get_width()):
+            value = _heat[y][x]
+            if value < 0.15:
+                _set_pen(_fire_colours[0])
+            elif value < 0.25:
+                _set_pen(_fire_colours[1])
+            elif value < 0.35:
+                _set_pen(_fire_colours[2])
+            elif value < 0.45:
+                _set_pen(_fire_colours[3])
+            else:
+                _set_pen(_fire_colours[4])
+            _pixel(x, y)
+
+    picounicorn.update(_graphics)
+
+
+width = picounicorn.get_height() + 2
+height = picounicorn.get_width() + 4
+heat = [[0.0 for y in range(height)] for x in range(width)]
+fire_spawns = 1
+damping_factor = 0.97
+
+while True:
+
+    start = time.ticks_ms()
+
+    update()
+    draw()
+
+    print("total took: {} ms".format(time.ticks_ms() - start))
+
+    # And sleep, so we update ~ 60fps
+    time.sleep(1.0 / 60)

--- a/micropython/examples/pico_unicorn/vertical-fire.py
+++ b/micropython/examples/pico_unicorn/vertical-fire.py
@@ -56,7 +56,7 @@ def draw():
 
     for y in range(picounicorn.get_height()):
         for x in range(picounicorn.get_width()):
-            value = _heat[y][x]
+            value = _heat[y + 1][x]
             if value < 0.15:
                 _set_pen(_fire_colours[0])
             elif value < 0.25:

--- a/micropython/modules/picographics/README.md
+++ b/micropython/modules/picographics/README.md
@@ -73,6 +73,7 @@ Bear in mind that MicroPython has only 192K of RAM available- a 320x240 pixel di
 * Interstate75 and 75W - HUB75 Matrix driver - `DISPLAY_INTERSTATE75_SIZEOFMATRIX` please read below!
 * Cosmic Unicorn - 32x32 LED Matrix - `DISPLAY_COSMIC_UNICORN`
 * Stellar Unicorn - 16x16 LED Matrix - `DISPLAY_STELLAR_UNICORN`
+* Pico Unicorn Pack - 16x7 LED Matrix - `DISPLAY_UNICORN_PACK`
 
 #### Interstate75 and Interstate75W Display modes
 
@@ -274,7 +275,7 @@ Send the contents of your Pico Graphics buffer to your screen:
 display.update()
 ```
 
-If you are using a Galactic Unicorn, then the process for updating the display is different. Instead of the above, do:
+If you are using a Unicorn (Galactic, Cosmic, Stellar or Pico), then the process for updating the display is different. Instead of the above, do:
 
 ```python
 galactic_unicorn.update(display)


### PR DESCRIPTION
As mentioned on the [forum](https://forums.pimoroni.com/t/pico-unicorn-pico-graphics/22811/4), the examples for the Pico Unicorn Pack used the 'native' graphics, rather than the newer PicoGraphics based ones.

Duplicated the two existing examples into `-picographics` versions, and added a version of `fire-effect.py` from the other Unicorns' examples, turned on it's side to get a bit more height displayed!

Also updated the PicoGraphics readme to (a) acknowledge the existence of the Pico Unicorn, and (b) mention that the special `update()` handling applies to *all* Unicorns, not just the Galactic.