### PR TITLE
CI: Bump MicroPython to v1.22.2.

### DIFF
--- a/.github/workflows/micropython.yml
+++ b/.github/workflows/micropython.yml
@@ -7,7 +7,7 @@ on:
     types: [created]
 
 env:
-  MICROPYTHON_VERSION: v1.22.1
+  MICROPYTHON_VERSION: v1.22.2
 
 jobs:
   build:

--- a/drivers/hub75/hub75.hpp
+++ b/drivers/hub75/hub75.hpp
@@ -73,7 +73,7 @@ class Hub75 {
     Pixel background = 0;
 
     // DMA & PIO
-    uint dma_channel = 0;
+    int dma_channel = -1;
     uint bit = 0;
     uint row = 0;
 


### PR DESCRIPTION
This patch release includes a number of fixes for RP2, notably:

* rp2/rp2_dma: fix fetching 'write' buffers for writing not reading
* rp2/machine_uart: fix event wait in uart.flush() and uart.read()
* rp2: change machine.I2S and rp2.DMA to use shared DMA IRQ handlers

https://github.com/micropython/micropython/releases/tag/v1.22.2

## Changes for release notes

* https://github.com/pimoroni/pimoroni-pico/pull/899
* https://github.com/pimoroni/pimoroni-pico/pull/907