### PR TITLE
[Inky Frame] Fix news headline redirect example

### DIFF
--- a/micropython/examples/inky_frame/inkylauncher/nasa_apod.py
+++ b/micropython/examples/inky_frame/inkylauncher/nasa_apod.py
@@ -39,6 +39,7 @@ def update():
         # Image for Inky Frame 4.0
         IMG_URL = "https://pimoroni.github.io/feed2image/nasa-apod-640x400-daily.jpg"
     elif HEIGHT == 480:
+        # Image for Inky Frame 7.3
         IMG_URL = "https://pimoroni.github.io/feed2image/nasa-apod-800x480-daily.jpg"
 
     try:

--- a/micropython/examples/inky_frame/inkylauncher/news_headlines.py
+++ b/micropython/examples/inky_frame/inkylauncher/news_headlines.py
@@ -3,8 +3,8 @@ import gc
 import qrcode
 
 # Uncomment one URL to use (Top Stories, World News and technology)
-# URL = "http://feeds.bbci.co.uk/news/rss.xml"
-# URL = "http://feeds.bbci.co.uk/news/world/rss.xml"
+# URL = "https://feeds.bbci.co.uk/news/rss.xml"
+# URL = "https://feeds.bbci.co.uk/news/world/rss.xml"
 URL = "https://feeds.bbci.co.uk/news/technology/rss.xml"
 
 # Length of time between updates in minutes.

--- a/micropython/examples/inky_frame/inkylauncher/news_headlines.py
+++ b/micropython/examples/inky_frame/inkylauncher/news_headlines.py
@@ -5,7 +5,7 @@ import qrcode
 # Uncomment one URL to use (Top Stories, World News and technology)
 # URL = "http://feeds.bbci.co.uk/news/rss.xml"
 # URL = "http://feeds.bbci.co.uk/news/world/rss.xml"
-URL = "http://feeds.bbci.co.uk/news/technology/rss.xml"
+URL = "https://feeds.bbci.co.uk/news/technology/rss.xml"
 
 # Length of time between updates in minutes.
 # Frequent updates will reduce battery life!


### PR DESCRIPTION
This very small PR accomplishes two things:

1. Swaps the protocol from `http` to `https` for BBC's example rss feeds. The current feed requests were failing because BBC has implemented a redirect on RSS to enforce `https`.
2. Adds a comment for the 7.3 frame size, to match the existing ones for the other Inky Frame sizes.