### PR TITLE
Fixes for PNGDEC on Badger 2040 / Badger 2040 W

### DIFF
--- a/libraries/pico_graphics/pico_graphics_pen_1bitY.cpp
+++ b/libraries/pico_graphics/pico_graphics_pen_1bitY.cpp
@@ -15,7 +15,7 @@ namespace pimoroni {
   }
 
   void PicoGraphics_Pen1BitY::set_pen(uint8_t r, uint8_t g, uint8_t b) {
-    color = std::max(r, std::max(g, b));
+    color = std::max(r, std::max(g, b)) >> 4;
   }
 
   void PicoGraphics_Pen1BitY::set_pixel(const Point &p) {

--- a/micropython/modules/pngdec/pngdec.cpp
+++ b/micropython/modules/pngdec/pngdec.cpp
@@ -186,18 +186,23 @@ mp_event_handle_nowait();
     } else if (pDraw->iPixelType == PNG_PIXEL_INDEXED) {
         for(int x = 0; x < pDraw->iWidth; x++) {
             uint8_t i = 0;
-            if(pDraw->iBpp == 8) {
+            if(pDraw->iBpp == 8) {  // 8bpp
                 i = *pixel++;
-            } else if (pDraw->iBpp == 4) {
+            } else if (pDraw->iBpp == 4) {  // 4bpp
                 i = *pixel;
                 i >>= (x & 0b1) ? 0 : 4;
                 i &= 0xf;
                 if (x & 1) pixel++;
-            } else {
+            } else if (pDraw->iBpp == 2) {  // 2bpp
                 i = *pixel;
                 i >>= 6 - ((x & 0b11) << 1);
                 i &= 0x3;
                 if ((x & 0b11) == 0b11) pixel++;
+            } else {  // 1bpp
+                i = *pixel;
+                i >>= 7 - (x & 0b111);
+                i &= 0b1;
+                if ((x & 0b111) == 0b111) pixel++;
             }
             if(x < target->source.x || x >= target->source.x + target->source.w) continue;
             // grab the colour from the palette
@@ -243,7 +248,6 @@ mp_event_handle_nowait();
                                 }
                             }
                         }
-
                 } else {
                     current_graphics->set_pen(r, g, b);
                     current_graphics->rectangle({current_position.x, current_position.y, scale.x, scale.y});


### PR DESCRIPTION
These fixes are required for PNGDEC to function correctly on Badger 2040 and Badger 2040 W, so it can be added - https://github.com/pimoroni/badger2040/pull/75

The fix to `PicoGraphics_Pen1BitY::set_pen` corrects handling of RGB and ARGB PNGs.

The fix to PNGDEC adds explicit support for 1bit PNGs, which would obviously be desirable on a 1bit display.