### PR TITLE
Add Garbage Collection to weather example

### DIFF
--- a/micropython/examples/plasma_stick/weather.py
+++ b/micropython/examples/plasma_stick/weather.py
@@ -3,6 +3,7 @@ from network_manager import NetworkManager
 import uasyncio
 import urequests
 import time
+import gc
 import plasma
 from plasma import plasma_stick
 # Random functions! randrange is for picking integers from a range, and uniform is for floats.
@@ -258,3 +259,5 @@ while True:
 
     move_to_target()   # nudge our current colours closer to the target colours
     display_current()  # display current colours to strip
+    gc.collect()
+


### PR DESCRIPTION
The existing weather example was resulting in `OSError: [Errno 12] ENOMEM` when executing subsequent calls to the open-meteo API.

After adding the garbage collection I am no longer seeing these errors and data is being collected as per the timer.

```
Requesting URL: https://api.open-meteo.com/v1/forecast?latitude=**.******&longitude=-*.*******&current_weather=true&timezone=auto
Data obtained!
Temperature = 17.8°C
Conditions = slight rain
Last Open-Meteo update: 2024-07-24, 19:45
    
Requesting URL: https://api.open-meteo.com/v1/forecast?latitude=**.******&longitude=-*.*******&current_weather=true&timezone=auto
Data obtained!
Temperature = 17.6°C
Conditions = cloudy
Last Open-Meteo update: 2024-07-24, 20:00

Requesting URL: https://api.open-meteo.com/v1/forecast?latitude=**.******&longitude=-*.*******&current_weather=true&timezone=auto
Data obtained!
Temperature = 17.4°C
Conditions = cloudy
Last Open-Meteo update: 2024-07-24, 20:15
```
    