### PR TITLE
Improve pretty_poly performance

### DIFF
--- a/libraries/pico_vector/alright_fonts.hpp
+++ b/libraries/pico_vector/alright_fonts.hpp
@@ -70,5 +70,6 @@ namespace alright_fonts {
   */
 
   void render_character(text_metrics_t &tm, uint16_t codepoint, pretty_poly::point_t<int> origin);
-  void render_character(text_metrics_t &tm, uint16_t codepoint, pretty_poly::point_t<int> origin, pretty_poly::mat3_t transform);
+  template<typename mat_t>
+  void render_character(text_metrics_t &tm, uint16_t codepoint, pretty_poly::point_t<int> origin, mat_t transform);
 }

--- a/libraries/pico_vector/pico_vector.cmake
+++ b/libraries/pico_vector/pico_vector.cmake
@@ -6,4 +6,4 @@ add_library(pico_vector
 
 target_include_directories(pico_vector INTERFACE ${CMAKE_CURRENT_LIST_DIR})
 
-target_link_libraries(pico_vector pico_stdlib)
+target_link_libraries(pico_vector pico_stdlib hardware_interp)

--- a/libraries/pico_vector/pico_vector.cpp
+++ b/libraries/pico_vector/pico_vector.cpp
@@ -10,44 +10,42 @@ namespace pimoroni {
   }
 
   void PicoVector::rotate(std::vector<pretty_poly::contour_t<picovector_point_type>> &contours, Point origin, float angle) {
-    pretty_poly::mat3_t t2 = pretty_poly::mat3_t::translation(origin.x, origin.y);
-    pretty_poly::mat3_t t1 = pretty_poly::mat3_t::translation(-origin.x, -origin.y);
-    angle = 2 * M_PI * (angle / 360.0f);
-    pretty_poly::mat3_t r = pretty_poly::mat3_t::rotation(angle);
+    pretty_poly::point_t<picovector_point_type> t{(picovector_point_type)origin.x, (picovector_point_type)origin.y};
+    angle = (2 * (float)M_PI / 360.f) * angle;
+    pretty_poly::mat2_t r = pretty_poly::mat2_t::rotation(angle);
     for(auto &contour : contours) {
       for(auto i = 0u; i < contour.count; i++) {
-        contour.points[i] *= t1;
+        contour.points[i] -= t;
         contour.points[i] *= r;
-        contour.points[i] *= t2;
+        contour.points[i] += t;
       }
     }
   }
 
   void PicoVector::translate(std::vector<pretty_poly::contour_t<picovector_point_type>> &contours, Point translation) {
-    pretty_poly::mat3_t t = pretty_poly::mat3_t::translation(translation.x, translation.y);
+    pretty_poly::point_t<picovector_point_type> t{(picovector_point_type)translation.x, (picovector_point_type)translation.y};
     for(auto &contour : contours) {
       for(auto i = 0u; i < contour.count; i++) {
-        contour.points[i] *= t;
+        contour.points[i] += t;
       }
     }
   }
 
   void PicoVector::rotate(pretty_poly::contour_t<picovector_point_type> &contour, Point origin, float angle) {
-    pretty_poly::mat3_t t2 = pretty_poly::mat3_t::translation(origin.x, origin.y);
-    pretty_poly::mat3_t t1 = pretty_poly::mat3_t::translation(-origin.x, -origin.y);
-    angle = 2 * M_PI * (angle / 360.0f);
-    pretty_poly::mat3_t r = pretty_poly::mat3_t::rotation(angle);
+    pretty_poly::point_t<picovector_point_type> t{(picovector_point_type)origin.x, (picovector_point_type)origin.y};
+    angle = (2 * (float)M_PI / 360.f) * angle;
+    pretty_poly::mat2_t r = pretty_poly::mat2_t::rotation(angle);
     for(auto i = 0u; i < contour.count; i++) {
-      contour.points[i] *= t1;
+      contour.points[i] -= t;
       contour.points[i] *= r;
-      contour.points[i] *= t2;
+      contour.points[i] += t;
     }
   }
 
   void PicoVector::translate(pretty_poly::contour_t<picovector_point_type> &contour, Point translation) {
-    pretty_poly::mat3_t t = pretty_poly::mat3_t::translation(translation.x, translation.y);
+    pretty_poly::point_t<picovector_point_type> t{(picovector_point_type)translation.x, (picovector_point_type)translation.y};
     for(auto i = 0u; i < contour.count; i++) {
-      contour.points[i] *= t;
+      contour.points[i] += t;
     }
   }
 
@@ -115,7 +113,7 @@ namespace pimoroni {
     pretty_poly::point_t<float> caret(0, 0);
 
     // Prepare a transformation matrix for character and offset rotation
-    angle = 2 * M_PI * (angle / 360.0f);
+    angle = (2 * (float)M_PI / 360.f) * angle;
     pretty_poly::mat3_t transform = pretty_poly::mat3_t::rotation(angle);
 
     // Align text from the bottom left

--- a/libraries/pico_vector/pico_vector.cpp
+++ b/libraries/pico_vector/pico_vector.cpp
@@ -114,7 +114,7 @@ namespace pimoroni {
 
     // Prepare a transformation matrix for character and offset rotation
     angle = (2 * (float)M_PI / 360.f) * angle;
-    pretty_poly::mat3_t transform = pretty_poly::mat3_t::rotation(angle);
+    pretty_poly::mat2_t transform = pretty_poly::mat2_t::rotation(angle);
 
     // Align text from the bottom left
     caret.y += text_metrics.line_height;

--- a/libraries/pico_vector/pretty_poly.cpp
+++ b/libraries/pico_vector/pretty_poly.cpp
@@ -252,7 +252,7 @@ namespace pretty_poly {
   }
   
   template<typename T>
-  void draw_polygon(std::vector<contour_t<T>> contours, point_t<int> origin, int scale) {    
+  void draw_polygon(const std::vector<contour_t<T>>& contours, point_t<int> origin, int scale) {    
 
     debug("> draw polygon with %lu contours\n", contours.size());
 
@@ -306,7 +306,7 @@ namespace pretty_poly {
         memset(tile.data, 0, tile_buffer_size);
 
         // build the nodes for each contour
-        for(contour_t<T> &contour : contours) {
+        for(const contour_t<T> &contour : contours) {
           debug("    : build nodes for contour\n");
           build_nodes(contour, tile, origin, scale);
         }
@@ -333,7 +333,7 @@ namespace pretty_poly {
   }
 }
 
-template void pretty_poly::draw_polygon<int>(std::vector<contour_t<int>> contours, point_t<int> origin, int scale);
-template void pretty_poly::draw_polygon<float>(std::vector<contour_t<float>> contours, point_t<int> origin, int scale);
-template void pretty_poly::draw_polygon<uint8_t>(std::vector<contour_t<uint8_t>> contours, point_t<int> origin, int scale);
-template void pretty_poly::draw_polygon<int8_t>(std::vector<contour_t<int8_t>> contours, point_t<int> origin, int scale);
+template void pretty_poly::draw_polygon<int>(const std::vector<contour_t<int>>& contours, point_t<int> origin, int scale);
+template void pretty_poly::draw_polygon<float>(const std::vector<contour_t<float>>& contours, point_t<int> origin, int scale);
+template void pretty_poly::draw_polygon<uint8_t>(const std::vector<contour_t<uint8_t>>& contours, point_t<int> origin, int scale);
+template void pretty_poly::draw_polygon<int8_t>(const std::vector<contour_t<int8_t>>& contours, point_t<int> origin, int scale);

--- a/libraries/pico_vector/pretty_poly.hpp
+++ b/libraries/pico_vector/pretty_poly.hpp
@@ -62,7 +62,7 @@ namespace pretty_poly {
   template<typename T>
   void build_nodes(const contour_t<T> &contour, const tile_t &tile, point_t<int> origin = point_t<int>(0, 0), int scale = 65536);
 
-  void render_nodes(const tile_t &tile);
+  void render_nodes(const tile_t &tile, rect_t &bounds);
 
   template<typename T>
   void draw_polygon(T *points, unsigned count);

--- a/libraries/pico_vector/pretty_poly.hpp
+++ b/libraries/pico_vector/pretty_poly.hpp
@@ -6,6 +6,7 @@
 #include <new>
 #include <filesystem>
 #include <fstream>
+#include <functional>
 
 #include "pretty_poly_types.hpp"
 

--- a/libraries/pico_vector/pretty_poly.hpp
+++ b/libraries/pico_vector/pretty_poly.hpp
@@ -68,5 +68,5 @@ namespace pretty_poly {
   void draw_polygon(T *points, unsigned count);
 
   template<typename T>
-  void draw_polygon(std::vector<contour_t<T>> contours, point_t<int> origin = point_t<int>(0, 0), int scale = 65536);
+  void draw_polygon(const std::vector<contour_t<T>>& contours, point_t<int> origin = point_t<int>(0, 0), int scale = 65536);
 }

--- a/libraries/pico_vector/pretty_poly_types.hpp
+++ b/libraries/pico_vector/pretty_poly_types.hpp
@@ -145,7 +145,7 @@ namespace pretty_poly {
     //point_t<T> *begin() const { return points; };
     //point_t<T> *end() const { return points + count * sizeof(point_t<T>); };
 
-    rect_t bounds() {
+    rect_t bounds() const {
       T minx = this->points[0].x, maxx = minx;
       T miny = this->points[0].y, maxy = miny;
       for(auto i = 1u; i < this->count; i++) {

--- a/libraries/pico_vector/pretty_poly_types.hpp
+++ b/libraries/pico_vector/pretty_poly_types.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <cstdint>
 #include <math.h>
+#include <vector>
 
 #ifdef PP_DEBUG
 #define debug(...) printf(__VA_ARGS__)
@@ -138,7 +139,7 @@ namespace pretty_poly {
     unsigned count;
 
     contour_t() {}
-    contour_t(std::vector<point_t<T>> v) : points(v.data()), count(v.size()) {};
+    contour_t(const std::vector<point_t<T>>& v) : points(v.data()), count(v.size()) {};
     contour_t(point_t<T> *points, unsigned count) : points(points), count(count) {};
 
     // TODO: Make this work, it's so much nicer to use auto point : contour

--- a/micropython/modules/picovector/micropython.cmake
+++ b/micropython/modules/picovector/micropython.cmake
@@ -18,4 +18,6 @@ target_compile_definitions(usermod_picovector INTERFACE
     MODULE_PICOVECTOR_ENABLED=1
 )
 
+target_link_libraries(usermod_picovector INTERFACE hardware_interp)
+
 target_link_libraries(usermod INTERFACE usermod_picovector)


### PR DESCRIPTION
While looking at the performance of the alpha blend, I noticed there were lots of blank rows.  This led me to suspect there would be some easy wins in the polygon rendering side of things.

Main change is to track the actually used tile bounds in render_nodes so the graphics callback only renders the used part of the tile (and indeed only if it is used at all).  Potentially this could be done more efficiently earlier, but this way is relatively simple.

Additionally I fixed up the todo in `add_line_segment_to_nodes` so it's not running through out of bounds rows.