### PR TITLE
Make Trackball::get_interrupt return the actual value

### DIFF
--- a/drivers/trackball/trackball.cpp
+++ b/drivers/trackball/trackball.cpp
@@ -105,7 +105,7 @@ namespace pimoroni {
       value = i2c->reg_read_uint8(address, reg::INT);
       value &= MSK_INT_TRIGGERED;
     }
-    return false;
+    return value;
   }
 
   void Trackball::set_rgbw(uint8_t r, uint8_t g, uint8_t b, uint8_t w) {


### PR DESCRIPTION
The current code returns false unconditionally, which is inconsistent with the [Python driver](https://github.com/pimoroni/trackball-python/blob/master/library/trackball/__init__.py#L101-L107). Changed to make it return value