### PR TITLE
PNGdec: Add greyscale support.

### DIFF
--- a/micropython/modules/pngdec/pngdec.c
+++ b/micropython/modules/pngdec/pngdec.c
@@ -49,6 +49,7 @@ STATIC const mp_map_elem_t PNG_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_PNG_POSTERISE), MP_ROM_INT(0) },
     { MP_ROM_QSTR(MP_QSTR_PNG_DITHER), MP_ROM_INT(1) },
     { MP_ROM_QSTR(MP_QSTR_PNG_COPY), MP_ROM_INT(2) },
+    { MP_ROM_QSTR(MP_QSTR_PNG_PEN), MP_ROM_INT(3) },
 };
 
 STATIC MP_DEFINE_CONST_DICT(mp_module_PNG_globals, PNG_globals_table);


### PR DESCRIPTION
Special case 1bit PNGs to use fixed black/white values or optionally - with MODE_PEN - draw the PNG in the current pen colour.