### PR TITLE
Fixed arg order bug

### DIFF
--- a/micropython/examples/inky_frame/inkylauncher/word_clock.py
+++ b/micropython/examples/inky_frame/inkylauncher/word_clock.py
@@ -95,7 +95,7 @@ def draw():
                 y += line_space
                 x = default_x
 
-            graphics.text(letter.upper(), x, y, 640, scale, spacing)
+            graphics.text(letter.upper(), x, y, 640, scale=scale, spacing=spacing)
             x += letter_space
 
     graphics.update()


### PR DESCRIPTION
Fixed a problem with the argument order in `graphics.text()` that stopped the text from displaying.