### PR TITLE
Unicorn(s): Remove some Hershey fonts.

### DIFF
--- a/libraries/hershey_fonts/hershey_fonts.cpp
+++ b/libraries/hershey_fonts/hershey_fonts.cpp
@@ -28,12 +28,17 @@ namespace hershey {
   }
 
   const font_t* font(std::string_view font) {
+#ifdef PG_HERSHEY_LITE
+    if(font == "serif") return &timesr;
+    return &futural;
+#else
     if(font == "sans") return &futural;
     else if(font == "gothic") return &gothgbt;
     else if(font == "cursive") return &scripts;
     else if(font == "serif_italic") return &timesi;
     else if(font == "serif") return &timesr;
     return &futural;
+#endif
   }
 
   inline float deg2rad(float degrees) {

--- a/micropython/modules/hershey_fonts/micropython.cmake
+++ b/micropython/modules/hershey_fonts/micropython.cmake
@@ -13,3 +13,9 @@ target_include_directories(usermod_${MOD_NAME} INTERFACE
 )
 
 target_link_libraries(usermod INTERFACE usermod_${MOD_NAME})
+
+function(hershey_lite)
+    target_compile_definitions(usermod_${MOD_NAME} INTERFACE
+        PG_HERSHEY_LITE=1
+    )
+endfunction()

--- a/micropython/modules/micropython-cosmic_unicorn.cmake
+++ b/micropython/modules/micropython-cosmic_unicorn.cmake
@@ -13,6 +13,9 @@ include(pimoroni_bus/micropython)
 
 # Pico Graphics Essential
 include(hershey_fonts/micropython)
+# We need to save ~3k somewhere,
+# and Hershey fonts don't make sense on these boards
+hershey_lite()
 include(bitmap_fonts/micropython)
 include(picographics/micropython)
 

--- a/micropython/modules/micropython-galactic_unicorn.cmake
+++ b/micropython/modules/micropython-galactic_unicorn.cmake
@@ -13,6 +13,9 @@ include(pimoroni_bus/micropython)
 
 # Pico Graphics Essential
 include(hershey_fonts/micropython)
+# We need to save ~3k somewhere,
+# and Hershey fonts don't make sense on these boards
+hershey_lite()
 include(bitmap_fonts/micropython)
 include(picographics/micropython)
 

--- a/micropython/modules/micropython-stellar_unicorn.cmake
+++ b/micropython/modules/micropython-stellar_unicorn.cmake
@@ -13,6 +13,9 @@ include(pimoroni_bus/micropython)
 
 # Pico Graphics Essential
 include(hershey_fonts/micropython)
+# We need to save ~3k somewhere,
+# and Hershey fonts don't make sense on these boards
+hershey_lite()
 include(bitmap_fonts/micropython)
 include(picographics/micropython)
 


### PR DESCRIPTION
Since Hershey fonts make virtually no sense on these low-resolution displays, remove all but Serif/Sans to make up for the additional flash usage of MicroPython 1.24.0 / Pico SDK 2.0.0.

Note: The need for this seemed to dissolve with the official 1.24.0 release, but I'm keeping it handy in case the code bloat appears again.