### PR TITLE
CI: Scannable artifact and release names.

### DIFF
--- a/.github/workflows/micropython.yml
+++ b/.github/workflows/micropython.yml
@@ -42,7 +42,7 @@ jobs:
 
     env:
       # MicroPython version will be contained in github.event.release.tag_name for releases
-      RELEASE_FILE: pimoroni-${{ matrix.name }}-${{ github.event.release.tag_name || github.sha }}-micropython
+      RELEASE_FILE: ${{ matrix.name }}-${{ github.event.release.tag_name || github.sha }}-pimoroni-micropython
       PIMORONI_PICO_DIR: "${{ github.workspace }}/pimoroni-pico-${{ github.sha }}"
       MICROPY_BOARD_DIR: "${{ github.workspace }}/pimoroni-pico-${{ github.sha }}/micropython/board/${{ matrix.BOARD }}"
       USER_C_MODULES: "${{ github.workspace }}/pimoroni-pico-${{ github.sha }}/micropython/modules/micropython-${{ matrix.name }}.cmake"

--- a/setting-up-micropython.md
+++ b/setting-up-micropython.md
@@ -19,18 +19,18 @@ On the releases page you'll find a bunch of different .uf2 files for use on diff
 
 | Board                                                        | What uf2 file to use                                         | Notes                                                        |
 | ------------------------------------------------------------ | ------------------------------------------------------------ | ------------------------------------------------------------ |
-| Raspberry Pi Pico and most other RP2040 boards without wireless (Plasma 2040, Interstate 75, Servo 2040, Motor 2040, Tiny 2040 2MB) | **pimoroni-pico-vx.x.x-micropython.uf2**                     |                                                              |
-| Raspberry Pi Pico W and most Pico W Aboard products (Automation 2040 W, Inventor 2040 W, Plasma Stick, Interstate 75 W) | **pimoroni-picow-vx.x.x-micropython.uf2**                    |                                                              |
-| Tufty 2040                                                   | **pimoroni-tufty2040-vx.x.x-micropython.uf2**                |                                                              |
-| Pimoroni Pico LiPo                                           | **pimoroni-picolipo_4mb-vx.x.x-micropython.uf2** or **pimoroni-picolipo_16mb-vx.x.x-micropython.uf2** | Includes support for the increased flash memory on these boards |
-| Tiny 2040 8MB                                                | **pimoroni-tiny2040-vx.x.x-micropython.uf2**                 | Includes support for the increased flash memory on this board |
-| Enviro Urban, Indoor, Weather & Grow                         | **pimoroni-picow_enviro-vx.x.x-micropython.uf2**             | For a .uf2 with examples built in, go to the [Enviro releases page](https://github.com/pimoroni/enviro/releases)! |
-| Galactic Unicorn                                             | **pimoroni-picow_galactic_unicorn-vx.x.x-micropython.uf2**   |                                                              |
-| Inky Frame                                                   | **pimoroni-picow_inky_frame-vx.x.x-micropython.uf2**         |                                                              |
-| Badger 2040 W                                                | **pimoroni-badger2040w-vx.x.x-micropython.uf2** or **pimoroni-badger2040w-v0.0.1-micropython-with-badger-os.uf2** | :warning: Badger OS will overwrite your files!
-| Badger 2040                                                  | **pimoroni-badger2040-vx.x.x-micropython.uf2** or  **pimoroni-badger2040-v0.0.1-micropython-with-badger-os.uf2** | :warning: Badger OS will overwrite your files!
-| Cosmic Unicorn                                               | **pimoroni-picow_cosmic_unicorn-vx.x.x-micropython.uf2**     |                                                              |
-| Stellar Unicorn                                               | **pimoroni-picow_stellar_unicorn-vx.x.x-micropython.uf2**     |                                                              |
+| Raspberry Pi Pico and most other RP2040 boards without wireless (Plasma 2040, Interstate 75, Servo 2040, Motor 2040, Tiny 2040 2MB) | **pico-vx.x.x-pimoroni-micropython.uf2**                     |                                                              |
+| Raspberry Pi Pico W and most Pico W Aboard products (Automation 2040 W, Inventor 2040 W, Plasma Stick, Interstate 75 W) | **picow-vx.x.x-pimoroni-micropython.uf2**                    |                                                              |
+| Tufty 2040                                                   | **tufty2040-vx.x.x-pimoroni-micropython.uf2**                |                                                              |
+| Pimoroni Pico LiPo                                           | **picolipo_4mb-vx.x.x-pimoroni-micropython.uf2** or **pimoroni-picolipo_16mb-vx.x.x-pimoroni-micropython.uf2** | Includes support for the increased flash memory on these boards |
+| Tiny 2040 8MB                                                | **tiny2040_8mb-vx.x.x-pimoroni-micropython.uf2**                 | Includes support for the increased flash memory on this board |
+| Enviro Urban, Indoor, Weather & Grow                         | **picow_enviro-vx.x.x-pimoroni-micropython.uf2**             | For a .uf2 with examples built in, go to the [Enviro releases page](https://github.com/pimoroni/enviro/releases)! |
+| Galactic Unicorn                                             | **picow_galactic_unicorn-vx.x.x-pimoroni-micropython.uf2**   |                                                              |
+| Inky Frame                                                   | **picow_inky_frame-vx.x.x-pimoroni-micropython.uf2**         |                                                              |
+| Badger 2040 W                                                | **badger2040w-vx.x.x-pimoroni-micropython.uf2** or **pimoroni-badger2040w-v0.0.1-micropython-with-badger-os.uf2** | :warning: Badger OS will overwrite your files!
+| Badger 2040                                                  | **badger2040-vx.x.x-pimoroni-micropython.uf2** or  **pimoroni-badger2040-v0.0.1-micropython-with-badger-os.uf2** | :warning: Badger OS will overwrite your files!
+| Cosmic Unicorn                                               | **picow_cosmic_unicorn-vx.x.x-pimoroni-micropython.uf2**     |                                                              |
+| Stellar Unicorn                                               | **picow_stellar_unicorn-vx.x.x-pimoroni-micropython.uf2**     |                                                              |
 
 ## Entering DFU/bootloader mode
 


### PR DESCRIPTION
When I go to fetch an artifact for a MicroPython build my brain is always confounded by the repetition of "pimoroni-" before each file.

Change the names so the product is up-front, so the list is easier to scan-read through.

This will break: https://github.com/pimoroni/pimoroni-pico/blob/main/setting-up-micropython.md (TODO: fix in this PR)

And probably: https://learn.pimoroni.com/article/getting-started-with-interstate-75

And: https://github.com/pimoroni/enviro/blob/b5bff82f9001409c9683be43b9f2114e7da8b430/.github/workflows/release-zip.yml#L16