### PR TITLE
PicoVector: Fix find_glyph char to uint16_t.

### DIFF
--- a/libraries/pico_vector/alright-fonts.h
+++ b/libraries/pico_vector/alright-fonts.h
@@ -241,7 +241,7 @@ uint8_t num_of_utf8_continuation_bytes(const char *text, const char *end) {
   return cont;
 }
 
-af_glyph_t *find_glyph(af_face_t *face, char c) {
+af_glyph_t *find_glyph(af_face_t *face, uint16_t c) {
   for(int i = 0; i < face->glyph_count; i++) {
     if(face->glyphs[i].codepoint == c) {
       return &face->glyphs[i];


### PR DESCRIPTION
Allow find_glyph to find 16-bit unicode codepoints (icons, yay!).