### PR TITLE
PNGdec: Add support for palette offsets and greyscale copy mode

### DIFF
--- a/micropython/modules/pngdec/pngdec.cpp
+++ b/micropython/modules/pngdec/pngdec.cpp
@@ -209,7 +209,20 @@ mp_event_handle_nowait();
 
             //mp_printf(&mp_plat_print, "Drawing pixel at %dx%d, %dbpp, value %d\n", current_position.x, current_position.y, pDraw->iBpp, i);
             if (current_mode != MODE_PEN) {
-                current_graphics->set_pen(i, i, i);
+                // Allow greyscale PNGs to be copied just like an indexed PNG
+                // since we might want to offset and recolour them.
+                if(current_mode == MODE_COPY
+                    && (current_graphics->pen_type == PicoGraphics::PEN_P8
+                    || current_graphics->pen_type == PicoGraphics::PEN_P4
+                    || current_graphics->pen_type == PicoGraphics::PEN_3BIT
+                    || current_graphics->pen_type == PicoGraphics::PEN_INKY7)) {
+                    if(current_palette_offset > 0) {
+                        i += ((int16_t)(i) + current_palette_offset) & 0xff;
+                    }
+                    current_graphics->set_pen(i);
+                } else {
+                    current_graphics->set_pen(i, i, i);
+                }
             }
             if (current_mode != MODE_PEN || i == 0) {
                 current_graphics->rectangle({current_position.x, current_position.y, scale.x, scale.y});

--- a/micropython/modules/pngdec/pngdec.cpp
+++ b/micropython/modules/pngdec/pngdec.cpp
@@ -217,7 +217,7 @@ mp_event_handle_nowait();
                     || current_graphics->pen_type == PicoGraphics::PEN_3BIT
                     || current_graphics->pen_type == PicoGraphics::PEN_INKY7)) {
                     if(current_palette_offset > 0) {
-                        i += ((int16_t)(i) + current_palette_offset) & 0xff;
+                        i = ((int16_t)(i) + current_palette_offset) & 0xff;
                     }
                     current_graphics->set_pen(i);
                 } else {
@@ -279,7 +279,7 @@ mp_event_handle_nowait();
                         // Copy raw palette indexes over
                         if(current_mode == MODE_COPY) {
                             if(current_palette_offset > 0) {
-                                i += ((int16_t)(i) + current_palette_offset) & 0xff;
+                                i = ((int16_t)(i) + current_palette_offset) & 0xff;
                             }
                             current_graphics->set_pen(i);
                             current_graphics->rectangle({current_position.x, current_position.y, scale.x, scale.y});

--- a/micropython/modules/pngdec/pngdec.cpp
+++ b/micropython/modules/pngdec/pngdec.cpp
@@ -190,20 +190,26 @@ mp_event_handle_nowait();
                 i &= 0xf;
                 if (x & 1) pixel++;
                 // Just copy the colour into the upper and lower nibble
-                i = (i << 4) | i;
+                if(current_mode != MODE_COPY) {
+                    i = (i << 4) | i;
+                }
             } else if (pDraw->iBpp == 2) {  // 2bpp
                 i = *pixel;
                 i >>= 6 - ((x & 0b11) << 1);
                 i &= 0x3;
                 if ((x & 0b11) == 0b11) pixel++;
                 // Evenly spaced 4-colour palette
-                i = (0xFFB86800 >> (i * 8)) & 0xFF;
+                if(current_mode != MODE_COPY) {
+                    i = (0xFFB86800 >> (i * 8)) & 0xFF;
+                }
             } else {  // 1bpp
                 i = *pixel;
                 i >>= 7 - (x & 0b111);
                 i &= 0b1;
                 if ((x & 0b111) == 0b111) pixel++;
-                i = i ? 255 : 0;
+                if(current_mode != MODE_COPY) {
+                    i = i ? 255 : 0;
+                }
             }
             if(x < target->source.x || x >= target->source.x + target->source.w) continue;
 


### PR DESCRIPTION
As if PNG rendering isn't already complex enough, I dreamed up "palette_offset" as an argument that would change a "COPY" mode PNG's pixel value by a certain offset value.

Eg: if you have a 4bit (16 colour) greyscale or indexed PNG you could copy it verbatim into the PicoGraphics buffer (ignoring the actual colour values). Normally this happens from palette index 0, so you could never swap out the palette to handle artwork variations.

Using an offset, - eg let's say we offset by 16- it's possible to render a PNG in "COPY" mode, offsetting each palette index by 16. Now in 8-bit palette mode we can draw up to sixteen copies of our PNG and - via palette manipulation - give them all distinct colours.

Yes, even trying to explain this is complicated...