### PR TITLE
Allow pen function for fast tile alpha blending

### DIFF
--- a/libraries/pico_graphics/pico_graphics.hpp
+++ b/libraries/pico_graphics/pico_graphics.hpp
@@ -293,6 +293,8 @@ namespace pimoroni {
     virtual void frame_convert(PenType type, conversion_callback_func callback);
     virtual void sprite(void* data, const Point &sprite, const Point &dest, const int scale, const int transparent);
 
+    virtual bool render_pico_vector_tile(const Rect &bounds, uint8_t* alpha_data, uint32_t stride, uint8_t alpha_type) { return false; }
+
     void set_font(const bitmap::font_t *font);
     void set_font(const hershey::font_t *font);
     void set_font(std::string_view name);

--- a/libraries/pico_vector/pico_vector.hpp
+++ b/libraries/pico_vector/pico_vector.hpp
@@ -21,6 +21,12 @@ namespace pimoroni {
                     uint8_t *tile_data = tile.data;
 
                     if(this->graphics->supports_alpha_blend() && pretty_poly::settings::antialias != pretty_poly::NONE) {
+                        if (this->graphics->render_pico_vector_tile({tile.bounds.x, tile.bounds.y, tile.bounds.w, tile.bounds.h},
+                                                                    tile.data,
+                                                                    tile.stride,
+                                                                    (uint8_t)pretty_poly::settings::antialias)) {
+                            return;
+                        }
                         for(auto y = 0; y < tile.bounds.h; y++) {
                             for(auto x = 0; x < tile.bounds.w; x++) {
                                 uint8_t alpha = *tile_data++;


### PR DESCRIPTION
This is just a hook to allow the pen implementation to provide a fast alpha blend for a picovector tile.