### PR TITLE
Circumvent hangs on update method of inky frame 7 when on battery power

### DIFF
--- a/drivers/inky73/inky73.cpp
+++ b/drivers/inky73/inky73.cpp
@@ -43,11 +43,20 @@ namespace pimoroni {
     TSSET = 0xE6 // E5 or E6
   };
 
+  int timeout = 0;
+
   bool Inky73::is_busy() {
-    return !(sr.read() & 128);
+    bool busy = !(sr.read() & 128);
+    if (!busy) {
+      return false;
+    } else if(absolute_time_diff_us(get_absolute_time(), timeout) < 0) {
+      return false;
+    }
+    return true;
   }
   
-  void Inky73::busy_wait() {
+  void Inky73::busy_wait(uint maximum_wait_ms=30000) {
+    timeout = make_timeout_time_ms(maximum_wait_ms);
     while(is_busy()) {
       tight_loop_contents();
     }
@@ -56,7 +65,7 @@ namespace pimoroni {
   void Inky73::reset() {
     gpio_put(RESET, 0); sleep_ms(10);
     gpio_put(RESET, 1); sleep_ms(10);
-    busy_wait();
+    busy_wait(5000);
   }
    
   void Inky73::init() {

--- a/drivers/inky73/inky73.cpp
+++ b/drivers/inky73/inky73.cpp
@@ -55,7 +55,7 @@ namespace pimoroni {
     return true;
   }
   
-  void Inky73::busy_wait(uint maximum_wait_ms=30000) {
+  void Inky73::busy_wait(uint maximum_wait_ms=45000) {
     timeout = make_timeout_time_ms(maximum_wait_ms);
     while(is_busy()) {
       tight_loop_contents();
@@ -65,7 +65,7 @@ namespace pimoroni {
   void Inky73::reset() {
     gpio_put(RESET, 0); sleep_ms(10);
     gpio_put(RESET, 1); sleep_ms(10);
-    busy_wait(5000);
+    busy_wait();
   }
    
   void Inky73::init() {

--- a/drivers/inky73/inky73.hpp
+++ b/drivers/inky73/inky73.hpp
@@ -70,7 +70,7 @@ namespace pimoroni {
     // Methods
     //--------------------------------------------------
   public:
-    void busy_wait();
+    void busy_wait(uint maximum_wait_ms);
     void reset();
     void power_off();
   


### PR DESCRIPTION
Some users and myself experienced issues with the update method, which often hangs when the inky frame is powered by batteries.
Discussions:
https://github.com/pimoroni/pimoroni-pico/issues/866
https://forums.pimoroni.com/t/inky-frame-not-refreshing-screen-on-battery-power-using-inky-frame-sleep-for/23174/23

This adds a timeout for the busy_wait function, so that the code continues after a default timeout of 45 seconds. It seems it fixes the issues, as there are no more hangs. Of course, the root cause seems to be somewhere else, but this way we can at least use the update method successfully on battery power.

Relases for testing pruposes can be found here:
https://github.com/w3stbam/pimoroni-pico/releases/