### PR TITLE
Allow spritesheets for PenRGB565

### DIFF
--- a/libraries/pico_graphics/pico_graphics.hpp
+++ b/libraries/pico_graphics/pico_graphics.hpp
@@ -510,6 +510,9 @@ namespace pimoroni {
       int create_pen_hsv(float h, float s, float v) override;
       void set_pixel(const Point &p) override;
       void set_pixel_span(const Point &p, uint l) override;
+
+      void sprite(void* data, const Point &sprite, const Point &dest, const int scale, const int transparent) override;
+
       static size_t buffer_size(uint w, uint h) {
         return w * h * sizeof(RGB565);
       }

--- a/libraries/pico_graphics/pico_graphics_pen_rgb565.cpp
+++ b/libraries/pico_graphics/pico_graphics_pen_rgb565.cpp
@@ -34,4 +34,27 @@ namespace pimoroni {
             *buf++ = color;
         }
     }
+
+
+     void PicoGraphics_PenRGB565::sprite(void* data, const Point &sprite, const Point &dest, const int scale, const int transparent) {
+         //int sprite_x = (sprite & 0x0f) << 3;
+         //int sprite_y = (sprite & 0xf0) >> 1;
+         Point s {
+             sprite.x << 3,
+             sprite.y << 3
+         };
+         RGB565 *ptr = (RGB565 *)data;
+         Point o = {0, 0};
+         for(o.y = 0; o.y < 8 * scale; o.y++) {
+             Point so = {
+                 0,
+                 o.y / scale
+             };
+             for(o.x = 0; o.x < 8 * scale; o.x++) {
+                 so.x = o.x / scale;
+                 color = ptr[(s.y + so.y) * 128 + (s.x + so.x)];
+                 if(color != transparent) pixel(dest + o);
+             }
+         }
+     }
 }

--- a/micropython/modules/picographics/README.md
+++ b/micropython/modules/picographics/README.md
@@ -510,6 +510,8 @@ Sprites must be 8x8 pixels arranged in a 128x128 pixel spritesheet. 1-bit transp
 
 We've prepared some RGB332-compatible sprite assets for you, but you can use `spritesheet-to-rgb332.py <filename>` to convert your own.
 
+For higher quality you can use RGB565 Spritesheets on some devices, like the Tufty2040, but try using a lower spritesheet resolution of up to 128x96 pixels to not exceed device memory.
+
 #### Loading Sprites
 
 You'll need to include the [pen_type](#supported-graphics-modes-pen-type) in the import statement, and define the pen_type before using loading the spritesheet:


### PR DESCRIPTION
I am using a tufty2040 and i wanted to use 565 to show high quality jpegs on my badge, but spritesheets did not work. Simply allowing this and generating a 128x96 Spritesheet (128x128 explodes memory-wise) and using https://github.com/jimmywong2003/PNG-to-RGB565/blob/master/png2rgb565.py with isSWAP=True to create the final spritesheet allows me to have a repeating high quality jpeg character being animated and a high quality spritesheet additionally to show icons, elements and borders.

Please allow this by default, as its the same as the 332 version and it makes my life easier by being able  to use regular releases (current main seems to have broken battery reading)