### PR TITLE
as7343: Fix channel and status order.

### DIFF
--- a/drivers/as7343/as7343.cpp
+++ b/drivers/as7343/as7343.cpp
@@ -30,7 +30,7 @@ namespace pimoroni {
     i2c->set_bits(address, reg::FIFO_MAP, 0, FIFO_MAP_CH5 | FIFO_MAP_CH4 | FIFO_MAP_CH3 | FIFO_MAP_CH2 | FIFO_MAP_CH1 | FIFO_MAP_CH0 | FIFO_MAP_ASTATUS);
 
     // Set the PON bit
-    i2c->reg_write_uint8(address, reg::ENABLE, ENABLE_WEN | ENABLE_SMUXEN | ENABLE_SP_EN | ENABLE_PON);
+    i2c->reg_write_uint8(address, reg::ENABLE, ENABLE_WEN | ENABLE_SP_EN | ENABLE_PON);
 
     return true;
   }
@@ -135,9 +135,22 @@ namespace pimoroni {
     }
   }
 
+  void AS7343::start_measurement() {
+    if(running) return;
+    i2c->set_bits(address, reg::ENABLE, 0, ENABLE_SMUXEN);
+    running = true;
+  }
+
+  void AS7343::stop_measurement() {
+    i2c->set_bits(address, reg::ENABLE, 0, ENABLE_SMUXEN);
+    running = false;
+  }
+
   void AS7343::read_fifo(uint16_t *buf) {
     uint16_t expected_results = read_cycles * 7;
     uint16_t result_slot = 0;
+
+    start_measurement();
 
     while (i2c->reg_read_uint8(address, reg::FIFO_LVL) < expected_results) {
         sleep_ms(1);

--- a/examples/breakout_as7343/as7343_demo.cpp
+++ b/examples/breakout_as7343/as7343_demo.cpp
@@ -62,6 +62,8 @@ int main() {
       reading.F8
     );
 
+    printf("Gain: C1: %fx C2: %fx C3: %fx\n", reading.gain(1), reading.gain(2), reading.gain(3));
+
     sleep_ms(1000);
   }
 


### PR DESCRIPTION
The astatus value was being interpreted as FZ, F2 and F1 causing bizarre readings and all other channels to be shifted one place.

Additionally the datasheet has been updated to re-order F5, F7 and F8 to F7, F8, F5, so these channels have been re-ordered accordingly.

Note: This will turn sensor output from confusing abject nonsense into what looks like pretty reasonable colour data and fixes #989.