### PR TITLE
Expose set_pixel to MicroPython

### DIFF
--- a/micropython/modules/galactic_unicorn/galactic_unicorn.c
+++ b/micropython/modules/galactic_unicorn/galactic_unicorn.c
@@ -20,6 +20,7 @@ MP_DEFINE_CONST_FUN_OBJ_KW(Channel_play_tone_obj, 2, Channel_play_tone);
 
 MP_DEFINE_CONST_FUN_OBJ_1(GalacticUnicorn___del___obj, GalacticUnicorn___del__);
 MP_DEFINE_CONST_FUN_OBJ_1(GalacticUnicorn_clear_obj, GalacticUnicorn_clear);
+MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(GalacticUnicorn_set_pixel_obj, 6, 6, GalacticUnicorn_set_pixel);
 MP_DEFINE_CONST_FUN_OBJ_2(GalacticUnicorn_update_obj, GalacticUnicorn_update);
 MP_DEFINE_CONST_FUN_OBJ_2(GalacticUnicorn_set_brightness_obj, GalacticUnicorn_set_brightness);
 MP_DEFINE_CONST_FUN_OBJ_1(GalacticUnicorn_get_brightness_obj, GalacticUnicorn_get_brightness);
@@ -62,6 +63,7 @@ STATIC const mp_rom_map_elem_t Channel_locals_dict_table[] = {
 STATIC const mp_rom_map_elem_t GalacticUnicorn_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR___del__), MP_ROM_PTR(&GalacticUnicorn___del___obj) },
     { MP_ROM_QSTR(MP_QSTR_clear), MP_ROM_PTR(&GalacticUnicorn_clear_obj) },
+    { MP_ROM_QSTR(MP_QSTR_set_pixel), MP_ROM_PTR(&GalacticUnicorn_set_pixel_obj) },
     { MP_ROM_QSTR(MP_QSTR_update), MP_ROM_PTR(&GalacticUnicorn_update_obj) },
     { MP_ROM_QSTR(MP_QSTR_set_brightness), MP_ROM_PTR(&GalacticUnicorn_set_brightness_obj) },
     { MP_ROM_QSTR(MP_QSTR_get_brightness), MP_ROM_PTR(&GalacticUnicorn_get_brightness_obj) },

--- a/micropython/modules/galactic_unicorn/galactic_unicorn.cpp
+++ b/micropython/modules/galactic_unicorn/galactic_unicorn.cpp
@@ -414,6 +414,27 @@ extern mp_obj_t GalacticUnicorn_clear(mp_obj_t self_in) {
     return mp_const_none;
 }
 
+extern mp_obj_t GalacticUnicorn_set_pixel(mp_uint_t n_args, const mp_obj_t *args) {
+    _GalacticUnicorn_obj_t *self = MP_OBJ_TO_PTR2(args[0], _GalacticUnicorn_obj_t);
+
+    int x = mp_obj_get_int(args[1]);
+    int y = mp_obj_get_int(args[2]);
+    int r = mp_obj_get_int(args[3]);
+    int g = mp_obj_get_int(args[4]);
+    int b = mp_obj_get_int(args[5]);
+
+    if(x < 0 || x >= GalacticUnicorn::WIDTH || y < 0 || y >= GalacticUnicorn::HEIGHT) {
+        mp_raise_ValueError("x or y out of range.");
+    }
+
+    if(r < 0 || r > 255) mp_raise_ValueError("r out of range. Expected 0 to 255");
+    if(g < 0 || g > 255) mp_raise_ValueError("g out of range. Expected 0 to 255");
+    if(b < 0 || b > 255) mp_raise_ValueError("b out of range. Expected 0 to 255");
+
+    self->galactic->set_pixel(x, y, r, g, b);
+    return mp_const_none;
+}
+
 extern mp_obj_t GalacticUnicorn_update(mp_obj_t self_in, mp_obj_t graphics_in) {
     _GalacticUnicorn_obj_t *self = MP_OBJ_TO_PTR2(self_in, _GalacticUnicorn_obj_t);
     ModPicoGraphics_obj_t *picographics = MP_OBJ_TO_PTR2(graphics_in, ModPicoGraphics_obj_t);

--- a/micropython/modules/galactic_unicorn/galactic_unicorn.h
+++ b/micropython/modules/galactic_unicorn/galactic_unicorn.h
@@ -29,6 +29,8 @@ extern mp_obj_t GalacticUnicorn_make_new(const mp_obj_type_t *type, size_t n_arg
 extern mp_obj_t GalacticUnicorn___del__(mp_obj_t self_in);
 extern mp_obj_t GalacticUnicorn_clear(mp_obj_t self_in);
 
+extern mp_obj_t GalacticUnicorn_set_pixel(size_t n_args, const mp_obj_t *args);
+
 extern mp_obj_t GalacticUnicorn_update(mp_obj_t self_in, mp_obj_t graphics_in);
 
 extern mp_obj_t GalacticUnicorn_set_brightness(mp_obj_t self_in, mp_obj_t value);


### PR DESCRIPTION
While using Pico Graphics might usually be the proper way to draw on the Stellar/Galactic/Cosmic Unicorn, there are use cases where setting the pixels directly is desirable.
This PR exposes `GalacticUnicorn::set_pixel` (https://github.com/pimoroni/pimoroni-pico/blob/v1.21.0/libraries/galactic_unicorn/galactic_unicorn.cpp#L447) to MicroPython.

The implementation is pretty much copy-pasted from https://github.com/pimoroni/pimoroni-pico/blob/v1.21.0/micropython/modules/pico_unicorn/pico_unicorn.cpp#L56.

If this change generally suits you, i'll add it to the Stellar and Cosmic Unicorn as well and update the Docs accordingly as preparation for the merge.