### PR TITLE
Allow writing data to psram directly

### DIFF
--- a/drivers/psram_display/psram_display.cpp
+++ b/drivers/psram_display/psram_display.cpp
@@ -68,6 +68,11 @@ namespace pimoroni {
     write(pointToAddress(p), l, colour);
   }
 
+  void PSRamDisplay::write_span(uint32_t offset, uint l, const uint8_t *colours)
+  {
+    write(start_address + offset, l, colours);
+  }
+
   void PSRamDisplay::read_pixel_span(const Point &p, uint l, uint8_t *data)
   {
     read(pointToAddress(p), l, data);

--- a/drivers/psram_display/psram_display.hpp
+++ b/drivers/psram_display/psram_display.hpp
@@ -88,6 +88,7 @@ namespace pimoroni {
       
       void write_pixel(const Point &p, uint8_t colour) override;
       void write_pixel_span(const Point &p, uint l, uint8_t colour) override;
+      void write_span(uint32_t offset, uint l, const uint8_t * colours) override;
       void read_pixel_span(const Point &p, uint l, uint8_t *data) override;
 
       int __not_in_flash_func(SpiSetBlocking)(const uint16_t uSrc, size_t uLen) 

--- a/libraries/pico_graphics/pico_graphics.hpp
+++ b/libraries/pico_graphics/pico_graphics.hpp
@@ -599,6 +599,7 @@ namespace pimoroni {
      public:
        virtual void write_pixel(const Point &p, T colour) = 0;
        virtual void write_pixel_span(const Point &p, uint l, T colour) = 0;
+       virtual void write_span(uint32_t offset, uint l, const T *colours) = 0;
 
        virtual void read_pixel(const Point &p, T &data) {};
        virtual void read_pixel_span(const Point &p, uint l, T *data) {};


### PR DESCRIPTION
I have a server that prepares a 800 * 480 byte image and the pico writes the bytes directly to the psram backed frame buffer as each packet comes in. This can be seen here: https://github.com/bozenalabs/rain_radar/blob/286b3949439b5dc78bca1af132a5cd2881aea3a7/firmware_c/rain_radar_app/data_fetching.cpp#L150

This PR adds support to do this. The alternatives are to either write each pixel one by one which takes far longer, or to create a jpeg image and then write the jpeg image to the buffer. It is far simpler to just write the image directly the frame buffer.
