### PR TITLE
CI: Switch to action-gh-release.

### DIFF
--- a/.github/workflows/micropython.yml
+++ b/.github/workflows/micropython.yml
@@ -127,11 +127,6 @@ jobs:
 
     - name: Upload .uf2
       if: github.event_name == 'release'
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      uses: softprops/action-gh-release@v2
       with:
-        asset_path: build-${{ matrix.name }}/firmware.uf2
-        upload_url: ${{ github.event.release.upload_url }}
-        asset_name: ${{ env.RELEASE_FILE }}.uf2
-        asset_content_type: application/octet-stream
+        files: build-${{ matrix.name }}/${{ env.RELEASE_FILE }}.uf2


### PR DESCRIPTION
Switch from the long deprecated upload-release-asset to action-gh-release and attempt to replicate the same behaviour.

Avoids nodejs and set-output deprecation warnings:
- https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
- https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/