### PR TITLE
JPEGDEC: Sync with latest upstream

### DIFF
--- a/libraries/jpegdec/JPEGDEC.cpp
+++ b/libraries/jpegdec/JPEGDEC.cpp
@@ -27,7 +27,7 @@ JPEG_STATIC int JPEGInit(JPEGIMAGE *pJPEG);
 JPEG_STATIC int JPEGParseInfo(JPEGIMAGE *pPage, int bExtractThumb);
 JPEG_STATIC void JPEGGetMoreData(JPEGIMAGE *pPage);
 JPEG_STATIC int DecodeJPEG(JPEGIMAGE *pImage);
-JPEG_STATIC void JPEG_setFramebuffer(JPEGIMAGE *pPage, void *pFramebuffer);
+void JPEG_setFramebuffer(JPEGIMAGE *pPage, void *pFramebuffer);
 
 // Include the C code which does the actual work
 #include "jpeg.inl"

--- a/libraries/jpegdec/JPEGDEC.cpp
+++ b/libraries/jpegdec/JPEGDEC.cpp
@@ -27,9 +27,15 @@ JPEG_STATIC int JPEGInit(JPEGIMAGE *pJPEG);
 JPEG_STATIC int JPEGParseInfo(JPEGIMAGE *pPage, int bExtractThumb);
 JPEG_STATIC void JPEGGetMoreData(JPEGIMAGE *pPage);
 JPEG_STATIC int DecodeJPEG(JPEGIMAGE *pImage);
+JPEG_STATIC void JPEG_setFramebuffer(JPEGIMAGE *pPage, void *pFramebuffer);
 
 // Include the C code which does the actual work
 #include "jpeg.inl"
+
+void JPEGDEC::setFramebuffer(void *pFramebuffer)
+{
+    JPEG_setFramebuffer(&_jpeg, pFramebuffer);
+} /* setFramebuffer() */
 
 void JPEGDEC::setPixelType(int iType)
 {
@@ -204,7 +210,6 @@ int JPEGDEC::decode(int x, int y, int iOptions)
     _jpeg.iXOffset = x;
     _jpeg.iYOffset = y;
     _jpeg.iOptions = iOptions;
-    _jpeg.pDitherBuffer = nullptr;
     return DecodeJPEG(&_jpeg);
 } /* decode() */
 //
@@ -215,11 +220,8 @@ void JPEGDEC::setUserPointer(void *p)
     _jpeg.pUser = p;
 }
 
-// TODO PR these tweaks to https://github.com/bitbank2/JPEGDEC
-int JPEGDEC::decodeDither(int x, int y, uint8_t *pDither, int iOptions)
+int JPEGDEC::decodeDither(uint8_t *pDither, int iOptions)
 {
-    _jpeg.iXOffset = x;
-    _jpeg.iYOffset = y;
     _jpeg.iOptions = iOptions;
     _jpeg.pDitherBuffer = pDither;
     return DecodeJPEG(&_jpeg);

--- a/libraries/jpegdec/jpeg.inl
+++ b/libraries/jpegdec/jpeg.inl
@@ -995,7 +995,7 @@ static int JPEGMakeHuffTables(JPEGIMAGE *pJPEG, int bThumbnail)
 {
     int code, repeat, count, codestart;
     int j;
-    int iLen, iTable;
+    uint16_t iLen, iTable;
     uint16_t *pTable, *pShort, *pLong;
     uint8_t *pHuffVals, *pucTable, *pucShort, *pucLong;
     uint32_t ul, *pLongTable;

--- a/libraries/jpegdec/jpeg.inl
+++ b/libraries/jpegdec/jpeg.inl
@@ -1923,7 +1923,6 @@ mcu_done:
 static void JPEGIDCT(JPEGIMAGE *pJPEG, int iMCUOffset, int iQuantTable)
 {
     int iRow;
-    unsigned char ucColMask;
     int iCol;
     signed int tmp6,tmp7,tmp10,tmp11,tmp12,tmp13;
     signed int z5,z10,z11,z12,z13;


### PR DESCRIPTION
Mostly in response to #941 

@bitbank2 there are a few commits here that might be appropriate upstream. Notably:

1. `JPEG_setFramebuffer` is forward-declared static, but not defined as static
2. `ucColMask` is defined but never used
3. `iTable` throws a sign compare- I looked over the code and figured it could be a `uint16_t` rather than an `int` to fix this, but am not sure if I'm missing some case where it might need to go negative or VERY BIG.