### PR TITLE
Fix Button class on Pico 2W

### DIFF
--- a/micropython/modules_py/pimoroni.py
+++ b/micropython/modules_py/pimoroni.py
@@ -96,7 +96,7 @@ class Button:
         self.invert = invert
         self.repeat_time = repeat_time
         self.hold_time = hold_time
-        self.pin = Pin(button, pull=Pin.PULL_UP if invert else Pin.PULL_DOWN)
+        self.pin = Pin(button, Pin.IN, Pin.PULL_UP if invert else Pin.PULL_DOWN)
         self.last_state = False
         self.pressed = False
         self.pressed_time = 0


### PR DESCRIPTION
I just picked up a Pico 2W and GFX Pack to dip my toes into Raspberry Pi microcontrollers. While experimenting, running the button demo didn't work. I stumbled upon a few forum threads and eventually discovered #1041 

This pull request modifies the `Button` class to specify the mode of the `Pin` object created within and, in my testing, this seems to fix the original example/built-in functionality that #1041 bypasses by locally creating `Pin` objects.

**Note:** I don't have the hardware to test this on any other Picos, so I only verified on my Pico 2W.