### PR TITLE
Don't include the spacing after the final letter when measuring bitmap text

### DIFF
--- a/libraries/bitmap_fonts/bitmap_fonts.cpp
+++ b/libraries/bitmap_fonts/bitmap_fonts.cpp
@@ -39,6 +39,12 @@ namespace bitmap {
       text_width += letter_spacing * scale;
       codepage = unicode_sorta::PAGE_195; // Reset back to default
     }
+
+    // Do not include the spacing on the final character
+    if (text_width>0) {
+      text_width -= letter_spacing * scale;
+    }
+
     return text_width;
   }
 


### PR DESCRIPTION
As mentioned in #1050, `measure_text` erroneously includes the spacing *after* the final character of a string in it's measurement, for bitmap fonts.

This patch fixes it; it probably needs highlighting in the release notes wherever it ends up, in case people (like me!) have dodgy hacks in their code to adjust the returned length.

(tested through to Presto firmware - which was an annoyingly convoluted build, I can tell you - so at least it should be painless to pick up in everything that rolls PicoGraphics in)