### PR TITLE
plasma: Drop pin definitions from C module.

### DIFF
--- a/micropython/modules/plasma/plasma.c
+++ b/micropython/modules/plasma/plasma.c
@@ -89,49 +89,10 @@ typedef struct _mp_obj_float_t {
 mp_obj_float_t shunt_resistor = {{&mp_type_float}, 0.015f};
 
 /***** Globals Table *****/
-static const mp_map_elem_t plasma2040_globals_table[] = {
-    { MP_OBJ_NEW_QSTR(MP_QSTR___name__), MP_OBJ_NEW_QSTR(MP_QSTR_plasma2040) },
-    { MP_ROM_QSTR(MP_QSTR_LED_R), MP_ROM_INT(16) },
-    { MP_ROM_QSTR(MP_QSTR_LED_G), MP_ROM_INT(17) },
-    { MP_ROM_QSTR(MP_QSTR_LED_B), MP_ROM_INT(18) },
-    { MP_ROM_QSTR(MP_QSTR_BUTTON_A), MP_ROM_INT(12) },
-    { MP_ROM_QSTR(MP_QSTR_BUTTON_B), MP_ROM_INT(13) },
-    { MP_ROM_QSTR(MP_QSTR_USER_SW), MP_ROM_INT(23) },
-    { MP_ROM_QSTR(MP_QSTR_CLK), MP_ROM_INT(14) },
-    { MP_ROM_QSTR(MP_QSTR_DAT), MP_ROM_INT(15) },
-    { MP_ROM_QSTR(MP_QSTR_CURRENT_SENSE), MP_ROM_INT(29) },
-    { MP_ROM_QSTR(MP_QSTR_SDA), MP_ROM_INT(20) },
-    { MP_ROM_QSTR(MP_QSTR_SCL), MP_ROM_INT(21) },
-
-    { MP_ROM_QSTR(MP_QSTR_SHUNT_RESISTOR), MP_ROM_PTR(&shunt_resistor) },
-    { MP_ROM_QSTR(MP_QSTR_ADC_GAIN), MP_ROM_INT(50) },
-};
-static MP_DEFINE_CONST_DICT(mp_module_plasma2040_globals, plasma2040_globals_table);
-
-static const mp_map_elem_t plasma_stick_globals_table[] = {
-    { MP_OBJ_NEW_QSTR(MP_QSTR___name__), MP_OBJ_NEW_QSTR(MP_QSTR_plasma_stick) },
-    { MP_ROM_QSTR(MP_QSTR_DAT), MP_ROM_INT(15) },
-    { MP_ROM_QSTR(MP_QSTR_SDA), MP_ROM_INT(4) },
-    { MP_ROM_QSTR(MP_QSTR_SCL), MP_ROM_INT(5) },
-};
-static MP_DEFINE_CONST_DICT(mp_module_plasma_stick_globals, plasma_stick_globals_table);
-
-const mp_obj_module_t plasma2040_user_cmodule = {
-    .base = { &mp_type_module },
-    .globals = (mp_obj_dict_t*)&mp_module_plasma2040_globals,
-};
-
-const mp_obj_module_t plasma_stick_user_cmodule = {
-    .base = { &mp_type_module },
-    .globals = (mp_obj_dict_t*)&mp_module_plasma_stick_globals,
-};
-
 static const mp_map_elem_t plasma_globals_table[] = {
     { MP_OBJ_NEW_QSTR(MP_QSTR___name__), MP_OBJ_NEW_QSTR(MP_QSTR_plasma) },
     { MP_OBJ_NEW_QSTR(MP_QSTR_APA102), (mp_obj_t)&PlasmaAPA102_type },
     { MP_OBJ_NEW_QSTR(MP_QSTR_WS2812), (mp_obj_t)&PlasmaWS2812_type },
-    { MP_OBJ_NEW_QSTR(MP_QSTR_plasma2040), (mp_obj_t)&plasma2040_user_cmodule },
-    { MP_OBJ_NEW_QSTR(MP_QSTR_plasma_stick), (mp_obj_t)&plasma_stick_user_cmodule },
 
     { MP_ROM_QSTR(MP_QSTR_COLOR_ORDER_RGB), MP_ROM_INT(0x00) },
     { MP_ROM_QSTR(MP_QSTR_COLOR_ORDER_RBG), MP_ROM_INT(0x01) },

--- a/micropython/modules/plasma/plasma.cpp
+++ b/micropython/modules/plasma/plasma.cpp
@@ -9,6 +9,7 @@ using namespace plasma;
 extern "C" {
 #include "plasma.h"
 #include "py/builtin.h"
+#include "machine_pin.h"
 
 typedef struct _mp_obj_float_t {
     mp_obj_base_t base;
@@ -64,7 +65,7 @@ mp_obj_t PlasmaWS2812_make_new(const mp_obj_type_t *type, size_t n_args, size_t 
         { MP_QSTR_num_leds, MP_ARG_REQUIRED | MP_ARG_INT },
         { MP_QSTR_pio, MP_ARG_REQUIRED | MP_ARG_INT },
         { MP_QSTR_sm, MP_ARG_REQUIRED | MP_ARG_INT },
-        { MP_QSTR_dat, MP_ARG_REQUIRED | MP_ARG_INT },
+        { MP_QSTR_dat, MP_ARG_REQUIRED | MP_ARG_OBJ },
         { MP_QSTR_freq, MP_ARG_INT, {.u_int = WS2812::DEFAULT_SERIAL_FREQ} },
         { MP_QSTR_buffer, MP_ARG_OBJ, {.u_obj = nullptr} },
         { MP_QSTR_rgbw, MP_ARG_BOOL, {.u_bool = false} },
@@ -78,7 +79,7 @@ mp_obj_t PlasmaWS2812_make_new(const mp_obj_type_t *type, size_t n_args, size_t 
     int num_leds = args[ARG_num_leds].u_int;
     PIO pio = args[ARG_pio].u_int == 0 ? pio0 : pio1;
     int sm = args[ARG_sm].u_int;
-    int dat = args[ARG_dat].u_int;
+    int dat = mp_hal_get_pin_obj(args[ARG_dat].u_obj);
     int freq = args[ARG_freq].u_int;
     bool rgbw = args[ARG_rgbw].u_bool;
     WS2812::COLOR_ORDER color_order = (WS2812::COLOR_ORDER)args[ARG_color_order].u_int;
@@ -269,8 +270,8 @@ mp_obj_t PlasmaAPA102_make_new(const mp_obj_type_t *type, size_t n_args, size_t 
         { MP_QSTR_num_leds, MP_ARG_REQUIRED | MP_ARG_INT },
         { MP_QSTR_pio, MP_ARG_REQUIRED | MP_ARG_INT },
         { MP_QSTR_sm, MP_ARG_REQUIRED | MP_ARG_INT },
-        { MP_QSTR_dat, MP_ARG_REQUIRED | MP_ARG_INT },
-        { MP_QSTR_clk, MP_ARG_REQUIRED | MP_ARG_INT },
+        { MP_QSTR_dat, MP_ARG_REQUIRED | MP_ARG_OBJ },
+        { MP_QSTR_clk, MP_ARG_REQUIRED | MP_ARG_OBJ },
         { MP_QSTR_freq, MP_ARG_INT, {.u_int = APA102::DEFAULT_SERIAL_FREQ} },
         { MP_QSTR_buffer, MP_ARG_OBJ, {.u_obj = nullptr} },
     };
@@ -282,8 +283,8 @@ mp_obj_t PlasmaAPA102_make_new(const mp_obj_type_t *type, size_t n_args, size_t 
     int num_leds = args[ARG_num_leds].u_int;
     PIO pio = args[ARG_pio].u_int == 0 ? pio0 : pio1;
     int sm = args[ARG_sm].u_int;
-    int dat = args[ARG_dat].u_int;
-    int clk = args[ARG_clk].u_int;
+    int dat = mp_hal_get_pin_obj(args[ARG_dat].u_obj);
+    int clk = mp_hal_get_pin_obj(args[ARG_clk].u_obj);
     int freq = args[ARG_freq].u_int;
 
     APA102::RGB *buffer = nullptr;


### PR DESCRIPTION
Remove pin definitions in anticipation of them moving to pins.csv.

Eg:

```
from plasma2040 import BUTTON_A
machine.Pin(BUTTON_A)
```

Should become:

```
machine.Pin("BUTTON_A")
```

This is part of the Plasma migration: https://github.com/pimoroni/plasma/issues/1