### PR TITLE
TEST: Revert to v1.23.0.

### DIFF
--- a/.github/workflows/micropython.yml
+++ b/.github/workflows/micropython.yml
@@ -7,7 +7,7 @@ on:
     types: [created]
 
 env:
-  MICROPYTHON_VERSION: 932f76c6ba64c5a3e68de3324556d9979f09303b
+  MICROPYTHON_VERSION: v1.23.0
 
 jobs:
   build:

--- a/ci/micropython.sh
+++ b/ci/micropython.sh
@@ -17,6 +17,7 @@ function micropython_clone {
     git clone https://github.com/micropython/micropython
     cd micropython
     git checkout $MICROPYTHON_VERSION
+    git cherry-pick -n 932f76c6ba64c5a3e68de3324556d9979f09303b
     git submodule update --init lib/pico-sdk
     git submodule update --init lib/cyw43-driver
     git submodule update --init lib/lwip


### PR DESCRIPTION
Revert our MicroPython builds back to v1.23.0, since "master" currently seems to have a breaky bug, documented here: https://github.com/micropython/micropython/issues/15220