### PR TITLE
Fix skipped character after line wrap

### DIFF
--- a/libraries/pico_vector/alright-fonts.h
+++ b/libraries/pico_vector/alright-fonts.h
@@ -418,7 +418,7 @@ void af_render(af_face_t *face, const char *text, size_t tlen, float max_line_wi
       
     }
 
-    line += 1; // Skip over \n
+    if (*line == '\n') line += 1; // Skip over \n
     line_len = line_length(line, tend);
 
     caret.x = 0;


### PR DESCRIPTION
The pico vector text renderer skipped over an assumed new line even when the line break was generated by a word wrap.  That meant the first character of the next word was missing.

Found while testing the C presto-boilerplate.