### PR TITLE
Add get_error_sum and reset_error_sum methods to PID class

### DIFF
--- a/drivers/pid/pid.cpp
+++ b/drivers/pid/pid.cpp
@@ -27,4 +27,12 @@ namespace pimoroni {
 
     return (error * kp) + (error_sum * ki) - (value_change * kd);
   }
+
+  float PID::get_error_sum() const {
+    return error_sum;
+  }
+
+  void PID::reset_error_sum() {
+    error_sum = 0.0f;
+  }
 }

--- a/drivers/pid/pid.hpp
+++ b/drivers/pid/pid.hpp
@@ -14,6 +14,9 @@ namespace pimoroni {
     float calculate(float value);
     float calculate(float value, float value_change);
 
+    [[nodiscard]] float get_error_sum() const;
+    void reset_error_sum();
+
   public:
     float kp;
     float ki;


### PR DESCRIPTION
This PR introduces two new methods to the PID class: `get_error_sum` and `reset_error_sum`. 

The `get_error_sum` method allows users to monitor the error sum or reset it as needed during runtime. For example, the getter would enable users of the library to know when a wheel has locked up or power has been lost, and the reset method would provide the ability to remediate that error state.

resolves #934