### PR TITLE
st7789: Remove mystery meat command implicated by #567.

### DIFF
--- a/drivers/st7789/st7789.cpp
+++ b/drivers/st7789/st7789.cpp
@@ -89,7 +89,6 @@ namespace pimoroni {
     if(width == 320 && height == 240) {
       command(reg::GCTRL, 1, "\x35");
       command(reg::VCOMS, 1, "\x1f");
-      command(0xd6, 1, "\xa1"); // ???
       command(reg::GMCTRP1, 14, "\xD0\x08\x11\x08\x0C\x15\x39\x33\x50\x36\x13\x14\x29\x2D");
       command(reg::GMCTRN1, 14, "\xD0\x08\x10\x08\x06\x06\x39\x44\x51\x0B\x16\x14\x2F\x31");
     }


### PR DESCRIPTION
This should, in theory, fix the weird display corruption bug affecting Tufty 2040.