### PR TITLE
PicoGraphics: Fix overflow bug in p4 pixel span.

### DIFF
--- a/libraries/pico_graphics/pico_graphics_pen_p4.cpp
+++ b/libraries/pico_graphics/pico_graphics_pen_p4.cpp
@@ -70,6 +70,10 @@ namespace pimoroni {
     }
 
     void PicoGraphics_PenP4::set_pixel_span(const Point &p, uint l) {
+        // prevent a zero length span causing an overflow in 'l'
+        // and trying to write 2GB of pixels.
+        if (l == 0) {return;}
+
         auto i = (p.x + p.y * bounds.w);
 
         // pointer to byte in framebuffer that contains this pixel


### PR DESCRIPTION
A properly aligned zero length pixel span would cause a single pixel to be drawn, the length overflowed and a subsequent 2GB of pixels drawn by the main loop.

Add a simple check to discard any attempt to draw zero length spans.

Fixes pimoroni/pimoroni-pico-rp2350#32