### PR TITLE
SCD4X: Add calibration commands for #1056.

### DIFF
--- a/micropython/modules/breakout_scd41/README.md
+++ b/micropython/modules/breakout_scd41/README.md
@@ -35,5 +35,25 @@ while True:
         time.sleep(1.0)
 ```
 
-The `measure()` method will return a Tuple containing the CO2 reading, temperature in degrees C and humidity.
+The `measure()` method will return a Tuple containing the CO₂ reading, temperature in degrees C and humidity.
 
+## Changing Calibration
+
+By default the SCD41 will perform automatic self calibration, which could lead to drift in readings over time.
+
+You can stop this with `breakout_scd41.set_automatic_self_calibration(False)`.
+
+You can then use force recalibration with a known good CO₂ PPM baseline to calibrate your sensor:
+
+```python
+correction_amount = breakout_scd41.scd41_perform_forced_recalibration(target_co2_concentration);
+```
+
+`correction_amount` is the resulting correction in CO₂ PPM.
+
+To successfully conduct an accurate forced recalibration, the following steps must be carried out:
+
+1. Operate the SCD4x in a periodic measurement mode for > 3 minutes in an environment with homogenous and constant CO₂ concentration. (read: don't breathe)
+2. Stop periodic measurement.
+3. Wait 500 ms.
+4. Issue the perform_forced_recalibration command.

--- a/micropython/modules/breakout_scd41/breakout_scd41.c
+++ b/micropython/modules/breakout_scd41/breakout_scd41.c
@@ -20,6 +20,10 @@ static MP_DEFINE_CONST_FUN_OBJ_0(scd41_get_data_ready_obj, scd41_get_data_ready)
 static MP_DEFINE_CONST_FUN_OBJ_1(scd41_set_temperature_offset_obj, scd41_set_temperature_offset);
 static MP_DEFINE_CONST_FUN_OBJ_0(scd41_get_temperature_offset_obj, scd41_get_temperature_offset);
 
+static MP_DEFINE_CONST_FUN_OBJ_1(scd41_perform_forced_recalibration_obj, scd41_perform_forced_recalibration);
+static MP_DEFINE_CONST_FUN_OBJ_1(scd41_set_automatic_self_calibration_obj, scd41_set_automatic_self_calibration);
+static MP_DEFINE_CONST_FUN_OBJ_0(scd41_get_automatic_self_calibration_obj, scd41_get_automatic_self_calibration);
+
 static MP_DEFINE_CONST_FUN_OBJ_1(scd41_set_sensor_altitude_obj, scd41_set_sensor_altitude);
 static MP_DEFINE_CONST_FUN_OBJ_1(scd41_set_ambient_pressure_obj, scd41_set_ambient_pressure);
 
@@ -38,6 +42,10 @@ static const mp_map_elem_t scd41_globals_table[] = {
 
     { MP_ROM_QSTR(MP_QSTR_set_temperature_offset), MP_ROM_PTR(&scd41_set_temperature_offset_obj) },
     { MP_ROM_QSTR(MP_QSTR_get_temperature_offset), MP_ROM_PTR(&scd41_get_temperature_offset_obj) },
+
+    { MP_ROM_QSTR(MP_QSTR_perform_forced_recalibration), MP_ROM_PTR(&scd41_perform_forced_recalibration_obj) },
+    { MP_ROM_QSTR(MP_QSTR_set_automatic_self_calibration), MP_ROM_PTR(&scd41_set_automatic_self_calibration_obj) },
+    { MP_ROM_QSTR(MP_QSTR_get_automatic_self_calibration), MP_ROM_PTR(&scd41_get_automatic_self_calibration_obj) },
 
     { MP_ROM_QSTR(MP_QSTR_set_sensor_altitude), MP_ROM_PTR(&scd41_set_sensor_altitude_obj) },
     { MP_ROM_QSTR(MP_QSTR_set_ambient_pressure), MP_ROM_PTR(&scd41_set_ambient_pressure_obj) },

--- a/micropython/modules/breakout_scd41/breakout_scd41.h
+++ b/micropython/modules/breakout_scd41/breakout_scd41.h
@@ -14,3 +14,7 @@ extern mp_obj_t scd41_set_temperature_offset(mp_obj_t offset);
 extern mp_obj_t scd41_get_temperature_offset();
 extern mp_obj_t scd41_set_sensor_altitude(mp_obj_t altitude);
 extern mp_obj_t scd41_set_ambient_pressure(mp_obj_t pressure);
+
+extern mp_obj_t scd41_perform_forced_recalibration(mp_obj_t target_co2_concentration_in);
+extern mp_obj_t scd41_set_automatic_self_calibration(mp_obj_t asc_enabled);
+extern mp_obj_t scd41_get_automatic_self_calibration();


### PR DESCRIPTION
#1056 makes a compelling case for adding these commands in order to avoid sensor drift over time. Here they are ✨

Note: To my future self, don't try to update the Sensiron SCD4X driver submodule until you've got a clear head and a half day to put up with their absolute nonsense.