### PR TITLE
inky73: Add busy wait timeout.

### DIFF
--- a/drivers/inky73/inky73.cpp
+++ b/drivers/inky73/inky73.cpp
@@ -47,8 +47,9 @@ namespace pimoroni {
     return !(sr.read() & 128);
   }
   
-  void Inky73::busy_wait() {
-    while(is_busy()) {
+  void Inky73::busy_wait(uint timeout_ms) {
+    absolute_time_t timeout = make_timeout_time_ms(timeout_ms);
+    while(is_busy() && !time_reached(timeout)) {
       tight_loop_contents();
     }
   }

--- a/drivers/inky73/inky73.hpp
+++ b/drivers/inky73/inky73.hpp
@@ -70,7 +70,7 @@ namespace pimoroni {
     // Methods
     //--------------------------------------------------
   public:
-    void busy_wait();
+    void busy_wait(uint timeout_ms=45000);
     void reset();
     void power_off();
   


### PR DESCRIPTION
Add a timeout to fix Inky 7.3" hanging on batteries.

Basically assumes the update has finished if it takes > 45s, and allows a subsequent attempt rather than hanging indefinitely.

Raised, tested and fixed by w3stbam: https://github.com/pimoroni/pimoroni-pico/pull/900

Rewritten as mentioned in the PR.

Replaces #900 