### PR TITLE
fix hue errors in plasma_stick_rainbows

### DIFF
--- a/examples/plasma_stick/plasma_stick_rainbows.cpp
+++ b/examples/plasma_stick/plasma_stick_rainbows.cpp
@@ -34,10 +34,15 @@ int main() {
   while(true) {
 
     offset += float(SPEED) / 2000.0f;
+    if (offset > 1.0) {
+      offset -= 1.0;
+    }
 
     for(auto i = 0u; i < NUM_LEDS; ++i) {
       float hue = float(i) / NUM_LEDS;
-      led_strip.set_hsv(i, hue + offset, 1.0f, 1.0f);
+      hue += offset;
+      hue -= floor(hue);
+      led_strip.set_hsv(i, hue, 1.0f, 1.0f);
     }
 
     sleep_ms(1000 / UPDATES);

--- a/micropython/examples/plasma_stick/rainbows.py
+++ b/micropython/examples/plasma_stick/rainbows.py
@@ -28,9 +28,10 @@ while True:
 
     SPEED = min(255, max(1, SPEED))
     offset += float(SPEED) / 2000.0
+    offset %= 1
 
     for i in range(NUM_LEDS):
-        hue = float(i) / NUM_LEDS
+        hue = (offset + float(i) / NUM_LEDS) % 1
         led_strip.set_hsv(i, hue + offset, 1.0, 1.0)
 
     time.sleep(1.0 / UPDATES)


### PR DESCRIPTION
In this example the use of the monotonically increasing `offset` variable in the hue calculations will cause the colours to stop rotating when the repeated addition of 20 / 2000 eventually becomes too small to make a difference to the accumulated value given the limited precision of a `float`.    That is, at some point `offset += float(SPEED) / 2000.0f` becomes a no-op.

<strike>Granted it will take a long time - 265 days with the current code - but in a modified version of this demo I've been able to trigger issues far more rapidly.</strike>

This patch first makes sure that `offset` doesn't increase without bound so that it stays within the numerical precision range of a `float`, and secondly ensures that all hue values passed to `RGBLED::set_hsv()` are within the range [0..1)

The second change begs the question of whether the various `FOO::set_hsv()` methods in the library should perform this normalisation of the `h` parameter on entry to those methods.  It would not only resolve some issues I've seen with negative hue values, but also avoid the need for the `i % 6` in the `switch` since with `h` constrained to [0..1) `i` will also be similarly constrained to [0..6).