### PR TITLE
CI: Add py_decl verify step to catch binary overflows.

### DIFF
--- a/.github/workflows/micropython.yml
+++ b/.github/workflows/micropython.yml
@@ -81,6 +81,13 @@ jobs:
         source $BUILD_TOOLS
         micropython_clone
 
+    - name: "Py_Decl: Checkout py_decl"
+      uses: actions/checkout@v4
+      with:
+        repository: gadgetoid/py_decl
+        ref: v0.0.1
+        path: py_decl
+
     - name: Build MPY Cross
       run: |
         source $BUILD_TOOLS
@@ -110,6 +117,11 @@ jobs:
       run: |
         source $BUILD_TOOLS
         cmake_build
+
+    - name: "Py_Decl: Verify UF2"
+      shell: bash
+      run: |
+        python3 py_decl/py_decl.py --to-json --verify build-${{ matrix.name }}/${{ env.RELEASE_FILE }}.uf2
 
     - name: Store .uf2 as artifact
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
This is a replacement to #927 with the intention of catching issues where the MicroPython binary leaks into the LittleFS filesystem region.

Since this PR involves no changes to the MicroPython codebase and requires no linker script modifications or other tomfoolery, it should be much easier to maintain for, more or less, the same result.