### PR TITLE
Update setup instructions for macOS

### DIFF
--- a/setting-up-the-pico-sdk.md
+++ b/setting-up-the-pico-sdk.md
@@ -40,8 +40,7 @@ sudo apt install cmake gcc-arm-none-eabi build-essential
 brew install cmake
 
 # Install the arm eabi toolchain
-brew tap ArmMbed/homebrew-formulae
-brew install arm-none-eabi-gcc
+brew install --cask gcc-arm-embedded
 
 # The equivalent to build-essential on linux, you probably already have this.
 xcode-select --install


### PR DESCRIPTION
The preferred method for installing the ARM toolchain has changed. The method currently shown results in a compilation failure:

```
arm-none-eabi-gcc: fatal error: cannot read spec file 'nosys.specs': No such file or directory
```

Refer to [pico-sdk issue 1529](https://github.com/raspberrypi/pico-sdk/issues/1529)