### PR TITLE
hub75: don't enable an unrelated IRQ

### DIFF
--- a/drivers/hub75/hub75.cpp
+++ b/drivers/hub75/hub75.cpp
@@ -146,7 +146,6 @@ void Hub75::start(irq_handler_t handler) {
 
         dma_channel_set_irq0_enabled(dma_channel, true);
 
-        irq_set_enabled(pio_get_dreq(pio, sm_data, true), true);
         irq_set_enabled(DMA_IRQ_0, true);
 
         row = 0;


### PR DESCRIPTION
DREQs are not IRQs, `DREQ_PIO0_TXn` happens to align with `TIMER_IRQ_n` so this enabled a timer IRQ.


(This is something I happened to notice while poking around in there)