### PR TITLE
README: Added link to RP2350 repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ This repository contains the C/C++ and MicroPython libraries for our range of RP
 
 # MicroPython
 
+:warning: This repository contains MicroPython builds for **RP2040** based products only. If you're looking for **RP2350** compatible MicroPython builds see here: https://github.com/pimoroni/pimoroni-pico-rp2350
+
 The easiest way to get started. If you're new to Pico, we recommend you read our [getting started with Pico](https://learn.pimoroni.com/article/getting-started-with-pico) tutorial.
 
 :warning: All of our MicroPython libraries are baked into a batteries-included, custom version of MicroPython which you can grab from releases: [https://github.com/pimoroni/pimoroni-pico/releases/latest/](https://github.com/pimoroni/pimoroni-pico/releases/latest/)


### PR DESCRIPTION
Added a warning about the repo being for RP2040 builds only and a link to the correct repo for RP2350