### PR TITLE
[Plasma Stick 2040W] add Plasma LEDs link

### DIFF
--- a/micropython/examples/plasma_stick/README.md
+++ b/micropython/examples/plasma_stick/README.md
@@ -188,3 +188,4 @@ Here are some Plasma Stick community projects and resources that you might find 
 
 - :link: [MQTT Script for Plasma Stick](https://github.com/digitalurban/MQTT-Plasma-Stick-2040W)
 - :link: [Pimoroni Wireless Plasma Kit - Server](https://github.com/brunon/Starlight)
+- :link: [Plasma LEDs](https://github.com/bitcdr/plasma-leds)


### PR DESCRIPTION
Add link to other resources section for [Plasma LEDs](https://github.com/bitcdr/plasma-leds).

Control LEDs attached to a [Pimoroni Plasma Stick 2040 W](https://shop.pimoroni.com/products/plasma-stick-2040-w) with your web browser.

The Plasma LEDs features a clean web frontend, which allows you to control the LEDs attached to a [Pimoroni Plasma Stick 2040 W](https://shop.pimoroni.com/products/plasma-stick-2040-w) via a web browser.

It comes with a variety of configurable colors and effects out of the box, and is extendable to additional effects if you have the programming skills.

Some of the effects are based on the awesome [example code provided by Pimoroni](https://github.com/pimoroni/pimoroni-pico/tree/main/micropython/examples/plasma_stick).