### PR TITLE
Add I2C pin definitions to motor2040 header

### DIFF
--- a/libraries/motor2040/motor2040.hpp
+++ b/libraries/motor2040/motor2040.hpp
@@ -47,10 +47,11 @@ namespace motor {
     const uint LED_DATA = 18;
     const uint NUM_LEDS = 1;
 
-    const uint USER_SW = 23;
-
+    const uint I2C_INT = 19;
     const uint I2C_SDA = 20;
     const uint I2C_SCL = 21;
+
+    const uint USER_SW = 23;
 
     const uint ADC_ADDR_0 = 22;
     const uint ADC_ADDR_1 = 24;

--- a/libraries/motor2040/motor2040.hpp
+++ b/libraries/motor2040/motor2040.hpp
@@ -49,6 +49,9 @@ namespace motor {
 
     const uint USER_SW = 23;
 
+    const uint I2C_SDA = 20;
+    const uint I2C_SCL = 21;
+
     const uint ADC_ADDR_0 = 22;
     const uint ADC_ADDR_1 = 24;
     const uint ADC_ADDR_2 = 25;

--- a/libraries/servo2040/servo2040.hpp
+++ b/libraries/servo2040/servo2040.hpp
@@ -30,6 +30,10 @@ namespace servo {
     const uint LED_DATA = 18;
     const uint NUM_LEDS = 6;
 
+    const uint I2C_INT = 19;
+    const uint I2C_SDA = 20;
+    const uint I2C_SCL = 21;
+
     const uint USER_SW = 23;
 
     const uint ADC_ADDR_0 = 22;


### PR DESCRIPTION
Add definitions for the QW/ST connector SDA & SCL pins

addresses #889 