### PR TITLE
fix: initialize the uninitialized

### DIFF
--- a/examples/cosmic_unicorn/cosmic_lava_lamp.cpp
+++ b/examples/cosmic_unicorn/cosmic_lava_lamp.cpp
@@ -106,11 +106,11 @@ int main() {
 
     // calculate dark, medium, and bright shades for rendering the 
     // lava
-    uint8_t dark_r, dark_g, dark_b;
+    uint8_t dark_r = 0, dark_g = 0, dark_b = 0;
     from_hsv(hue, 1.0f, 0.3f, dark_r, dark_g, dark_b);
-    uint8_t mid_r, mid_g, mid_b;
+    uint8_t mid_r = 0, mid_g = 0, mid_b = 0;
     from_hsv(hue, 1.0f, 0.6f, mid_r, mid_g, mid_b);
-    uint8_t bright_r, bright_g, bright_b;
+    uint8_t bright_r = 0, bright_g = 0, bright_b = 0;
     from_hsv(hue, 1.0f, 1.0f, bright_r, bright_g, bright_b);
 
     // clear the canvas

--- a/examples/galactic_unicorn/lava_lamp.cpp
+++ b/examples/galactic_unicorn/lava_lamp.cpp
@@ -107,11 +107,11 @@ int main() {
 
     // calculate dark, medium, and bright shades for rendering the 
     // lava
-    uint8_t dark_r, dark_g, dark_b;
+    uint8_t dark_r = 0, dark_g = 0, dark_b = 0;
     from_hsv(hue, 1.0f, 0.3f, dark_r, dark_g, dark_b);
-    uint8_t mid_r, mid_g, mid_b;
+    uint8_t mid_r = 0, mid_g = 0, mid_b = 0;
     from_hsv(hue, 1.0f, 0.6f, mid_r, mid_g, mid_b);
-    uint8_t bright_r, bright_g, bright_b;
+    uint8_t bright_r = 0, bright_g = 0, bright_b = 0;
     from_hsv(hue, 1.0f, 1.0f, bright_r, bright_g, bright_b);
 
     // clear the canvas

--- a/examples/stellar_unicorn/stellar_lava_lamp.cpp
+++ b/examples/stellar_unicorn/stellar_lava_lamp.cpp
@@ -106,11 +106,11 @@ int main() {
 
     // calculate dark, medium, and bright shades for rendering the 
     // lava
-    uint8_t dark_r, dark_g, dark_b;
+    uint8_t dark_r = 0, dark_g = 0, dark_b = 0;
     from_hsv(hue, 1.0f, 0.3f, dark_r, dark_g, dark_b);
-    uint8_t mid_r, mid_g, mid_b;
+    uint8_t mid_r = 0, mid_g = 0, mid_b = 0;
     from_hsv(hue, 1.0f, 0.6f, mid_r, mid_g, mid_b);
-    uint8_t bright_r, bright_g, bright_b;
+    uint8_t bright_r = 0, bright_g = 0, bright_b = 0;
     from_hsv(hue, 1.0f, 1.0f, bright_r, bright_g, bright_b);
 
     // clear the canvas


### PR DESCRIPTION
While building all demos I found that several colors are uninitialized, and where throwing an error when building.

Sample "error":

```
pimoroni-pico/examples/stellar_unicorn/stellar_lava_lamp.cpp: In function 'int main()':
pimoroni-pico/examples/stellar_unicorn/stellar_lava_lamp.cpp:128:27: error: 'bright_r' may be used uninitialized [-Werror=maybe-uninitialized]
  128 |           graphics.set_pen(bright_r, bright_g, bright_b);
      |           ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
pimoroni-pico/examples/stellar_unicorn/stellar_lava_lamp.cpp:113:13: note: 'bright_r' was declared here
  113 |     uint8_t bright_r, bright_g, bright_b;
      |             ^~~~~~~~
```

I could have added the build flag for dismissing that warning, but I felt more explicit is better.

Let me know what you think.