### PR TITLE
Fix clean Micropython build

### DIFF
--- a/drivers/encoder/encoder.cpp
+++ b/drivers/encoder/encoder.cpp
@@ -4,7 +4,10 @@
 #include "hardware/irq.h"
 #include "hardware/clocks.h"
 #include "encoder.hpp"
+
+#ifndef NO_QSTR
 #include "encoder.pio.h"
+#endif
 
 #define LAST_STATE(state)  ((state) & 0b0011)
 #define CURR_STATE(state)  (((state) & 0b1100) >> 2)

--- a/drivers/hub75/hub75.hpp
+++ b/drivers/hub75/hub75.hpp
@@ -5,7 +5,10 @@
 #include "hardware/dma.h"
 #include "hardware/irq.h"
 #include "libraries/pico_graphics/pico_graphics.hpp"
+
+#ifndef NO_QSTR
 #include "hub75.pio.h"
+#endif
 
 namespace pimoroni {
 const uint DATA_BASE_PIN = 0;

--- a/drivers/hub75_legacy/hub75.hpp
+++ b/drivers/hub75_legacy/hub75.hpp
@@ -4,7 +4,10 @@
 #include "hardware/pio.h"
 #include "hardware/dma.h"
 #include "hardware/irq.h"
+
+#ifndef NO_QSTR
 #include "hub75.pio.h"
+#endif
 
 const uint DATA_BASE_PIN = 0;
 const uint DATA_N_PINS = 6;

--- a/drivers/plasma/apa102.hpp
+++ b/drivers/plasma/apa102.hpp
@@ -14,7 +14,9 @@ found here: https://github.com/raspberrypi/pico-examples/tree/master/pio/apa102
 #include <math.h>
 #include <cstdint>
 
+#ifndef NO_QSTR
 #include "apa102.pio.h"
+#endif
 
 #include "pico/stdlib.h"
 #include "hardware/pio.h"

--- a/drivers/plasma/ws2812.hpp
+++ b/drivers/plasma/ws2812.hpp
@@ -14,7 +14,9 @@ found here: https://github.com/raspberrypi/pico-examples/tree/master/pio/ws2812
 #include <math.h>
 #include <cstdint>
 
+#ifndef NO_QSTR
 #include "ws2812.pio.h"
+#endif
 
 #include "pico/stdlib.h"
 #include "hardware/pio.h"

--- a/drivers/pwm/pwm_cluster.cpp
+++ b/drivers/pwm/pwm_cluster.cpp
@@ -1,7 +1,10 @@
 #include "pwm_cluster.hpp"
 #include "hardware/gpio.h"
 #include "hardware/clocks.h"
+
+#ifndef NO_QSTR
 #include "pwm_cluster.pio.h"
+#endif
 
 // Uncomment the below line to enable debugging
 //#define DEBUG_MULTI_PWM

--- a/drivers/sdcard/pio_spi.h
+++ b/drivers/sdcard/pio_spi.h
@@ -7,7 +7,9 @@
 #define _PIO_SPI_H
 
 #include "hardware/pio.h"
+#ifndef NO_QSTR
 #include "spi.pio.h"
+#endif
 
 typedef struct pio_spi_inst {
     PIO pio;

--- a/drivers/st7789/st7789.hpp
+++ b/drivers/st7789/st7789.hpp
@@ -11,7 +11,9 @@
 #include "libraries/pico_graphics/pico_graphics.hpp"
 
 
+#ifndef NO_QSTR
 #include "st7789_parallel.pio.h"
+#endif
 
 #include <algorithm>
 

--- a/examples/pico_explorer_encoder/pico_explorer_encoder.cpp
+++ b/examples/pico_explorer_encoder/pico_explorer_encoder.cpp
@@ -3,7 +3,11 @@
 #include "pico_explorer.hpp"
 #include "pico/stdlib.h"
 #include "encoder.hpp"
+
+#ifndef NO_QSTR
 #include "quadrature_out.pio.h"
+#endif
+
 #include "drivers/st7789/st7789.hpp"
 #include "libraries/pico_graphics/pico_graphics.hpp"
 #include "button.hpp"

--- a/libraries/cosmic_unicorn/cosmic_unicorn.cpp
+++ b/libraries/cosmic_unicorn/cosmic_unicorn.cpp
@@ -6,8 +6,10 @@
 #include "hardware/clocks.h"
 
 
+#ifndef NO_QSTR
 #include "cosmic_unicorn.pio.h"
 #include "audio_i2s.pio.h"
+#endif
 
 #include "cosmic_unicorn.hpp"
 

--- a/libraries/galactic_unicorn/galactic_unicorn.cpp
+++ b/libraries/galactic_unicorn/galactic_unicorn.cpp
@@ -6,8 +6,10 @@
 #include "hardware/clocks.h"
 
 
+#ifndef NO_QSTR
 #include "galactic_unicorn.pio.h"
 #include "audio_i2s.pio.h"
+#endif
 
 #include "galactic_unicorn.hpp"
 

--- a/libraries/pico_unicorn/pico_unicorn.cpp
+++ b/libraries/pico_unicorn/pico_unicorn.cpp
@@ -2,7 +2,9 @@
 #include "hardware/irq.h"
 #include "common/pimoroni_common.hpp"
 
+#ifndef NO_QSTR
 #include "pico_unicorn.pio.h"
+#endif
 #include "pico_unicorn.hpp"
 
 // pixel data is stored as a stream of bits delivered in the

--- a/libraries/stellar_unicorn/stellar_unicorn.cpp
+++ b/libraries/stellar_unicorn/stellar_unicorn.cpp
@@ -6,8 +6,10 @@
 #include "hardware/clocks.h"
 
 
+#ifndef NO_QSTR
 #include "stellar_unicorn.pio.h"
 #include "audio_i2s.pio.h"
+#endif
 
 #include "stellar_unicorn.hpp"
 


### PR DESCRIPTION
I had trouble with my local MicroPython build for ages until @Daft-Freak suggested wrapping the `pio.h` includes like this..  I feel this should be in the standard build to avoid others having the same pain!